### PR TITLE
Add runCommands to google-cli file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ node_modules
 
 #############################################
 # Please do not add rules here without a proper category.
+
+# Ignore the Google Cloud SDK tarball
+google-cloud-cli-*.tar.gz
+
+# Ignore the unpacked Google Cloud SDK directory
+google-cloud-sdk/

--- a/.gitignore
+++ b/.gitignore
@@ -48,9 +48,3 @@ node_modules
 
 #############################################
 # Please do not add rules here without a proper category.
-
-# Ignore the Google Cloud SDK tarball
-google-cloud-cli-*.tar.gz
-
-# Ignore the unpacked Google Cloud SDK directory
-google-cloud-sdk/

--- a/packages/blocks/google-cloud/src/lib/google-cloud-cli.ts
+++ b/packages/blocks/google-cloud/src/lib/google-cloud-cli.ts
@@ -3,12 +3,33 @@ import {
   loginGCPWithKeyObject,
   runCliCommand,
 } from '@openops/common';
+
 export async function runCommand(
   command: string,
   auth: any,
   shouldUseHostCredentials: boolean,
   project?: string,
 ): Promise<string> {
+  const result = await runCommands(
+    [command],
+    auth,
+    shouldUseHostCredentials,
+    project,
+  );
+
+  if (result.length !== 1) {
+    throw new Error(`Expected exactly one result, but got ${result.length}.`);
+  }
+
+  return result[0];
+}
+
+export async function runCommands(
+  commands: string[],
+  auth: any,
+  shouldUseHostCredentials: boolean,
+  project?: string,
+): Promise<string[]> {
   const envVars: Record<string, string> = {
     PATH: process.env['PATH'] || '',
     CLOUDSDK_CORE_DISABLE_PROMPTS: '1',
@@ -33,5 +54,11 @@ export async function runCommand(
     );
   }
 
-  return await runCliCommand(command, 'gcloud', envVars);
+  const results: string[] = [];
+  for (const command of commands) {
+    const output = await runCliCommand(command, 'gcloud', envVars);
+    results.push(output);
+  }
+
+  return results;
 }


### PR DESCRIPTION
Part of OPS-1483

this is prep work for the above mentioned ticket, in the new action, there will be a multiselect dropdown for "recommenders", over which we will loop over to run the cli command, we dont want to set the project each time so this way we avoid duplicate calling logic.