### PR TITLE
Return the exit code of the node process to exit the container 

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     image: public.ecr.aws/openops/openops-engine:${OPS_VERSION:-latest}
     restart: unless-stopped
     env_file: .env
-    command: ["cp -r /var/tmp-base/. /tmp/ && node main.js"]
+    command: ["cp -r /var/tmp-base/. /tmp/ && node main.js; exit $?"]
     environment:
       OPS_BASE_CODE_DIRECTORY: /tmp/codes
       OPS_COMPONENT: engine

--- a/engine.Dockerfile
+++ b/engine.Dockerfile
@@ -72,4 +72,4 @@ COPY tools/link-packages-to-root.sh tools/link-packages-to-root.sh
 RUN ./tools/link-packages-to-root.sh
 
 ENTRYPOINT [ "/bin/bash", "-c" ]
-CMD [ "cp -r /var/tmp-base/. /tmp/ && /lambda-entrypoint.sh main.handler" ]
+CMD [ "cp -r /var/tmp-base/. /tmp/ && /lambda-entrypoint.sh main.handler; exit $?" ]


### PR DESCRIPTION

Part of OPS-1516.

## Additional Notes
When the container crashes due to lack of memory, an error occurs but the container does not restart.