### PR TITLE
Can switch between single and multi-select in canavs

### DIFF
--- a/packages/react-ui/src/app/features/builder/index.tsx
+++ b/packages/react-ui/src/app/features/builder/index.tsx
@@ -10,7 +10,7 @@ import {
   useElementSize,
 } from '@openops/components/ui';
 import { ReactFlowProvider } from '@xyflow/react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ImperativePanelHandle } from 'react-resizable-panels';
 import { useSearchParams } from 'react-router-dom';
 
@@ -101,6 +101,7 @@ const BuilderPage = () => {
     readonly,
     setReadOnly,
     setRightSidebar,
+    exitStepSettings,
   ] = useBuilderStateContext((state) => [
     state.selectedStep,
     state.leftSidebar,
@@ -111,7 +112,12 @@ const BuilderPage = () => {
     state.readonly,
     state.setReadOnly,
     state.setRightSidebar,
+    state.exitStepSettings,
   ]);
+
+  const clearSelectedStep = useCallback(() => {
+    exitStepSettings();
+  }, [exitStepSettings]);
 
   const { memorizedSelectedStep, containerKey } = useBuilderStateContext(
     (state) => {
@@ -262,7 +268,10 @@ const BuilderPage = () => {
                 'min-w-[830px]': leftSidebar === LeftSideBarType.NONE,
               })}
             >
-              <CanvasContextProvider>
+              <CanvasContextProvider
+                selectedStep={selectedStep}
+                clearSelectedStep={clearSelectedStep}
+              >
                 <div ref={middlePanelRef} className="relative h-full w-full">
                   <BuilderHeader />
 

--- a/packages/ui-components/src/components/flow-canvas/canvas-context.test.tsx
+++ b/packages/ui-components/src/components/flow-canvas/canvas-context.test.tsx
@@ -9,7 +9,16 @@ import { SHIFT_KEY, SPACE_KEY } from './constants';
 jest.mock('@xyflow/react', () => ({
   useKeyPress: jest.fn(),
   useStoreApi: jest.fn(() => ({
-    getState: jest.fn(),
+    getState: jest.fn().mockReturnValue({
+      setNodes: jest.fn(),
+      setEdges: jest.fn(),
+      nodes: [
+        {
+          id: 'step_1',
+          selected: true,
+        },
+      ],
+    }),
   })),
 }));
 

--- a/packages/ui-components/src/components/flow-canvas/canvas-context.tsx
+++ b/packages/ui-components/src/components/flow-canvas/canvas-context.tsx
@@ -15,6 +15,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { usePrevious } from 'react-use';
 import { useDebounceCallback } from 'usehooks-ts';
 import {
   COPY_KEYS,
@@ -39,12 +40,17 @@ const CanvasContext = createContext<CanvasContextState | undefined>(undefined);
 
 export const CanvasContextProvider = ({
   flowCanvasContainerId,
+  selectedStep,
+  clearSelectedStep,
   children,
 }: {
   flowCanvasContainerId?: string;
+  selectedStep: string | null;
+  clearSelectedStep: () => void;
   children: ReactNode;
 }) => {
   const [panningMode, setPanningMode] = useState<PanningMode>('grab');
+  const previousSelectedStep = usePrevious(selectedStep);
   const [selectedActions, setSelectedActions] = useState<Action[]>([]);
   const selectedFlowActionRef = useRef<Action | null>(null);
   const selectedNodeCounterRef = useRef<number>(0);
@@ -59,6 +65,19 @@ export const CanvasContextProvider = ({
       : null;
   }, [flowCanvasContainerId]);
   const copyPressed = useKeyPress(COPY_KEYS, { target: canvas });
+
+  // clear multi-selection if we have a new selected step
+  useEffect(() => {
+    if (selectedStep && previousSelectedStep !== selectedStep) {
+      state.setNodes(
+        state.nodes.map((node) => ({
+          ...node,
+          selected: undefined,
+        })),
+      );
+      state.setEdges(state.edges);
+    }
+  }, [selectedStep, previousSelectedStep, state]);
 
   const effectivePanningMode: PanningMode = useMemo(() => {
     if ((spacePressed || panningMode === 'grab') && !shiftPressed) {
@@ -118,7 +137,8 @@ export const CanvasContextProvider = ({
     );
 
     setSelectedActions([]);
-  }, [selectedActions, state]);
+    clearSelectedStep();
+  }, [clearSelectedStep, selectedActions, state]);
 
   const copySelectedArea = useDebounceCallback(() => {
     const selectionArea = document.querySelector(


### PR DESCRIPTION
Fixes OPS-1426

## Additional Notes
Selecting a single step will cancel any multi-selection. Conversely, selecting multiple steps will clear any previously selected single step.

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [x] Changes are backwards compatible with any existing data

## Visual Changes (if applicable)
https://www.loom.com/share/99b8058536a541ef8bd116043956ce89