### PR TITLE
Send auth in options request payload

### DIFF
--- a/packages/react-ui/src/app/features/builder/block-properties/dynamic-block-property.tsx
+++ b/packages/react-ui/src/app/features/builder/block-properties/dynamic-block-property.tsx
@@ -92,6 +92,7 @@ const DynamicProperties = React.memo((props: DynamicPropertiesProps) => {
     const input: Record<string, unknown> = {};
     newRefreshers.forEach((refresher, index) => {
       input[refresher] = refresherValues[index];
+      input.auth = form.getValues('settings.input.auth');
     });
 
     mutate(

--- a/packages/react-ui/src/app/features/builder/block-properties/dynamic-dropdown-block-property.tsx
+++ b/packages/react-ui/src/app/features/builder/block-properties/dynamic-dropdown-block-property.tsx
@@ -106,6 +106,7 @@ const DynamicDropdownBlockProperty = React.memo(
       const input: Record<string, unknown> = {};
       newRefreshers.forEach((refresher, index) => {
         input[refresher] = refresherValues[index];
+        input.auth = form.getValues('settings.input.auth');
       });
 
       mutate(


### PR DESCRIPTION
Fixes OPS-1251
Fixes OPS-1252
Fixes OPS-1240

Created another issue for the Jira trigger 403:
https://linear.app/openops/issue/OPS-1289/jira-trigger-doesnt-work

## Additional Notes
Previous change removing auth means we don't send it in input unless it's on refresher. With this change we send auth in input in each option call.

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [ ] I verified all affected areas still work as expected

- [ ] Automated tests were added/updated if necessary

- [ ] Changes are backwards compatible with any existing data, otherwise a migration script is provided

## Visual Changes (if applicable)
https://www.loom.com/share/2db61d6bde1d4cd9b57592a76d584ccb
