### PR TITLE
Restore SingleSelect filters in "Get Records"

### DIFF
--- a/packages/openops/src/lib/openops-tables/filters.ts
+++ b/packages/openops/src/lib/openops-tables/filters.ts
@@ -18,6 +18,10 @@ export enum ViewFilterTypesEnum {
   lower_than_or_equal = 'Is lower than or equal',
   not_empty = 'Is not empty',
   not_equal = 'Is not equal',
+  single_select_equal = 'Single select is equal',
+  single_select_is_any_of = 'Single select is any of',
+  single_select_is_none_of = 'Single select is none of',
+  single_select_not_equal = 'Single select is not equal',
 }
 
 export function isSingleValueFilter(filterType: ViewFilterTypesEnum): boolean {


### PR DESCRIPTION
Fixes OPS-1355

## Additional Notes
This part was never implemented in [PR #1470](https://github.com/openops-cloud/workflow-editor/pull/1470/files), so the change broke the single select.
`3. For single select, we will need to artifically support "equals/not equals", and convert it to the single-select operators behind the scene`
