### PR TITLE
Fix CI workflow triggers and conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  debug:
+    name: Debug
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   install:
     name: Install Dependencies
     if: ${{ ! github.event.pull_request || github.event.pull_request.head.repo.owner != 'openops-cloud' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 concurrency:
@@ -10,7 +11,6 @@ concurrency:
 jobs:
   install:
     name: Install Dependencies
-    if: ${{ ! github.event.pull_request || github.event.pull_request.head.repo.full_name != 'openops-cloud/openops' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -148,7 +148,6 @@ jobs:
           path: dist
           key: dist-${{ github.sha }}
   build-images:
-    if: vars.ECR_REGION
     strategy:
         matrix:
             target:
@@ -171,6 +170,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Configure AWS credentials
+        if: vars.ECR_REGION
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY_ID }}
@@ -178,17 +178,19 @@ jobs:
           aws-region: ${{ vars.ECR_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
+        if: vars.ECR_REGION
         uses: aws-actions/amazon-ecr-login@v2
       - name: Format image tag parts
         env:
           BRANCH: ${{ github.ref_name }}
-          SHA: ${{ github.sha }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           echo sanitized_branch=${BRANCH//[\/.:_]/-} >> "$GITHUB_ENV"
           echo repository_uri=${REGISTRY}/openops/${{ matrix.target.repository }} >> "$GITHUB_ENV"
           echo short_sha=${SHA::8} >> "$GITHUB_ENV"
       - name: Build image
+        if: vars.ECR_REGION
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -204,33 +206,8 @@ jobs:
             type=registry,ref=${{ env.repository_uri }}:${{ env.sanitized_branch }}-cache
             type=registry,ref=${{ env.repository_uri }}:main-cache
           cache-to: mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${{ env.repository_uri }}:${{ env.sanitized_branch }}-cache
-  build-images-for-forks:
-    if: ${{ ! vars.ECR_REGION }}
-    strategy:
-        matrix:
-            target:
-            - name: Editor
-              file: Dockerfile
-              repository: openops-app
-            - name: Engine
-              file: engine.Dockerfile
-              repository: openops-engine
-    name: Build ${{ matrix.target.name }} Image
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Restore build cache
-        uses: actions/cache/restore@v4
-        with:
-          path: dist
-          key: dist-${{ github.sha }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Set short SHA
-        run: |
-          echo "short_sha=${GITHUB_SHA::8}" >> $GITHUB_ENV
       - name: Build image
+        if: ${{ !vars.ECR_REGION }}
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  debug:
-    name: Debug
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
   install:
     name: Install Dependencies
     if: ${{ ! github.event.pull_request || github.event.pull_request.head.repo.full_name != 'openops-cloud/openops' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           path: dist
           key: dist-${{ github.sha }}
   build-images:
-    if: secrets.ECR_ACCESS_KEY_ID
+    if: vars.ECR_REGION
     strategy:
         matrix:
             target:
@@ -205,7 +205,7 @@ jobs:
             type=registry,ref=${{ env.repository_uri }}:main-cache
           cache-to: mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${{ env.repository_uri }}:${{ env.sanitized_branch }}-cache
   build-images-for-forks:
-    if: ${{ secrets.ECR_ACCESS_KEY_ID }}
+    if: ${{ ! vars.ECR_REGIONS }}
     strategy:
         matrix:
             target:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
 
 concurrency:
@@ -11,6 +10,7 @@ concurrency:
 jobs:
   install:
     name: Install Dependencies
+    if: ${{ ! github.event.pull_request || github.event.pull_request.head.repo.owner != 'openops-cloud' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +77,6 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Update THIRD_PARTY_LICENSES.txt
-
   test:
     strategy:
         matrix:
@@ -149,7 +148,7 @@ jobs:
           path: dist
           key: dist-${{ github.sha }}
   build-images:
-    if: github.repository_owner == 'openops-cloud'
+    if: secrets.ECR_ACCESS_KEY_ID
     strategy:
         matrix:
             target:
@@ -206,7 +205,7 @@ jobs:
             type=registry,ref=${{ env.repository_uri }}:main-cache
           cache-to: mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${{ env.repository_uri }}:${{ env.sanitized_branch }}-cache
   build-images-for-forks:
-    if: github.repository_owner != 'openops-cloud'
+    if: ${{ secrets.ECR_ACCESS_KEY_ID }}
     strategy:
         matrix:
             target:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
             type=registry,ref=${{ env.repository_uri }}:main-cache
           cache-to: mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${{ env.repository_uri }}:${{ env.sanitized_branch }}-cache
   build-images-for-forks:
-    if: ${{ ! vars.ECR_REGIONS }}
+    if: ${{ ! vars.ECR_REGION }}
     strategy:
         matrix:
             target:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
   install:
     name: Install Dependencies
-    if: ${{ ! github.event.pull_request || github.event.pull_request.head.repo.owner != 'openops-cloud' }}
+    if: ${{ ! github.event.pull_request || github.event.pull_request.head.repo.full_name != 'openops-cloud/openops' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes OPS-1261.

Fixed the tagging of docker images in PR builds. It will tag the image with the proper git SHA, allowing deployments to work from PRs.

Also consolidated the two docker image builds, relying on the fact that fork PRs don't have access to the "ECR_REGION" variable. In fork PRs we're not publishing the images, only building them for validation.