### PR TITLE
Fix panning mode selection for Shift key modifier

### DIFF
--- a/packages/ui-components/src/components/flow-canvas/canvas-context.test.tsx
+++ b/packages/ui-components/src/components/flow-canvas/canvas-context.test.tsx
@@ -1,0 +1,119 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { useKeyPress } from '@xyflow/react';
+import React from 'react';
+import { CanvasContextProvider, useCanvasContext } from './canvas-context';
+import { SHIFT_KEY, SPACE_KEY } from './constants';
+
+// Mock the useKeyPress hook
+jest.mock('@xyflow/react', () => ({
+  useKeyPress: jest.fn(),
+}));
+
+// Test component to consume the context
+const TestComponent = () => {
+  const { panningMode } = useCanvasContext();
+  return <div data-testid="panning-mode">{panningMode}</div>;
+};
+
+describe('CanvasContextProvider', () => {
+  const useKeyPressMock = useKeyPress as jest.Mock;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should default to "grab" panning mode when no keys are pressed', () => {
+    useKeyPressMock.mockReturnValue(false); // Neither space nor shift pressed
+
+    const { getByTestId } = render(
+      <CanvasContextProvider>
+        <TestComponent />
+      </CanvasContextProvider>,
+    );
+
+    expect(getByTestId('panning-mode')).toHaveTextContent('grab');
+  });
+
+  it('should set panning mode to "grab" when space is pressed and shift is not', () => {
+    useKeyPressMock.mockImplementation((key: string) => key === SPACE_KEY);
+
+    const { getByTestId } = render(
+      <CanvasContextProvider>
+        <TestComponent />
+      </CanvasContextProvider>,
+    );
+
+    expect(getByTestId('panning-mode')).toHaveTextContent('grab');
+  });
+
+  it('should set panning mode to "pan" when shift is pressed and space is not', () => {
+    useKeyPressMock.mockImplementation((key: string) => key === SHIFT_KEY);
+
+    const { getByTestId } = render(
+      <CanvasContextProvider>
+        <TestComponent />
+      </CanvasContextProvider>,
+    );
+
+    expect(getByTestId('panning-mode')).toHaveTextContent('pan');
+  });
+
+  it('should return "grab" when both space and shift keys are pressed', () => {
+    useKeyPressMock.mockReturnValue(true); // Simulate both keys pressed
+
+    const { getByTestId } = render(
+      <CanvasContextProvider>
+        <TestComponent />
+      </CanvasContextProvider>,
+    );
+
+    expect(getByTestId('panning-mode')).toHaveTextContent('grab');
+  });
+
+  it('should correctly update panningMode when setPanningMode is called', () => {
+    useKeyPressMock.mockReturnValue(false); // Neither space nor shift pressed
+
+    const ComponentWithSetter = () => {
+      const { panningMode, setPanningMode } = useCanvasContext();
+
+      React.useEffect(() => {
+        setPanningMode('pan');
+      }, [setPanningMode]);
+
+      return <div data-testid="panning-mode">{panningMode}</div>;
+    };
+
+    const { getByTestId } = render(
+      <CanvasContextProvider>
+        <ComponentWithSetter />
+      </CanvasContextProvider>,
+    );
+
+    expect(getByTestId('panning-mode')).toHaveTextContent('pan');
+  });
+
+  it('should return "pan" when shift is pressed even if panningMode state is "grab"', () => {
+    useKeyPressMock.mockImplementation((key: string) => key === SHIFT_KEY);
+
+    const { getByTestId } = render(
+      <CanvasContextProvider>
+        <TestComponent />
+      </CanvasContextProvider>,
+    );
+
+    expect(getByTestId('panning-mode')).toHaveTextContent('pan');
+  });
+
+  it('should return "grab" when space is pressed even if panningMode state is "pan"', () => {
+    useKeyPressMock.mockImplementation((key: string) => key === SPACE_KEY);
+
+    const { getByTestId } = render(
+      <CanvasContextProvider>
+        <TestComponent />
+      </CanvasContextProvider>,
+    );
+
+    expect(getByTestId('panning-mode')).toHaveTextContent('grab');
+  });
+});

--- a/packages/ui-components/src/components/flow-canvas/canvas-context.tsx
+++ b/packages/ui-components/src/components/flow-canvas/canvas-context.tsx
@@ -1,4 +1,6 @@
+import { useKeyPress } from '@xyflow/react';
 import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+import { SHIFT_KEY, SPACE_KEY } from './constants';
 
 export type PanningMode = 'grab' | 'pan';
 
@@ -16,12 +18,24 @@ export const CanvasContextProvider = ({
 }) => {
   const [panningMode, setPanningMode] = useState<PanningMode>('grab');
 
+  const spacePressed = useKeyPress(SPACE_KEY);
+  const shiftPressed = useKeyPress(SHIFT_KEY);
+
+  const effectivePanningMode: PanningMode = useMemo(() => {
+    if ((spacePressed || panningMode === 'grab') && !shiftPressed) {
+      return 'grab';
+    } else if ((shiftPressed || panningMode === 'pan') && !spacePressed) {
+      return 'pan';
+    }
+    return 'grab';
+  }, [panningMode, shiftPressed, spacePressed]);
+
   const contextValue = useMemo(
     () => ({
-      panningMode,
+      panningMode: effectivePanningMode,
       setPanningMode,
     }),
-    [panningMode],
+    [effectivePanningMode],
   );
   return (
     <CanvasContext.Provider value={contextValue}>

--- a/packages/ui-components/src/components/flow-canvas/canvas-controls/panning-mode-toggle-control.tsx
+++ b/packages/ui-components/src/components/flow-canvas/canvas-controls/panning-mode-toggle-control.tsx
@@ -25,9 +25,7 @@ export const PanningModeToggleControl = () => {
   const { panningMode, setPanningMode } = useCanvasContext();
   const spacePressed = useKeyPress(SPACE_KEY);
   const shiftPressed = useKeyPress(SHIFT_KEY);
-  const isInGrabMode =
-    (spacePressed || panningMode === 'grab') && !shiftPressed;
-
+  const isInGrabMode = panningMode === 'grab';
   return (
     <Tooltip>
       <TooltipTrigger asChild>


### PR DESCRIPTION
Fixes OPS-1392.

## Additional Notes
The `isInGrabMode` logic in PanningModeToggleControl and FlowCanvas needs to be in sync.
Currently, the logic PanningModeToggleControl is correct but not not in FlowCanvas.
## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [x] Automated tests were added/updated if necessary

- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided
