### PR TITLE
Extract common logic in cli block

### DIFF
--- a/packages/blocks/aws/src/lib/actions/cli/aws-cli-action.ts
+++ b/packages/blocks/aws/src/lib/actions/cli/aws-cli-action.ts
@@ -4,8 +4,9 @@ import {
   dryRunCheckBox,
   getAwsAccountsSingleSelectDropdown,
   getCredentialsForAccount,
+  handleCliError,
+  tryParseJson,
 } from '@openops/common';
-import { logger } from '@openops/server-shared';
 import { runCommand } from './aws-cli';
 
 export const awsCliAction = createAction({
@@ -35,20 +36,14 @@ export const awsCliAction = createAction({
         context.auth.defaultRegion,
         credential,
       );
-      try {
-        const jsonObject = JSON.parse(result);
-        return jsonObject;
-      } catch (error) {
-        return result;
-      }
+
+      return tryParseJson(result);
     } catch (error) {
-      logger.error('AWS CLI execution failed.', {
+      handleCliError({
+        provider: 'AWS',
         command: context.propsValue['commandToRun'],
-        error: error,
+        error,
       });
-      throw new Error(
-        'An error occurred while running an AWS CLI command: ' + error,
-      );
     }
   },
 });

--- a/packages/blocks/azure/src/lib/actions/azure-cli-action.ts
+++ b/packages/blocks/azure/src/lib/actions/azure-cli-action.ts
@@ -1,6 +1,10 @@
 import { createAction, Property } from '@openops/blocks-framework';
-import { azureAuth, dryRunCheckBox } from '@openops/common';
-import { logger } from '@openops/server-shared';
+import {
+  azureAuth,
+  dryRunCheckBox,
+  handleCliError,
+  tryParseJson,
+} from '@openops/common';
 import { runCommand } from '../azure-cli';
 import { subDropdown, useHostSession } from '../common-properties';
 
@@ -29,24 +33,14 @@ export const azureCliAction = createAction({
         context.propsValue.useHostSession?.['useHostSessionCheckbox'],
         context.propsValue.subscriptions?.['subDropdown'],
       );
-      try {
-        const jsonObject = JSON.parse(result);
-        return jsonObject;
-      } catch (error) {
-        return result;
-      }
+
+      return tryParseJson(result);
     } catch (error) {
-      logger.error('Azure CLI execution failed.', {
+      handleCliError({
+        provider: 'Azure',
         command: context.propsValue['commandToRun'],
-        error: error,
+        error,
       });
-      let message = 'An error occurred while running an Azure CLI command: ';
-      if (String(error).includes('login --service-principal')) {
-        message += 'login --service-principal ***REDACTED***';
-      } else {
-        message += error;
-      }
-      throw new Error(message);
     }
   },
 });

--- a/packages/blocks/azure/src/lib/azure-cli.ts
+++ b/packages/blocks/azure/src/lib/azure-cli.ts
@@ -37,7 +37,18 @@ export async function runCommand(
 }
 
 async function login(credentials: any, envVars: any) {
-  const loginCommand = `login --service-principal --username ${credentials.clientId} --password ${credentials.clientSecret} --tenant ${credentials.tenantId}`;
+  try {
+    const loginCommand = `login --service-principal --username ${credentials.clientId} --password ${credentials.clientSecret} --tenant ${credentials.tenantId}`;
 
-  return await runCliCommand(loginCommand, 'az', envVars);
+    return await runCliCommand(loginCommand, 'az', envVars);
+  } catch (error) {
+    let message = 'Error while login into azure: ';
+    if (String(error).includes('login --service-principal')) {
+      message += 'login --service-principal ***REDACTED***';
+    } else {
+      message += error;
+    }
+
+    throw new Error(message);
+  }
 }

--- a/packages/openops/src/index.ts
+++ b/packages/openops/src/index.ts
@@ -57,4 +57,5 @@ export * from './lib/azure/auth';
 export * from './lib/azure/subscription/get-subscription-dropdown';
 
 export * from './lib/axios-wrapper';
+export * from './lib/cloud-cli-common';
 export * from './lib/dry-run-property';

--- a/packages/openops/src/lib/cloud-cli-common.ts
+++ b/packages/openops/src/lib/cloud-cli-common.ts
@@ -1,0 +1,28 @@
+import { logger } from '@openops/server-shared';
+
+export function tryParseJson(result: string): any {
+  try {
+    return JSON.parse(result);
+  } catch {
+    return result;
+  }
+}
+
+export function handleCliError({
+  provider,
+  command,
+  error,
+}: {
+  provider: string;
+  command: string;
+  error: unknown;
+}): never {
+  logger.error(`${provider} CLI execution failed.`, {
+    command,
+    error,
+  });
+
+  const message = `An error occurred while running a ${provider} CLI command: ${error}`;
+
+  throw new Error(message);
+}

--- a/packages/openops/test/cloud-cli-common.test.ts
+++ b/packages/openops/test/cloud-cli-common.test.ts
@@ -1,0 +1,53 @@
+const loggerMock = {
+  error: jest.fn(),
+};
+
+jest.mock('@openops/server-shared', () => ({
+  logger: loggerMock,
+}));
+
+import { handleCliError, tryParseJson } from '../src/lib/cloud-cli-common';
+
+describe('tryParseJson', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns parsed JSON when input is valid JSON', () => {
+    const input = '{"someKey":"some value"}';
+    const result = tryParseJson(input);
+    expect(result).toEqual({ someKey: 'some value' });
+  });
+
+  test('returns original string when input is not valid JSON', () => {
+    const input = 'not a json string';
+    const result = tryParseJson(input);
+    expect(result).toBe(input);
+  });
+});
+
+describe('handleCliError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('logs the error and throws with correct message', () => {
+    const error = new Error('Something went wrong');
+    const command = 'aws s3 ls';
+    const provider = 'AWS';
+
+    expect(() => {
+      handleCliError({ provider, command, error });
+    }).toThrowError(
+      `An error occurred while running a AWS CLI command: Error: Something went wrong`,
+    );
+
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      'AWS CLI execution failed.',
+      expect.objectContaining({
+        command,
+        error,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Fixes OPS-1436

Since we will be adding a third CLI block, I thought it made sense to extract some common logic, especially the error logging and json parsing. 