### PR TITLE
Move dryRunCheckbox out of aws-common-properties

### DIFF
--- a/packages/openops/src/index.ts
+++ b/packages/openops/src/index.ts
@@ -57,3 +57,4 @@ export * from './lib/azure/auth';
 export * from './lib/azure/subscription/get-subscription-dropdown';
 
 export * from './lib/axios-wrapper';
+export * from './lib/dry-run-property';

--- a/packages/openops/src/lib/aws/aws-common-properties.ts
+++ b/packages/openops/src/lib/aws/aws-common-properties.ts
@@ -1,14 +1,6 @@
 import { DynamicPropsValue, Property } from '@openops/blocks-framework';
-import { getARNsProperty, parseArn } from './arn-handler';
+import { getARNsProperty } from './arn-handler';
 import { getRegionsDropdownState } from './regions';
-
-export function dryRunCheckBox(): any {
-  return Property.Checkbox({
-    displayName: 'Dry Run',
-    description: 'Run the operation in dry run mode',
-    required: false,
-  });
-}
 
 export function waitForProperties(): any {
   return {

--- a/packages/openops/src/lib/dry-run-property.ts
+++ b/packages/openops/src/lib/dry-run-property.ts
@@ -1,0 +1,9 @@
+import { Property } from '@openops/blocks-framework';
+
+export function dryRunCheckBox(): any {
+  return Property.Checkbox({
+    displayName: 'Dry Run',
+    description: 'Run the operation in dry run mode',
+    required: false,
+  });
+}


### PR DESCRIPTION
Fixes OPS-1381

## Additional Notes

Dry run is now used in actions not related to aws, this is just a minimal backend improvement