### PR TITLE
Fix readonly canvas & templates canvas glitch

### DIFF
--- a/packages/react-ui/src/app/features/builder/index.tsx
+++ b/packages/react-ui/src/app/features/builder/index.tsx
@@ -1,9 +1,10 @@
 import {
   AiWidget,
   BuilderTreeViewProvider,
-  CanvasContextProvider,
   CanvasControls,
   cn,
+  InteractiveContextProvider,
+  ReadonlyCanvasProvider,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
@@ -262,27 +263,48 @@ const BuilderPage = () => {
                 'min-w-[830px]': leftSidebar === LeftSideBarType.NONE,
               })}
             >
-              <CanvasContextProvider>
-                <div ref={middlePanelRef} className="relative h-full w-full">
-                  <BuilderHeader />
+              {readonly ? (
+                <ReadonlyCanvasProvider>
+                  <div ref={middlePanelRef} className="relative h-full w-full">
+                    <BuilderHeader />
 
-                  <CanvasControls
-                    topOffset={FLOW_CANVAS_Y_OFFESET}
-                  ></CanvasControls>
-                  <AiWidget />
-                  <DataSelector
-                    parentHeight={middlePanelSize.height}
-                    parentWidth={middlePanelSize.width}
-                  ></DataSelector>
+                    <CanvasControls
+                      topOffset={FLOW_CANVAS_Y_OFFESET}
+                    ></CanvasControls>
 
-                  <div
-                    className="h-screen w-full flex-1 z-10"
-                    id={FLOW_CANVAS_CONTAINER_ID}
-                  >
-                    <FlowBuilderCanvas />
+                    <div
+                      className={cn('h-screen w-full flex-1 z-10', {
+                        'bg-background': !isDraggingHandle,
+                      })}
+                      id={FLOW_CANVAS_CONTAINER_ID}
+                    >
+                      <FlowBuilderCanvas />
+                    </div>
                   </div>
-                </div>
-              </CanvasContextProvider>
+                </ReadonlyCanvasProvider>
+              ) : (
+                <InteractiveContextProvider>
+                  <div ref={middlePanelRef} className="relative h-full w-full">
+                    <BuilderHeader />
+
+                    <CanvasControls
+                      topOffset={FLOW_CANVAS_Y_OFFESET}
+                    ></CanvasControls>
+                    <AiWidget />
+                    <DataSelector
+                      parentHeight={middlePanelSize.height}
+                      parentWidth={middlePanelSize.width}
+                    ></DataSelector>
+
+                    <div
+                      className="h-screen w-full flex-1 z-10"
+                      id={FLOW_CANVAS_CONTAINER_ID}
+                    >
+                      <FlowBuilderCanvas />
+                    </div>
+                  </div>
+                </InteractiveContextProvider>
+              )}
             </ResizablePanel>
 
             <>

--- a/packages/ui-components/src/components/flow-canvas/canvas-context.test.tsx
+++ b/packages/ui-components/src/components/flow-canvas/canvas-context.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import { useKeyPress } from '@xyflow/react';
 import React from 'react';
-import { CanvasContextProvider, useCanvasContext } from './canvas-context';
+import { InteractiveContextProvider, useCanvasContext } from './canvas-context';
 import { SHIFT_KEY, SPACE_KEY } from './constants';
 
 // Mock the useKeyPress hook
@@ -23,7 +23,7 @@ const TestComponent = () => {
   return <div data-testid="panning-mode">{panningMode}</div>;
 };
 
-describe('CanvasContextProvider', () => {
+describe('InteractiveContextProvider', () => {
   const useKeyPressMock = useKeyPress as jest.Mock;
 
   afterEach(() => {
@@ -34,9 +34,9 @@ describe('CanvasContextProvider', () => {
     useKeyPressMock.mockReturnValue(false); // Neither space nor shift pressed
 
     const { getByTestId } = render(
-      <CanvasContextProvider>
+      <InteractiveContextProvider>
         <TestComponent />
-      </CanvasContextProvider>,
+      </InteractiveContextProvider>,
     );
 
     expect(getByTestId('panning-mode')).toHaveTextContent('grab');
@@ -46,9 +46,9 @@ describe('CanvasContextProvider', () => {
     useKeyPressMock.mockImplementation((key: string) => key === SPACE_KEY);
 
     const { getByTestId } = render(
-      <CanvasContextProvider>
+      <InteractiveContextProvider>
         <TestComponent />
-      </CanvasContextProvider>,
+      </InteractiveContextProvider>,
     );
 
     expect(getByTestId('panning-mode')).toHaveTextContent('grab');
@@ -58,9 +58,9 @@ describe('CanvasContextProvider', () => {
     useKeyPressMock.mockImplementation((key: string) => key === SHIFT_KEY);
 
     const { getByTestId } = render(
-      <CanvasContextProvider>
+      <InteractiveContextProvider>
         <TestComponent />
-      </CanvasContextProvider>,
+      </InteractiveContextProvider>,
     );
 
     expect(getByTestId('panning-mode')).toHaveTextContent('pan');
@@ -70,9 +70,9 @@ describe('CanvasContextProvider', () => {
     useKeyPressMock.mockReturnValue(true); // Simulate both keys pressed
 
     const { getByTestId } = render(
-      <CanvasContextProvider>
+      <InteractiveContextProvider>
         <TestComponent />
-      </CanvasContextProvider>,
+      </InteractiveContextProvider>,
     );
 
     expect(getByTestId('panning-mode')).toHaveTextContent('grab');
@@ -92,9 +92,9 @@ describe('CanvasContextProvider', () => {
     };
 
     const { getByTestId } = render(
-      <CanvasContextProvider>
+      <InteractiveContextProvider>
         <ComponentWithSetter />
-      </CanvasContextProvider>,
+      </InteractiveContextProvider>,
     );
 
     expect(getByTestId('panning-mode')).toHaveTextContent('pan');
@@ -104,9 +104,9 @@ describe('CanvasContextProvider', () => {
     useKeyPressMock.mockImplementation((key: string) => key === SHIFT_KEY);
 
     const { getByTestId } = render(
-      <CanvasContextProvider>
+      <InteractiveContextProvider>
         <TestComponent />
-      </CanvasContextProvider>,
+      </InteractiveContextProvider>,
     );
 
     expect(getByTestId('panning-mode')).toHaveTextContent('pan');
@@ -116,9 +116,9 @@ describe('CanvasContextProvider', () => {
     useKeyPressMock.mockImplementation((key: string) => key === SPACE_KEY);
 
     const { getByTestId } = render(
-      <CanvasContextProvider>
+      <InteractiveContextProvider>
         <TestComponent />
-      </CanvasContextProvider>,
+      </InteractiveContextProvider>,
     );
 
     expect(getByTestId('panning-mode')).toHaveTextContent('grab');

--- a/packages/ui-components/src/components/flow-canvas/canvas-context.tsx
+++ b/packages/ui-components/src/components/flow-canvas/canvas-context.tsx
@@ -33,11 +33,37 @@ type CanvasContextState = {
   onSelectionEnd: () => void;
   copySelectedArea: () => void;
   copyAction: (action: Action) => void;
+  readonly: boolean;
 };
 
 const CanvasContext = createContext<CanvasContextState | undefined>(undefined);
 
-export const CanvasContextProvider = ({
+export const ReadonlyCanvasProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const contextValue = useMemo(
+    () => ({
+      panningMode: 'grab' as const,
+      setPanningMode: () => {},
+      onSelectionChange: () => {},
+      onSelectionEnd: () => {},
+      copySelectedArea: () => {},
+      copyAction: () => {},
+      readonly: true,
+    }),
+    [],
+  );
+
+  return (
+    <CanvasContext.Provider value={contextValue}>
+      {children}
+    </CanvasContext.Provider>
+  );
+};
+
+export const InteractiveContextProvider = ({
   flowCanvasContainerId,
   children,
 }: {
@@ -178,8 +204,15 @@ export const CanvasContextProvider = ({
       onSelectionEnd,
       copySelectedArea,
       copyAction,
+      readonly: false,
     }),
-    [effectivePanningMode, onSelectionChange, onSelectionEnd, copySelectedArea],
+    [
+      effectivePanningMode,
+      onSelectionChange,
+      onSelectionEnd,
+      copySelectedArea,
+      copyAction,
+    ],
   );
   return (
     <CanvasContext.Provider value={contextValue}>

--- a/packages/ui-components/src/components/flow-canvas/canvas-controls/canvas-controls.tsx
+++ b/packages/ui-components/src/components/flow-canvas/canvas-controls/canvas-controls.tsx
@@ -7,11 +7,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../../../ui/tooltip';
 
 import { CenterFlowIcon } from '../../../icons';
 import { VerticalDivider } from '../../../ui/vertical-divider';
+import { useCanvasContext } from '../canvas-context';
 import { InitialZoom } from '../constants';
 import { PanningModeToggleControl } from './panning-mode-toggle-control';
 
 const CanvasControls = ({ topOffset }: { topOffset?: number }) => {
   const reactFlow = useReactFlow();
+  const { readonly } = useCanvasContext();
 
   const handleZoomIn = useCallback(() => {
     reactFlow.zoomIn({
@@ -45,7 +47,7 @@ const CanvasControls = ({ topOffset }: { topOffset?: number }) => {
 
   return (
     <div className="bg-background absolute left-[10px] bottom-[10px] z-50 rounded-xl flex flex-row items-center gap-1 shadow-editor py-0.5 px-2">
-      <PanningModeToggleControl />
+      {!readonly && <PanningModeToggleControl />}
 
       <VerticalDivider height={24} />
 

--- a/packages/ui-components/src/components/flow-canvas/flow-canvas.tsx
+++ b/packages/ui-components/src/components/flow-canvas/flow-canvas.tsx
@@ -73,7 +73,7 @@ const FlowCanvas = React.memo(
       [topOffset],
     );
 
-    const { panningMode, onSelectionChange, onSelectionEnd } =
+    const { readonly, panningMode, onSelectionChange, onSelectionEnd } =
       useCanvasContext();
     const inGrabPanningMode = panningMode === 'grab';
 
@@ -136,16 +136,20 @@ const FlowCanvas = React.memo(
               elementsSelectable={true}
               nodesDraggable={false}
               nodesFocusable={false}
-              selectionKeyCode={inGrabPanningMode ? SHIFT_KEY : null}
-              multiSelectionKeyCode={inGrabPanningMode ? SHIFT_KEY : null}
-              selectionOnDrag={!inGrabPanningMode}
+              selectionKeyCode={
+                inGrabPanningMode && !readonly ? SHIFT_KEY : null
+              }
+              multiSelectionKeyCode={
+                inGrabPanningMode && !readonly ? SHIFT_KEY : null
+              }
+              selectionOnDrag={!inGrabPanningMode && !readonly}
               proOptions={{
                 hideAttribution: true,
               }}
               onInit={onInit}
               onContextMenu={onContextMenu}
-              onSelectionChange={onSelectionChange}
-              onSelectionEnd={onSelectionEnd}
+              onSelectionChange={readonly ? undefined : onSelectionChange}
+              onSelectionEnd={readonly ? undefined : onSelectionEnd}
             >
               <Background color="lightgray" />
               {children}

--- a/packages/ui-components/src/components/flow-template/template-canvas.tsx
+++ b/packages/ui-components/src/components/flow-template/template-canvas.tsx
@@ -2,7 +2,7 @@ import { Trigger } from '@openops/shared';
 import { EdgeTypes, getNodesBounds, NodeTypes } from '@xyflow/react';
 import React, { ReactNode, useMemo } from 'react';
 import { flowCanvasUtils } from '../../lib/flow-canvas-utils';
-import { CanvasContextProvider } from '../flow-canvas/canvas-context';
+import { ReadonlyCanvasProvider } from '../flow-canvas/canvas-context';
 import { FlowCanvas } from '../flow-canvas/flow-canvas';
 import { BelowFlowWidget } from '../flow-canvas/widgets/below-flow-widget';
 import { TemplateCanvasProvider } from './template-canvas-context';
@@ -34,7 +34,7 @@ const TemplateCanvas = React.memo(
       <div className="w-full h-full relative">
         {!!graph && (
           <TemplateCanvasProvider template={template}>
-            <CanvasContextProvider>
+            <ReadonlyCanvasProvider>
               <FlowCanvas
                 edgeTypes={edgeTypes}
                 nodeTypes={nodeTypes}
@@ -47,7 +47,7 @@ const TemplateCanvas = React.memo(
                   graphHeight={graphHeight.height}
                 ></BelowFlowWidget>
               </FlowCanvas>
-            </CanvasContextProvider>
+            </ReadonlyCanvasProvider>
           </TemplateCanvasProvider>
         )}
       </div>

--- a/packages/ui-components/src/stories/flow-canvas/flow-canvas.stories.tsx
+++ b/packages/ui-components/src/stories/flow-canvas/flow-canvas.stories.tsx
@@ -2,7 +2,7 @@ import { Action, ActionType, Trigger, TriggerType } from '@openops/shared';
 import type { StoryObj } from '@storybook/react';
 import { getNodesBounds } from '@xyflow/react';
 import React, { useMemo } from 'react';
-import { CanvasContextProvider } from '../../components/flow-canvas/canvas-context';
+import { ReadonlyCanvasProvider } from '../../components/flow-canvas/canvas-context';
 import { CanvasControls } from '../../components/flow-canvas/canvas-controls';
 import { ReturnLoopedgeButton } from '../../components/flow-canvas/edges/return-loop-edge';
 import {
@@ -75,7 +75,7 @@ const FlowCanvasStory = (args: FlowCanvasProps) => {
   return (
     <div className="w-full h-[100vh] relative">
       <TemplateCanvasProvider template={template}>
-        <CanvasContextProvider>
+        <ReadonlyCanvasProvider>
           <TooltipProvider>
             <FlowCanvas {...args} graph={graph}>
               <BelowFlowWidget
@@ -84,7 +84,7 @@ const FlowCanvasStory = (args: FlowCanvasProps) => {
               <CanvasControls />
             </FlowCanvas>
           </TooltipProvider>
-        </CanvasContextProvider>
+        </ReadonlyCanvasProvider>
       </TemplateCanvasProvider>
     </div>
   );


### PR DESCRIPTION
Fixes OPS-1422, OPS-1409

## Additional Notes
Added a ReadOnlyCanvasContext for view-only and templates canvas. 

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided

## Visual Changes (if applicable)

https://www.loom.com/share/713cc1f56bff4763bb6e44ef8636418e
