### PR TITLE
Fix generic trigger test "action required" i18n KV 

### DIFF
--- a/packages/react-ui/public/locales/en/translation.json
+++ b/packages/react-ui/public/locales/en/translation.json
@@ -213,7 +213,7 @@
   "There is no sample data available found for this trigger.": "There is no sample data available found for this trigger.",
   "Failed to run test step, please ensure settings are correct.": "Failed to run test step, please ensure settings are correct.",
   "Please click on Test URL to generate sample data": "Please click on Test URL to generate sample data",
-  "testBlockWebhookTriggerNote": "testBlockWebhookTriggerNote",
+  "Please go to {blockName} and trigger {triggerName}.": "Please go to {blockName} and trigger {triggerName}.",
   "No sample data available": "No sample data available",
   "Old results were removed, retest for new sample data": "Old results were removed, retest for new sample data",
   "Result #": "Result #",

--- a/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
@@ -232,7 +232,7 @@ const TestTriggerSection = React.memo(
     const testTriggerNote =
       formValues.settings.triggerName === CATCH_WEBHOOK
         ? t('Please click on Test URL to generate sample data')
-        : t('testBlockWebhookTriggerNote', {
+        : t('Please go to {blockName} and trigger {triggerName}.', {
             blockName: blockModel?.displayName,
             triggerName:
               blockModel?.triggers[formValues.settings.triggerName].displayName,


### PR DESCRIPTION
Fixes OPS-1301

## Additional Notes
This PR is fixing a regression. The original AP translation value was accidentaly overridden during `i18n:extract` npm script execution some time ago.

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases
- [x] I verified all affected areas still work as expected
- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided
