### PR TITLE
Logout when project id is different than the one from the session

### DIFF
--- a/packages/server/api/src/app/project/project-controller.ts
+++ b/packages/server/api/src/app/project/project-controller.ts
@@ -3,7 +3,9 @@ import {
   Type,
 } from '@fastify/type-provider-typebox';
 import {
+  ApplicationError,
   EndpointScope,
+  ErrorCode,
   PrincipalType,
   Project,
   UpdateProjectRequestInCommunity,
@@ -17,8 +19,16 @@ export const userProjectController: FastifyPluginCallbackTypebox = (
   _opts,
   done,
 ) => {
-  fastify.get('/:id', async (request) => {
-    return projectService.getOneOrThrow(request.principal.projectId);
+  fastify.get('/:id', async (request, response) => {
+    try {
+      return await projectService.getOneOrThrow(request.principal.projectId);
+    } catch (err) {
+      if (err instanceof ApplicationError) {
+        err.error.code = ErrorCode.ENTITY_NOT_FOUND;
+        return response.code(401).send();
+      }
+      throw err;
+    }
   });
 
   fastify.get('/', async (request) => {


### PR DESCRIPTION
Fixes OPS-1336

## Additional Notes

Return 401 whe project is not the current from the users session. The FE will logout.

In the loom flag service returned 500, probably the server was not up and running properly yet.
https://www.loom.com/share/cb4f53472f0047f5b7395a63efd57752
