### PR TITLE
Add support for date comparisons when inserting in tables

### DIFF
--- a/packages/blocks/openops-tables/src/actions/delete-record-action.ts
+++ b/packages/blocks/openops-tables/src/actions/delete-record-action.ts
@@ -49,6 +49,7 @@ export const deleteRecordAction = createAction({
       tableId,
       rowPrimaryKey,
       primaryKeyField.name,
+      primaryKeyField.type,
     );
     if (!rowToDelete) {
       throw new Error('No record found with given primary key');

--- a/packages/blocks/openops-tables/src/actions/update-record-action.ts
+++ b/packages/blocks/openops-tables/src/actions/update-record-action.ts
@@ -144,6 +144,7 @@ export const updateRecordAction = createAction({
           tableId,
           primaryKeyValue,
           primaryKeyField.name,
+          primaryKeyField.type,
         )
       : undefined;
 

--- a/packages/blocks/openops-tables/test/actions/delete-record-action.test.ts
+++ b/packages/blocks/openops-tables/test/actions/delete-record-action.test.ts
@@ -142,6 +142,7 @@ describe('deleteRecordAction', () => {
   test('should throw if no row was found with primary key', async () => {
     openopsCommonMock.getPrimaryKeyFieldFromFields.mockReturnValue({
       name: 'primary key field',
+      type: 'text',
     });
     cacheWrapperMock.getOrAdd
       .mockReturnValueOnce(1)
@@ -173,12 +174,14 @@ describe('deleteRecordAction', () => {
       1,
       'some primary key value',
       'primary key field',
+      'text',
     );
   });
 
   test('should delete record', async () => {
     openopsCommonMock.getPrimaryKeyFieldFromFields.mockReturnValue({
       name: 'primary key field',
+      type: 'text',
     });
     cacheWrapperMock.getOrAdd
       .mockReturnValueOnce(1)
@@ -188,6 +191,9 @@ describe('deleteRecordAction', () => {
     const context = createContext({
       tableName: 'Opportunity',
       rowPrimaryKey: 'some primary key value',
+    });
+    openopsCommonMock.authenticateDefaultUserInOpenOpsTables.mockResolvedValue({
+      token: 'some databaseToken',
     });
 
     const result = (await deleteRecordAction.run(context)) as any;
@@ -202,6 +208,7 @@ describe('deleteRecordAction', () => {
       1,
       'some primary key value',
       'primary key field',
+      'text',
     );
     expect(
       openopsCommonMock.getPrimaryKeyFieldFromFields,

--- a/packages/blocks/openops-tables/test/actions/update-record-action.test.ts
+++ b/packages/blocks/openops-tables/test/actions/update-record-action.test.ts
@@ -125,6 +125,7 @@ describe('updateRowAction', () => {
   test('should update fields', async () => {
     openopsCommonMock.getPrimaryKeyFieldFromFields.mockReturnValue({
       name: 'primary key field',
+      type: 'text',
     });
     openopsCommonMock.getRowByPrimaryKeyValue.mockResolvedValue({ id: 1 });
 
@@ -155,6 +156,7 @@ describe('updateRowAction', () => {
       1,
       'some primary key value',
       'primary key field',
+      'text',
     );
     expect(
       openopsCommonMock.getPrimaryKeyFieldFromFields,
@@ -181,6 +183,7 @@ describe('updateRowAction', () => {
     ]);
     openopsCommonMock.getPrimaryKeyFieldFromFields.mockReturnValue({
       name: 'primary key field',
+      type: 'text',
     });
     openopsCommonMock.getRowByPrimaryKeyValue.mockResolvedValue(undefined);
     openopsCommonMock.addRow.mockResolvedValue('mock result');
@@ -205,6 +208,7 @@ describe('updateRowAction', () => {
       1,
       'some primary key value',
       'primary key field',
+      'text',
     );
     expect(openopsCommonMock.updateRow).not.toHaveBeenCalled();
     expect(

--- a/packages/openops/src/lib/openops-tables/rows.ts
+++ b/packages/openops/src/lib/openops-tables/rows.ts
@@ -153,7 +153,7 @@ export async function getRowByPrimaryKeyValue(
       {
         fieldName: primaryKeyFieldName,
         value: primaryKeyFieldValue,
-        type: getFilterTypesEnum(primaryKeyFieldType),
+        type: getEqualityFilterType(primaryKeyFieldType),
       },
     ],
   });
@@ -165,7 +165,9 @@ export async function getRowByPrimaryKeyValue(
   return rows[0];
 }
 
-function getFilterTypesEnum(primaryKeyFieldType: string): ViewFilterTypesEnum {
+function getEqualityFilterType(
+  primaryKeyFieldType: string,
+): ViewFilterTypesEnum {
   if (primaryKeyFieldType === 'date') {
     return ViewFilterTypesEnum.date_equal;
   }

--- a/packages/openops/src/lib/openops-tables/rows.ts
+++ b/packages/openops/src/lib/openops-tables/rows.ts
@@ -144,6 +144,7 @@ export async function getRowByPrimaryKeyValue(
   tableId: number,
   primaryKeyFieldValue: string,
   primaryKeyFieldName: any,
+  primaryKeyFieldType: string,
 ) {
   const rows = await getRows({
     tableId: tableId,
@@ -152,7 +153,7 @@ export async function getRowByPrimaryKeyValue(
       {
         fieldName: primaryKeyFieldName,
         value: primaryKeyFieldValue,
-        type: ViewFilterTypesEnum.equal,
+        type: getFilterTypesEnum(primaryKeyFieldType),
       },
     ],
   });
@@ -162,4 +163,12 @@ export async function getRowByPrimaryKeyValue(
   }
 
   return rows[0];
+}
+
+function getFilterTypesEnum(primaryKeyFieldType: string): ViewFilterTypesEnum {
+  if (primaryKeyFieldType === 'date') {
+    return ViewFilterTypesEnum.date_equal;
+  }
+
+  return ViewFilterTypesEnum.equal;
 }

--- a/packages/openops/test/openops-tables/rows.test.ts
+++ b/packages/openops/test/openops-tables/rows.test.ts
@@ -296,54 +296,72 @@ describe('getRowByPrimaryKeyValue', () => {
     jest.clearAllMocks();
   });
 
-  test('Should get row by primary key value', async () => {
-    makeOpenOpsTablesGetMock.mockResolvedValue([
-      { results: [{ id: 1, order: 1234 }] },
-    ]);
-    createAxiosHeadersMock.mockReturnValue('some header');
+  test.each([
+    ['text', 'equal'],
+    ['rating', 'equal'],
+    ['email', 'equal'],
+    ['date', 'date_equal'],
+  ])(
+    'Should get row by primary key value',
+    async (fieldType: string, expected: string) => {
+      makeOpenOpsTablesGetMock.mockResolvedValue([
+        { results: [{ id: 1, order: 1234 }] },
+      ]);
+      createAxiosHeadersMock.mockReturnValue('some header');
 
-    const result = await getRowByPrimaryKeyValue(
-      'token',
-      1,
-      'primaryKeyValue',
-      'primaryFieldName',
-    );
-
-    expect(result).toStrictEqual({ id: 1, order: 1234 });
-    expect(makeOpenOpsTablesGetMock).toBeCalledTimes(1);
-    expect(makeOpenOpsTablesGetMock).toHaveBeenCalledWith(
-      'api/database/rows/table/1/?user_field_names=true&filter__primaryFieldName__equal=primaryKeyValue',
-      'some header',
-    );
-    expect(createAxiosHeadersMock).toBeCalledTimes(1);
-    expect(createAxiosHeadersMock).toHaveBeenCalledWith('token');
-  });
-
-  test('should throw if more than one row was found', async () => {
-    makeOpenOpsTablesGetMock.mockResolvedValue([
-      {
-        results: [
-          { id: 1, order: 1234 },
-          { id: 2, order: 1234 },
-        ],
-      },
-    ]);
-    createAxiosHeadersMock.mockReturnValue('some header');
-    await expect(
-      getRowByPrimaryKeyValue(
+      const result = await getRowByPrimaryKeyValue(
         'token',
         1,
         'primaryKeyValue',
         'primaryFieldName',
-      ),
-    ).rejects.toThrow('More than one row found with given primary key');
+        fieldType,
+      );
 
-    expect(makeOpenOpsTablesGetMock).toBeCalledTimes(1);
-    expect(makeOpenOpsTablesGetMock).toHaveBeenCalledWith(
-      'api/database/rows/table/1/?user_field_names=true&filter__primaryFieldName__equal=primaryKeyValue',
-      'some header',
-    );
-    expect(createAxiosHeadersMock).toBeCalledTimes(1);
-    expect(createAxiosHeadersMock).toHaveBeenCalledWith('token');
-  });
+      expect(result).toStrictEqual({ id: 1, order: 1234 });
+      expect(makeOpenOpsTablesGetMock).toBeCalledTimes(1);
+      expect(makeOpenOpsTablesGetMock).toHaveBeenCalledWith(
+        `api/database/rows/table/1/?user_field_names=true&filter__primaryFieldName__${expected}=primaryKeyValue`,
+        'some header',
+      );
+      expect(createAxiosHeadersMock).toBeCalledTimes(1);
+      expect(createAxiosHeadersMock).toHaveBeenCalledWith('token');
+    },
+  );
+
+  test.each([
+    ['text', 'equal'],
+    ['rating', 'equal'],
+    ['email', 'equal'],
+    ['date', 'date_equal'],
+  ])(
+    'should throw if more than one row was found',
+    async (fieldType: string, expected: string) => {
+      makeOpenOpsTablesGetMock.mockResolvedValue([
+        {
+          results: [
+            { id: 1, order: 1234 },
+            { id: 2, order: 1234 },
+          ],
+        },
+      ]);
+      createAxiosHeadersMock.mockReturnValue('some header');
+      await expect(
+        getRowByPrimaryKeyValue(
+          'token',
+          1,
+          'primaryKeyValue',
+          'primaryFieldName',
+          fieldType,
+        ),
+      ).rejects.toThrow('More than one row found with given primary key');
+
+      expect(makeOpenOpsTablesGetMock).toBeCalledTimes(1);
+      expect(makeOpenOpsTablesGetMock).toHaveBeenCalledWith(
+        `api/database/rows/table/1/?user_field_names=true&filter__primaryFieldName__${expected}=primaryKeyValue`,
+        'some header',
+      );
+      expect(createAxiosHeadersMock).toBeCalledTimes(1);
+      expect(createAxiosHeadersMock).toHaveBeenCalledWith('token');
+    },
+  );
 });


### PR DESCRIPTION

Fixes OPS-1377.

## Additional Notes

The date must be in the format 'YYYY-MM-DD' and can include the time if the table is set to do so.

<img width="571" alt="image" src="https://github.com/user-attachments/assets/8063d8fe-8e35-4beb-82bf-dbedd9db9d01" />

In case of invalid format:
<img width="568" alt="image" src="https://github.com/user-attachments/assets/ad7eff9b-3710-404c-b4e2-0a438fa1cc0a" />
