### PR TITLE
Fix flow page 404 issue 

### DIFF
--- a/packages/react-ui/src/app/routes/flows/id/index.tsx
+++ b/packages/react-ui/src/app/routes/flows/id/index.tsx
@@ -45,6 +45,9 @@ const FlowBuilderPage = () => {
   if (isError && (error as AxiosError).status === 404) {
     return <Navigate to="/404" />;
   }
+  if (isError && error) {
+    throw error;
+  }
 
   if (isLoading) {
     return (


### PR DESCRIPTION
Fixes OPS-1175

## Additional Notes

This happened because react-query still tries to re-fetch stale data when going from offline to online mode again.
A more detailed perspective on it can be seen here:
https://github.com/TanStack/query/issues/2927

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [ ] Automated tests were added/updated if necessary

- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided

## Visual Changes (if applicable)
https://www.loom.com/share/53e8269b427a471fa10236f0492d18da
