### PR TITLE
Expose port 4200 for slack interactions

### DIFF
--- a/.devcontainer/codespaces.sh
+++ b/.devcontainer/codespaces.sh
@@ -12,3 +12,4 @@ curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo 
 gh codespace ports visibility 3000:public -c $CODESPACE_NAME
 gh codespace ports visibility 3001:public -c $CODESPACE_NAME
 gh codespace ports visibility 3005:public -c $CODESPACE_NAME
+gh codespace ports visibility 4200:public -c $CODESPACE_NAME


### PR DESCRIPTION
Part of OPS-1433

Small fix for codespaces. Otherwise we get back 401 because the oauth lambda can't reach the codespace.