### PR TITLE
Adjust FE to always pass version searchParam when fetching template list

### DIFF
--- a/packages/react-ui/src/app/features/templates/lib/templates-hooks.ts
+++ b/packages/react-ui/src/app/features/templates/lib/templates-hooks.ts
@@ -74,7 +74,7 @@ export const templatesHooks = {
             domains,
             blocks,
             tags,
-            version: version && version !== 'local' ? version : undefined,
+            version: version ?? undefined,
           })
         ).filter(
           (template: FlowTemplateMetadata) =>


### PR DESCRIPTION
Fixes OPS-1345

## Additional Notes

When running in localdev - HTTP://localhost:4200 - the FE also needs to pass the version searchParam to the GET API call when fetching the template catalog.

