### PR TITLE
Fix shadcn / radix pointer events none on body element

### DIFF
--- a/packages/ui-components/src/tailwind.css
+++ b/packages/ui-components/src/tailwind.css
@@ -154,5 +154,6 @@
   body {
     @apply bg-background text-foreground;
     font-feature-settings: 'rlig' 1, 'calt' 1;
+    pointer-events: auto !important;
   }
 }


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes #325

This looks like a shadcn or radix issue, as I see it reported in multiple places. Somehow in some cases after opening a modal / popup it leaves `pointer-events:none` in the body element, thus making the page not interactive. We should leave `pointer-events: auto` on the body, then it will behave correctly. 

https://github.com/shadcn-ui/ui/issues/6988
https://github.com/shadcn-ui/ui/issues/5350
