### PR TITLE
Fix right sidebar state logic 

### DIFF
--- a/packages/react-ui/src/app/features/builder/blocks-selector/index.tsx
+++ b/packages/react-ui/src/app/features/builder/blocks-selector/index.tsx
@@ -98,7 +98,7 @@ const BlockSelector = ({
     setSelectedTag(BlockTagEnum.ALL);
   };
 
-  const handleSelect = (
+  const handleSelect = async (
     block: StepMetadata | undefined,
     item: ItemListMetadata,
   ) => {
@@ -117,7 +117,7 @@ const BlockSelector = ({
 
     switch (operation.type) {
       case FlowOperationType.UPDATE_TRIGGER: {
-        applyOperationAndPushToHistory(
+        await applyOperationAndPushToHistory(
           {
             type: FlowOperationType.UPDATE_TRIGGER,
             request: stepData as Trigger,

--- a/packages/react-ui/src/app/features/builder/builder-header/builder-header-action-bar.tsx
+++ b/packages/react-ui/src/app/features/builder/builder-header/builder-header-action-bar.tsx
@@ -11,7 +11,7 @@ import {
 } from '@openops/components/ui';
 import { t } from 'i18next';
 import { EllipsisVertical, History, Workflow } from 'lucide-react';
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 const ICON_SIZE_SMALL = 16;

--- a/packages/react-ui/src/app/features/builder/builder-hooks.ts
+++ b/packages/react-ui/src/app/features/builder/builder-hooks.ts
@@ -164,13 +164,19 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
         selectStepByName: (stepName: string, openRightSideBar = true) => {
           set(
             (state) => {
-              if (state.flowVersion.trigger.type === TriggerType.EMPTY) {
+              if (
+                stepName === 'trigger' &&
+                state.flowVersion.trigger.type === TriggerType.EMPTY
+              ) {
                 return {
                   selectedStep: stepName,
                   rightSidebar: RightSideBarType.NONE,
                   leftSidebar: getLeftSidebarOnSelectStep(state),
                 };
-              } else if (state.flowVersion.trigger.type === TriggerType.BLOCK) {
+              } else if (
+                stepName === 'trigger' &&
+                state.flowVersion.trigger.type === TriggerType.BLOCK
+              ) {
                 return {
                   selectedStep: stepName,
                   rightSidebar: RightSideBarType.BLOCK_SETTINGS,

--- a/packages/react-ui/src/app/features/builder/builder-hooks.ts
+++ b/packages/react-ui/src/app/features/builder/builder-hooks.ts
@@ -181,8 +181,8 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
               return {
                 selectedStep: stepName,
                 rightSidebar: openRightSideBar
-                  ? RightSideBarType.NONE
-                  : RightSideBarType.BLOCK_SETTINGS,
+                  ? RightSideBarType.BLOCK_SETTINGS
+                  : RightSideBarType.NONE,
                 leftSidebar: getLeftSidebarOnSelectStep(state),
               };
             },

--- a/packages/react-ui/src/app/features/builder/builder-hooks.ts
+++ b/packages/react-ui/src/app/features/builder/builder-hooks.ts
@@ -164,14 +164,25 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
         selectStepByName: (stepName: string, openRightSideBar = true) => {
           set(
             (state) => {
+              if (state.flowVersion.trigger.type === TriggerType.EMPTY) {
+                return {
+                  selectedStep: stepName,
+                  rightSidebar: RightSideBarType.NONE,
+                  leftSidebar: getLeftSidebarOnSelectStep(state),
+                };
+              } else if (state.flowVersion.trigger.type === TriggerType.BLOCK) {
+                return {
+                  selectedStep: stepName,
+                  rightSidebar: RightSideBarType.BLOCK_SETTINGS,
+                  leftSidebar: getLeftSidebarOnSelectStep(state),
+                };
+              }
+
               return {
                 selectedStep: stepName,
-                rightSidebar:
-                  (stepName === 'trigger' &&
-                    state.flowVersion.trigger.type === TriggerType.EMPTY) ||
-                  !openRightSideBar
-                    ? RightSideBarType.NONE
-                    : RightSideBarType.BLOCK_SETTINGS,
+                rightSidebar: openRightSideBar
+                  ? RightSideBarType.NONE
+                  : RightSideBarType.BLOCK_SETTINGS,
                 leftSidebar: getLeftSidebarOnSelectStep(state),
               };
             },
@@ -434,6 +445,7 @@ const updateFlowVersion = (
     operation.request.name === state.selectedStep
   ) {
     set({ selectedStep: undefined });
+    set({ rightSidebar: RightSideBarType.NONE });
   }
 
   const updateRequest = async () => {

--- a/packages/react-ui/src/app/features/builder/flow-canvas/nodes/step-node.tsx
+++ b/packages/react-ui/src/app/features/builder/flow-canvas/nodes/step-node.tsx
@@ -60,7 +60,6 @@ const WorkflowStepNode = React.memo(
       selectedStep,
       run,
       readonly,
-      exitStepSettings,
       flowVersion,
       loopIndexes,
     ] = useBuilderStateContext((state) => [
@@ -70,7 +69,6 @@ const WorkflowStepNode = React.memo(
       state.selectedStep,
       state.run,
       state.readonly,
-      state.exitStepSettings,
       state.flowVersion,
       state.loopsIndexes,
     ]);
@@ -179,8 +177,6 @@ const WorkflowStepNode = React.memo(
                 setOpenBlockSelector(open);
                 if (open) {
                   setOpenStepActionsMenu(false);
-                } else if (data.step?.type === TriggerType.EMPTY) {
-                  exitStepSettings();
                 }
               }}
               asChild={true}

--- a/packages/react-ui/src/app/features/builder/flow-canvas/nodes/step-node.tsx
+++ b/packages/react-ui/src/app/features/builder/flow-canvas/nodes/step-node.tsx
@@ -62,6 +62,7 @@ const WorkflowStepNode = React.memo(
       readonly,
       flowVersion,
       loopIndexes,
+      exitStepSettings,
     ] = useBuilderStateContext((state) => [
       state.selectStepByName,
       state.selectedStep === data.step?.name,
@@ -71,6 +72,7 @@ const WorkflowStepNode = React.memo(
       state.readonly,
       state.flowVersion,
       state.loopsIndexes,
+      state.exitStepSettings,
     ]);
 
     const { stepMetadata } = blocksHooks.useStepMetadata({
@@ -177,6 +179,8 @@ const WorkflowStepNode = React.memo(
                 setOpenBlockSelector(open);
                 if (open) {
                   setOpenStepActionsMenu(false);
+                } else if (data.step?.type === TriggerType.EMPTY) {
+                  exitStepSettings();
                 }
               }}
               asChild={true}

--- a/packages/react-ui/src/app/features/builder/flow-canvas/nodes/step-node.tsx
+++ b/packages/react-ui/src/app/features/builder/flow-canvas/nodes/step-node.tsx
@@ -60,9 +60,9 @@ const WorkflowStepNode = React.memo(
       selectedStep,
       run,
       readonly,
+      exitStepSettings,
       flowVersion,
       loopIndexes,
-      exitStepSettings,
     ] = useBuilderStateContext((state) => [
       state.selectStepByName,
       state.selectedStep === data.step?.name,
@@ -70,9 +70,9 @@ const WorkflowStepNode = React.memo(
       state.selectedStep,
       state.run,
       state.readonly,
+      state.exitStepSettings,
       state.flowVersion,
       state.loopsIndexes,
-      state.exitStepSettings,
     ]);
 
     const { stepMetadata } = blocksHooks.useStepMetadata({

--- a/packages/react-ui/src/app/features/builder/flow-version-undo-redo/hooks/flow-version-undo-redo.ts
+++ b/packages/react-ui/src/app/features/builder/flow-version-undo-redo/hooks/flow-version-undo-redo.ts
@@ -20,14 +20,21 @@ export type FlowVersionUndoRedo = {
 };
 
 const useFlowVersionUndoRedo = (): FlowVersionUndoRedo => {
-  const [flowVersion, setVersion, canUndo, canRedo, setVersionUpdateTimestamp] =
-    useBuilderStateContext((state) => [
-      state.flowVersion,
-      state.setVersion,
-      state.canUndo,
-      state.canRedo,
-      state.setVersionUpdateTimestamp,
-    ]);
+  const [
+    flowVersion,
+    setVersion,
+    canUndo,
+    canRedo,
+    setVersionUpdateTimestamp,
+    exitStepSettings,
+  ] = useBuilderStateContext((state) => [
+    state.flowVersion,
+    state.setVersion,
+    state.canUndo,
+    state.canRedo,
+    state.setVersionUpdateTimestamp,
+    state.exitStepSettings,
+  ]);
   const centerWorkflowViewOntoStep = useCenterWorkflowViewOntoStep();
 
   const { initializeUndoRedoDB, addToUndo, bulkMoveAction, clearUndoRedoDB } =
@@ -113,6 +120,8 @@ const useFlowVersionUndoRedo = (): FlowVersionUndoRedo => {
   }, [debouncedProcessQueue]);
 
   const enqueueAction = (action: MoveActionType) => {
+    exitStepSettings();
+
     actionQueue.current.push(action);
     if (!isBulkActionInProgress.current) {
       processQueue(); // Start processing if no request is currently running

--- a/packages/react-ui/src/app/features/builder/flow-version-undo-redo/hooks/tests/flow-version-undo-redo.test.ts
+++ b/packages/react-ui/src/app/features/builder/flow-version-undo-redo/hooks/tests/flow-version-undo-redo.test.ts
@@ -45,6 +45,7 @@ describe('useFlowVersionUndoRedo', () => {
   let mockSetVersionUpdateTimestamp: jest.Mock;
   let mockInitializeUndoRedoDB: jest.Mock;
   let mockBulkMoveAction: jest.Mock;
+  let mockExitStepSettings: jest.Mock;
 
   beforeEach(() => {
     mockFlowVersion = {
@@ -60,6 +61,7 @@ describe('useFlowVersionUndoRedo', () => {
 
     mockInitializeUndoRedoDB = jest.fn();
     mockBulkMoveAction = jest.fn();
+    mockExitStepSettings = jest.fn();
 
     (useBuilderStateContext as jest.Mock).mockImplementation((selector) =>
       selector({
@@ -68,6 +70,7 @@ describe('useFlowVersionUndoRedo', () => {
         canUndo: true,
         canRedo: false,
         setVersionUpdateTimestamp: mockSetVersionUpdateTimestamp,
+        exitStepSettings: mockExitStepSettings,
       }),
     );
 
@@ -84,6 +87,7 @@ describe('useFlowVersionUndoRedo', () => {
     renderHook(() => useFlowVersionUndoRedo());
 
     expect(mockInitializeUndoRedoDB).toHaveBeenCalledTimes(1);
+    expect(mockExitStepSettings).not.toHaveBeenCalled();
   });
 
   it('should enqueue an undo action and process it correctly', async () => {
@@ -115,6 +119,7 @@ describe('useFlowVersionUndoRedo', () => {
     expect(mockCenterWorkflowViewOntoStep).toHaveBeenCalledWith(
       'previous-step',
     );
+    expect(mockExitStepSettings).toHaveBeenCalled();
   });
 
   it('should enqueue a redo action and process it correctly', async () => {
@@ -144,6 +149,7 @@ describe('useFlowVersionUndoRedo', () => {
       trigger: { name: 'future-trigger' },
     });
     expect(mockCenterWorkflowViewOntoStep).toHaveBeenCalledWith('future-step');
+    expect(mockExitStepSettings).toHaveBeenCalled();
   });
 
   it('should handle API update failures gracefully', async () => {
@@ -164,6 +170,7 @@ describe('useFlowVersionUndoRedo', () => {
     });
 
     expect(toast).toHaveBeenCalledWith('Unsaved changes');
+    expect(mockExitStepSettings).toHaveBeenCalled();
   });
 
   it('should correctly report canUndo and canRedo states', () => {

--- a/packages/react-ui/src/app/features/builder/index.tsx
+++ b/packages/react-ui/src/app/features/builder/index.tsx
@@ -102,7 +102,6 @@ const BuilderPage = () => {
     canExitRun,
     readonly,
     setReadOnly,
-    setRightSidebar,
     exitStepSettings,
     flowVersion,
   ] = useBuilderStateContext((state) => [
@@ -114,7 +113,6 @@ const BuilderPage = () => {
     state.canExitRun,
     state.readonly,
     state.setReadOnly,
-    state.setRightSidebar,
     state.exitStepSettings,
     state.flowVersion,
   ]);
@@ -198,15 +196,6 @@ const BuilderPage = () => {
       setReadOnly(viewOnlyParam);
     }
   }, [readonly, run, searchParams, setLeftSidebar, setReadOnly]);
-
-  useEffect(() => {
-    if (
-      !memorizedSelectedStep ||
-      memorizedSelectedStep.type === TriggerType.EMPTY
-    ) {
-      setRightSidebar(RightSideBarType.NONE);
-    }
-  }, [memorizedSelectedStep, setRightSidebar]);
 
   const { switchToDraft, isSwitchingToDraftPending } = useSwitchToDraft();
 


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-1320

## Additional context
- When we add or replace a trigger or a step, the step settings are always shown
- Undo / Redo closes step settings

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [x] Automated tests were added/updated if necessary

- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided

## Visual Changes (if applicable)
Deployed to UX
https://www.loom.com/share/2d1ea79dc9ff4904965f3a31c701bcfb