### PR TITLE
Use placeholder AzureCLI error message when error includes "az login" cmd to prevent displaying crendentials in the FE

### DIFF
--- a/packages/blocks/azure/src/lib/actions/azure-cli-action.ts
+++ b/packages/blocks/azure/src/lib/actions/azure-cli-action.ts
@@ -120,7 +120,7 @@ export const azureCliAction = createAction({
       });
       let message = 'An error occurred while running an Azure CLI command: ';
       if (String(error).includes('login --service-principal')) {
-        message += 'az login <<credentials redacted>>';
+        message += 'login --service-principal ***REDACTED***';
       } else {
         message += error;
       }


### PR DESCRIPTION
Fixes OPS-1340

## Additional Notes

It's more of a quick hack, but it handles this particular use case:
Before:
<img width="380" alt="Screenshot 2025-03-14 at 00 15 15" src="https://github.com/user-attachments/assets/bfa59648-f406-4d3d-b55f-f1ad2d7abcb0" />


After:
<img width="266" alt="Screenshot 2025-03-14 at 00 07 46" src="https://github.com/user-attachments/assets/2c6d3490-05e1-49b3-8e1d-1ac77ae764d1" />

