### PR TITLE
Disable showing dynamic toggle for simple properties

### DIFF
--- a/packages/react-ui/src/app/features/builder/block-properties/auto-properties-form.tsx
+++ b/packages/react-ui/src/app/features/builder/block-properties/auto-properties-form.tsx
@@ -280,7 +280,7 @@ const selectFormComponentForProperty = ({
           field={field}
           propertyName={propertyName}
           disabled={disabled}
-          allowDynamicValues={allowDynamicValues}
+          allowDynamicValues={false}
         >
           {useMentionTextInput ? (
             <TextInputWithMentions


### PR DESCRIPTION
Fixes OPS-1419

Removed from Number:
<img width="449" alt="image" src="https://github.com/user-attachments/assets/732becec-1912-420c-a89e-fde4ef36d4d4" />

Removed from text:
<img width="446" alt="image" src="https://github.com/user-attachments/assets/2adca680-d053-4cd5-9e27-463df46280cd" />

Removed from long text:
<img width="468" alt="image" src="https://github.com/user-attachments/assets/df15d5d6-e1ef-47a1-a5bc-bc0b1ed24b95" />

Removed from date:
<img width="452" alt="image" src="https://github.com/user-attachments/assets/a0a2c9ba-cf7c-4ea4-9ae9-47b80e2db2f3" />

Removed from file:
<img width="441" alt="image" src="https://github.com/user-attachments/assets/4b40ab00-4c6c-47b8-bb0a-7ca4aa44702b" />



Kept for toggles and dropdowns:
<img width="429" alt="image" src="https://github.com/user-attachments/assets/5cec3fd8-2a17-4576-971e-74f84d240152" />
