### PR TITLE
Fix committing third party license changes for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
             echo "Please update THIRD_PARTY_LICENSES.txt by running 'npm run license-check'" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
-      - name: Commit changes
-        if: failure()
+      - name: Commit changes for dependabot
+        if: failure() && startsWith(github.head_ref, 'dependabot/')
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Update THIRD_PARTY_LICENSES.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v4
+        if: failure() && startsWith(github.head_ref, 'dependabot/')
         with:
           clean: false
           ref: ${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - name: Restore node_modules cache
         id: node-modules-cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: Restore node_modules cache
         id: node-modules-cache
         uses: actions/cache/restore@v4
         with:
           path: node_modules
           key: node-modules-cache-${{ hashFiles('package-lock.json', '.npmrc') }}
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - name: Check licenses
         run: |
           npm run license-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - name: Restore node_modules cache
         id: node-modules-cache
         uses: actions/cache/restore@v4
         with:
           path: node_modules
           key: node-modules-cache-${{ hashFiles('package-lock.json', '.npmrc') }}
+          fail-on-cache-miss: true
       - name: Check licenses
         run: |
           npm run license-check
@@ -72,11 +75,6 @@ jobs:
             echo "Please update THIRD_PARTY_LICENSES.txt by running 'npm run license-check'" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
-      - uses: actions/checkout@v4
-        if: failure() && startsWith(github.head_ref, 'dependabot/')
-        with:
-          clean: false
-          ref: ${{ github.head_ref }}
       - name: Commit changes for dependabot
         if: failure() && startsWith(github.head_ref, 'dependabot/')
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,6 @@ jobs:
         with:
           path: node_modules
           key: node-modules-cache-${{ hashFiles('package-lock.json', '.npmrc') }}
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: Check licenses
         run: |
           npm run license-check
@@ -75,6 +72,10 @@ jobs:
             echo "Please update THIRD_PARTY_LICENSES.txt by running 'npm run license-check'" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+      - uses: actions/checkout@v4
+        with:
+          clean: false
+          ref: ${{ github.head_ref }}
       - name: Commit changes for dependabot
         if: failure() && startsWith(github.head_ref, 'dependabot/')
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
             echo "Please update THIRD_PARTY_LICENSES.txt by running 'npm run license-check'" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
-      - name: Commit changes for dependabot
-        if: failure() && startsWith(github.ref, 'refs/heads/dependabot/')
+      - name: Commit changes
+        if: failure()
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Update THIRD_PARTY_LICENSES.txt


### PR DESCRIPTION
The automatic commit of third party licenses by dependabot stopped working since we moved to "pull request" trigger. This PR fixes that.

Part of OPS-195.