### PR TITLE
Create template from flow API supports adding version

### DIFF
--- a/packages/server/api/src/app/flow-template/flow-template.controller.ts
+++ b/packages/server/api/src/app/flow-template/flow-template.controller.ts
@@ -79,6 +79,8 @@ export const flowTemplateController: FastifyPluginAsyncTypebox = async (
             domains: { type: 'array' },
             isSample: { type: 'boolean' },
             isGettingStarted: { type: 'boolean' },
+            minVersion: { type: 'string' },
+            maxVersion: { type: 'string' },
           },
         },
       },
@@ -92,6 +94,8 @@ export const flowTemplateController: FastifyPluginAsyncTypebox = async (
           domains: string[];
           isSample: boolean;
           isGettingStarted: boolean;
+          minVersion: string;
+          maxVersion: string;
         };
       }>,
       reply,
@@ -106,6 +110,8 @@ export const flowTemplateController: FastifyPluginAsyncTypebox = async (
           isGettingStarted: request.body.isGettingStarted,
           projectId: request.principal.projectId,
           organizationId: request.principal.organization.id,
+          minVersion: request.body.minVersion,
+          maxVersion: request.body.maxVersion,
         });
 
         await reply.status(200).send({ result });

--- a/packages/server/api/src/app/flow-template/flow-template.service.ts
+++ b/packages/server/api/src/app/flow-template/flow-template.service.ts
@@ -36,6 +36,8 @@ type createFlowTemplateParams = {
   type?: string;
   isSample?: boolean;
   isGettingStarted?: boolean;
+  minVersion?: string;
+  maxVersion?: string;
 };
 
 export const flowTemplateService = {
@@ -170,6 +172,8 @@ export const flowTemplateService = {
       organizationId: requestOptions.organizationId,
       isSample: requestOptions.isSample,
       isGettingStarted: requestOptions.isGettingStarted,
+      minSupportedVersion: requestOptions.minVersion,
+      maxSupportedVersion: requestOptions.maxVersion,
     });
   },
 };


### PR DESCRIPTION
Fixes OPS-1271

## Additional Notes

Supports adding min/max versions:
```bash
curl --location 'http://localhost:4200/api/v1/flow-templates' \
--header 'Authorization: Bearer ...' \
--header 'Content-Type: application/json' \
--data '{
    "flowId": "ddngDMpRlg4Lxnxx8D1n4",
    "minVersion": "0.01",
    "maxVersion": "0.11"
}'
```
## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [ ] Automated tests were added/updated if necessary

- [x] Changes are backwards compatible with any existing data

![image](https://github.com/user-attachments/assets/537a90b2-05bf-496b-a501-739d88cfda18)
