### PR TITLE
Setup connection maxLoginRetries prop

### DIFF
--- a/packages/blocks/snowflake/src/lib/actions/run-multiple-queries.ts
+++ b/packages/blocks/snowflake/src/lib/actions/run-multiple-queries.ts
@@ -56,14 +56,23 @@ export const runMultipleQueries = createAction({
   auth: customAuth,
   props,
   async run(context) {
-    const { username, password, role, database, warehouse, account } =
-      context.auth;
+    const {
+      username,
+      password,
+      maxLoginRetries,
+      role,
+      database,
+      warehouse,
+      account,
+    } = context.auth;
 
     const connection = snowflake.createConnection({
       application: context.propsValue.application,
       timeout: context.propsValue.timeout,
       username,
       password,
+      // @ts-expect-error ConnectionOptions interface definition in @types/snowflake-sdk is missing this property
+      sfRetryMaxLoginRetries: maxLoginRetries,
       role,
       database,
       warehouse,

--- a/packages/blocks/snowflake/src/lib/actions/run-query.ts
+++ b/packages/blocks/snowflake/src/lib/actions/run-query.ts
@@ -41,14 +41,23 @@ export const runQuery = createAction({
   auth: customAuth,
   props,
   async run(context) {
-    const { username, password, role, database, warehouse, account } =
-      context.auth;
+    const {
+      username,
+      password,
+      maxLoginRetries,
+      role,
+      database,
+      warehouse,
+      account,
+    } = context.auth;
 
     const connection = snowflake.createConnection({
       application: context.propsValue.application,
       timeout: context.propsValue.timeout,
       username,
       password,
+      // @ts-expect-error ConnectionOptions interface definition in @types/snowflake-sdk is missing this property
+      sfRetryMaxLoginRetries: maxLoginRetries,
       role,
       database,
       warehouse,

--- a/packages/blocks/snowflake/src/lib/common/configure-connection.ts
+++ b/packages/blocks/snowflake/src/lib/common/configure-connection.ts
@@ -15,5 +15,7 @@ export function configureConnection(
     database: auth.database,
     warehouse: auth.warehouse,
     account: auth.account,
+    // @ts-expect-error ConnectionOptions interface definition in @types/snowflake-sdk is missing this property
+    sfRetryMaxLoginRetries: auth.maxLoginRetries,
   });
 }

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -12,7 +12,7 @@ const markdown = `
 
 For the **Password**, you will need to provide the same password you use to log in to your Snowflake account.
 
-**Important:** Please note that providing an incorrect Account Identifier will not result in an immediate connection failure. The system will attempt to connect for approximately 5 minutes before timing out with a generic error message: "Request to Snowflake failed.". Ensure you have accurately copied your Account Identifier to avoid these delays.
+**Important:** Increasing the default \`maxLoginRetries\` setting can significantly extend response times if the **Account Identifier** is incorrect. The system will repeatedly attempt to connect, potentially delaying feedback before ultimately failing with a generic error message: "Request to Snowflake failed.".
 `;
 
 export const customAuth = BlockAuth.CustomAuth({

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -1,4 +1,7 @@
+import { HttpError } from '@openops/blocks-common';
 import { BlockAuth, Property, Validators } from '@openops/blocks-framework';
+import { configureConnection } from './configure-connection';
+import { connect } from './utils';
 
 const markdown = `
 1.  Go to the [Snowflake Login Page](https://app.snowflake.com/) and log in to your account.
@@ -61,4 +64,20 @@ export const customAuth = BlockAuth.CustomAuth({
     }),
   },
   required: true,
+  validate: async ({ auth }) => {
+    const connection = configureConnection(auth);
+    try {
+      await connect(connection);
+
+      return {
+        valid: true,
+      };
+    } catch (e) {
+      return {
+        valid: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        error: ((e as HttpError).response.body as any).message,
+      };
+    }
+  },
 });

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -12,7 +12,7 @@ const markdown = `
 
 For the **Password**, you will need to provide the same password you use to log in to your Snowflake account.
 
-**Important:** Increasing the default \`maxLoginRetries\` setting can significantly extend response times if the **Account Identifier** is incorrect. The system will repeatedly attempt to connect, potentially delaying feedback before ultimately failing with a generic error message: "Request to Snowflake failed.".
+**Important:** Increasing the default **maxLoginRetries** setting can significantly extend response times if the **Account Identifier** is incorrect. The system will repeatedly attempt to connect, potentially delaying feedback before ultimately failing with a generic error message: "Request to Snowflake failed.".
 `;
 
 export const customAuth = BlockAuth.CustomAuth({

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -1,4 +1,4 @@
-import { BlockAuth, Property } from '@openops/blocks-framework';
+import { BlockAuth, Property, Validators } from '@openops/blocks-framework';
 
 const markdown = `
 1.  Go to the [Snowflake Login Page](https://app.snowflake.com/) and log in to your account.
@@ -29,6 +29,17 @@ export const customAuth = BlockAuth.CustomAuth({
       displayName: 'Password',
       description: 'Password for the user.',
       required: true,
+    }),
+    maxLoginRetries: Property.Number({
+      displayName: 'Max Login Retries',
+      description: 'The maximum number of times to retry login',
+      required: true,
+      defaultValue: 2,
+      validators: [
+        Validators.number,
+        Validators.minValue(0),
+        Validators.maxValue(7),
+      ],
     }),
     database: Property.ShortText({
       displayName: 'Database',


### PR DESCRIPTION
Fixes OPS-1537.

Follows the solution Snowflake support suggested on [Discourse](https://snowflake.discourse.group/t/reducing-connection-timeout-for-incorrect-account-identifier-in-snowflake-node-js-sdk/15990/3).

Upon running the Snowflake query, the user will get the generic "Request to Snowflake failed." error message. With maxLoginRetries = 2(default), it will respond promptly. 
On my tests, using maxLoginRetries=2 responds in less than 5s every time.

![Screenshot 2025-04-09 at 14 07 55](https://github.com/user-attachments/assets/5ee6aa23-8e46-4c21-ab72-0c8e92a5692e)
