### PR TITLE
Fix resume payload path validation in loop executor

### DIFF
--- a/packages/engine/src/lib/handler/loop-executor.ts
+++ b/packages/engine/src/lib/handler/loop-executor.ts
@@ -77,7 +77,7 @@ export const loopExecutor: BaseExecutor<LoopOnItemsAction> = {
 
     const isCompleted = executionState.isCompleted({ stepName: action.name });
     if (isCompleted) {
-      if (payload && !payload.path?.includes(action.name)) {
+      if (payload && !pathContainsAction(action.name, payload.path)) {
         return executionState;
       }
     } else {
@@ -417,6 +417,15 @@ async function getIterationKey(
     iterationKey = (await store.get(path)) as string;
   }
   return iterationKey;
+}
+
+function pathContainsAction(actionName: string, path: string): boolean {
+  if (!path) {
+    return false;
+  }
+
+  const regex = new RegExp(`\\b${actionName}\\b`);
+  return regex.test(path);
 }
 
 type IterationResult = {


### PR DESCRIPTION
Fixes OPS-1360.

## Additional Notes

When resuming a workflow with a loop, we need to validate whether we are resuming one iteration or a block outside the loop. This PR fixes the validation if a loop's actionName belongs to the path to be resumed or not.

The path is a string like these:
- 'step_1,0.step_3' -> resume a iteration
- 'step_10' -> resume a block

