### PR TITLE
Force panel to collapse when right sidebar gets unset after undo operation

### DIFF
--- a/packages/react-ui/src/app/features/builder/index.tsx
+++ b/packages/react-ui/src/app/features/builder/index.tsx
@@ -187,12 +187,13 @@ const BuilderPage = () => {
   }, [readonly, run, searchParams, setLeftSidebar, setReadOnly]);
 
   useEffect(() => {
-    if (!memorizedSelectedStep) {
-      rightHandleRef.current?.resize(0);
-    } else if (memorizedSelectedStep.type === TriggerType.EMPTY) {
+    if (
+      !memorizedSelectedStep ||
+      memorizedSelectedStep.type === TriggerType.EMPTY
+    ) {
       setRightSidebar(RightSideBarType.NONE);
     }
-  }, [memorizedSelectedStep, rightHandleRef, setRightSidebar]);
+  }, [memorizedSelectedStep, setRightSidebar]);
 
   const { switchToDraft, isSwitchingToDraftPending } = useSwitchToDraft();
 


### PR DESCRIPTION
Fixes OPS-1250

## Additional Notes
The bug revealed in the Loom authored by Roman:
https://www.loom.com/share/45b6c4c1b23b4847ac6f2fa7852772ad?sid=88fea237-6715-4470-89c9-ab19967aba54

Demo of my bug-fix:
https://www.loom.com/share/fbd2802b7abe489ba19de28c88bf885e

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases
- [x] I verified all affected areas still work as expected
- [x] Changes are backwards compatible with any existing data, otherwise, a migration script is provided

