### PR TITLE
Add token refresh logic

### DIFF
--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
@@ -443,6 +443,7 @@ function needRefresh(connection: AppConnection): boolean {
   switch (connection.value.type) {
     case AppConnectionType.PLATFORM_OAUTH2:
     case AppConnectionType.CLOUD_OAUTH2:
+      return oauth2Util.isExpired(connection.value);
     case AppConnectionType.OAUTH2:
       return oauth2Util.isExpired(connection.value);
     default:

--- a/packages/server/api/src/app/app-connection/app-connection-service/oauth2/services/cloud-oauth2-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/oauth2/services/cloud-oauth2-service.ts
@@ -31,7 +31,7 @@ async function refresh({
     tokenUrl: connectionValue.token_url,
   };
 
-  logger.info(`Refreshing token via Lambda for block: ${blockName}`);
+  logger.debug(`Refreshing token for block: ${blockName}`);
 
   try {
     const oauthProxyUrl = system.get<string>(
@@ -51,7 +51,7 @@ async function refresh({
       type: AppConnectionType.CLOUD_OAUTH2,
     };
   } catch (e: unknown) {
-    logger.error('Error refreshing token via Lambda', e);
+    logger.error(`Error refreshing token for block: ${blockName}`, e);
     throw new ApplicationError({
       code: ErrorCode.INVALID_CLOUD_REFRESH,
       params: { blockName },

--- a/packages/shared/src/lib/common/application-error.ts
+++ b/packages/shared/src/lib/common/application-error.ts
@@ -33,6 +33,7 @@ export type ApplicationErrorParams =
   | InvalidBearerTokenParams
   | InvalidClaimParams
   | InvalidCloudClaimParams
+  | InvalidCloudRefreshParams
   | InvalidCredentialsErrorParams
   | InvalidJwtTokenErrorParams
   | InvalidOtpParams
@@ -83,6 +84,11 @@ export type InvalidClaimParams = BaseErrorParams<
 >;
 export type InvalidCloudClaimParams = BaseErrorParams<
   ErrorCode.INVALID_CLOUD_CLAIM,
+  { blockName: string }
+>;
+
+export type InvalidCloudRefreshParams = BaseErrorParams<
+  ErrorCode.INVALID_CLOUD_REFRESH,
   { blockName: string }
 >;
 
@@ -429,6 +435,7 @@ export enum ErrorCode {
   INVALID_BEARER_TOKEN = 'INVALID_BEARER_TOKEN',
   INVALID_CLAIM = 'INVALID_CLAIM',
   INVALID_CLOUD_CLAIM = 'INVALID_CLOUD_CLAIM',
+  INVALID_CLOUD_REFRESH = 'INVALID_CLOUD_REFRESH',
   INVALID_CREDENTIALS = 'INVALID_CREDENTIALS',
   INVALID_OR_EXPIRED_JWT_TOKEN = 'INVALID_OR_EXPIRED_JWT_TOKEN',
   INVALID_OTP = 'INVALID_OTP',


### PR DESCRIPTION
Part of OPS-1205

Adds logic to refresh token if it has expired. This is needed for OAUTH2 apps like teams, which has a token expiry of 1 hour.