### PR TITLE
Add OPC and CI as issue prefixes to PRLint

### DIFF
--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -15,7 +15,7 @@
   ],
   "body": [
     {
-      "pattern": "(?:Fixes|Resolves|Closes|Part of) (?:#|OPS-)[1-9]\\d*|Dependabot commands and options",
+      "pattern": "(?:Fixes|Resolves|Closes|Part of) (?:#|OPS-|OPC-|CI-)[1-9]\\d*|Dependabot commands and options",
       "message": "Add a GitHub or Linear issue ID to your PR body, e.g. \"Fixes #1002\""
     }
   ]


### PR DESCRIPTION
Fixes OPS-1539.