### PR TITLE
Add a connection markdown for Snowflake block

### DIFF
--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -5,7 +5,7 @@ const markdown = `
 2.  From the left sidebar, expand your account information located in the bottom menu.
 3.  Click on the menu item labeled "**Account**" to expand a side menu.
 4.  In the expanded side menu, select "**View Account Details**" (it might be listed under a heading like "Admin").
-5.  On the resulting page, you will find both the **Account Identifier** (typically in the format \`<organization_name>-<account_name>\` or a shorter alphanumeric string depending on your Snowflake region) and your **Username**.
+5.  On the resulting page, you will find both the **Account Identifier** and your **Username**.
 
 For the **Password**, you will need to provide the same password you use to log in to your Snowflake account.
 

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -1,9 +1,6 @@
 import { BlockAuth, Property } from '@openops/blocks-framework';
 
-const markdown = `## Snowflake connections
-
-To configure a Snowflake connection, you will need the following credentials: Account Identifier, Username, and Password. Here's how to locate your Account Identifier and Username:
-
+const markdown = `
 1.  Go to the [Snowflake Login Page](https://app.snowflake.com/) and log in to your account.
 2.  From the left sidebar, expand your account information located in the bottom menu.
 3.  Click on the menu item labeled "**Account**" to expand a side menu.

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -9,8 +9,6 @@ const markdown = `
 
 For the **Password**, you will need to provide the same password you use to log in to your Snowflake account.
 
-Once you have your Account Identifier, Username, and Password, you can configure the Snowflake connection in OpenOps.
-
 **Important:** Please note that providing an incorrect Account Identifier will not result in an immediate connection failure. The system will attempt to connect for approximately 5 minutes before timing out with a generic error message: "Request to Snowflake failed.". Ensure you have accurately copied your Account Identifier to avoid these delays.
 `;
 

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -1,6 +1,26 @@
 import { BlockAuth, Property } from '@openops/blocks-framework';
 
+const markdown = `## Snowflake connections
+
+To configure a Snowflake connection, you will need the following credentials: Account Identifier, Username, and Password. Here's how to locate your Account Identifier and Username:
+
+1.  Go to the [Snowflake Login Page](https://app.snowflake.com/) and log in to your account.
+2.  From the left sidebar, expand your account information located in the bottom menu.
+3.  Click on the menu item labeled "**Account**" to expand a side menu.
+4.  In the expanded side menu, select "**View Account Details**" (it might be listed under a heading like "Admin").
+5.  On the resulting page, you will find both the **Account Identifier** (typically in the format \`<organization_name>-<account_name>\` or a shorter alphanumeric string depending on your Snowflake region) and your **Username**.
+
+![Snowflake Account Details Location](/images/access-snowflake-account-details.png)
+
+For the **Password**, you will need to provide the same password you use to log in to your Snowflake account.
+
+Once you have your Account Identifier, Username, and Password, you can configure the Snowflake connection in OpenOps.
+
+**Important:** Please note that providing an incorrect Account Identifier will not result in an immediate connection failure. The system will attempt to connect for approximately 5 minutes before timing out with a generic error message: "Request to Snowflake failed.". Ensure you have accurately copied your Account Identifier to avoid these delays.
+`;
+
 export const customAuth = BlockAuth.CustomAuth({
+  description: markdown,
   props: {
     account: Property.ShortText({
       displayName: 'Account',

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -7,8 +7,6 @@ const markdown = `
 4.  In the expanded side menu, select "**View Account Details**" (it might be listed under a heading like "Admin").
 5.  On the resulting page, you will find both the **Account Identifier** (typically in the format \`<organization_name>-<account_name>\` or a shorter alphanumeric string depending on your Snowflake region) and your **Username**.
 
-![Snowflake Account Details Location](/images/access-snowflake-account-details.png)
-
 For the **Password**, you will need to provide the same password you use to log in to your Snowflake account.
 
 Once you have your Account Identifier, Username, and Password, you can configure the Snowflake connection in OpenOps.


### PR DESCRIPTION
Fixes OPS-1537.

The connection form modal looks similar to the GoogleCloud connection. The user sees the markdown and has to scroll down for the form fields.
Google:
![Screenshot 2025-04-08 at 19 19 56](https://github.com/user-attachments/assets/705fade3-a5ee-485d-8766-c8d522ed9a86)
Snowflake:

![Screenshot 2025-04-08 at 19 23 50](https://github.com/user-attachments/assets/eda43034-852c-4370-89b4-f5493f6e1985)
