### PR TITLE
Patch template canvas ClipboardContextProvider to unblock weekly release

### DIFF
--- a/packages/ui-components/src/components/flow-template/template-canvas.tsx
+++ b/packages/ui-components/src/components/flow-template/template-canvas.tsx
@@ -3,6 +3,7 @@ import { EdgeTypes, getNodesBounds, NodeTypes } from '@xyflow/react';
 import React, { ReactNode, useMemo } from 'react';
 import { flowCanvasUtils } from '../../lib/flow-canvas-utils';
 import { ReadonlyCanvasProvider } from '../flow-canvas/canvas-context';
+import { ClipboardContextProvider } from '../flow-canvas/clipboard-context';
 import { FlowCanvas } from '../flow-canvas/flow-canvas';
 import { BelowFlowWidget } from '../flow-canvas/widgets/below-flow-widget';
 import { TemplateCanvasProvider } from './template-canvas-context';
@@ -34,20 +35,23 @@ const TemplateCanvas = React.memo(
       <div className="w-full h-full relative">
         {!!graph && (
           <TemplateCanvasProvider template={template}>
-            <ReadonlyCanvasProvider>
-              <FlowCanvas
-                edgeTypes={edgeTypes}
-                nodeTypes={nodeTypes}
-                graph={graph}
-                allowCanvasPanning={true}
-                topOffset={topOffset}
-              >
-                {children}
-                <BelowFlowWidget
-                  graphHeight={graphHeight.height}
-                ></BelowFlowWidget>
-              </FlowCanvas>
-            </ReadonlyCanvasProvider>
+            {/* TODO: OPS-1460 remove this provider when we have a better solution */}
+            <ClipboardContextProvider copyPasteActionsEnabled={false}>
+              <ReadonlyCanvasProvider>
+                <FlowCanvas
+                  edgeTypes={edgeTypes}
+                  nodeTypes={nodeTypes}
+                  graph={graph}
+                  allowCanvasPanning={true}
+                  topOffset={topOffset}
+                >
+                  {children}
+                  <BelowFlowWidget
+                    graphHeight={graphHeight.height}
+                  ></BelowFlowWidget>
+                </FlowCanvas>
+              </ReadonlyCanvasProvider>
+            </ClipboardContextProvider>
           </TemplateCanvasProvider>
         )}
       </div>


### PR DESCRIPTION
Fixes OPS-1462.

## Additional Notes

This PR documents the TODO (ticket OPS-1460) and patches the regression in TemplateCanvas 


![Screenshot 2025-03-27 at 09 06 20](https://github.com/user-attachments/assets/fde97376-6a06-46f0-818b-f12602169292)

