### PR TITLE
Improve connection docs wording for Max Login Retries in relation to incorrect account identifier

### DIFF
--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -12,7 +12,7 @@ const markdown = `
 
 For the **Password**, you will need to provide the same password you use to log in to your Snowflake account.
 
-If you're experiencing delays, double-check that your Account Identifier is correct. An incorrect identifier combined with an increasedMax Login Retries value will cause the system to repeatedly try connecting, resulting in longer wait times before it eventually fails with the error: "Request to Snowflake failed."
+If you're experiencing delays, double-check that your Account Identifier is correct. An incorrect identifier combined with an increased **Max Login Retries** value will cause the system to repeatedly try connecting, resulting in longer wait times before it eventually fails with the error: "Request to Snowflake failed."
 `;
 
 export const customAuth = BlockAuth.CustomAuth({

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -12,7 +12,7 @@ const markdown = `
 
 For the **Password**, you will need to provide the same password you use to log in to your Snowflake account.
 
-If you're experiencing delays, double-check that your Account Identifier is correct. An incorrect identifier combined with an increased **Max Login Retries** value will cause the system to repeatedly try connecting, resulting in longer wait times before it eventually fails with the error: "Request to Snowflake failed."
+If you're experiencing delays, double-check that your **Account Identifier** is correct. An incorrect identifier combined with an increased **Max Login Retries** value will cause the system to repeatedly try connecting, resulting in longer wait times before it eventually fails with the error: "Request to Snowflake failed."
 `;
 
 export const customAuth = BlockAuth.CustomAuth({

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -12,7 +12,7 @@ const markdown = `
 
 For the **Password**, you will need to provide the same password you use to log in to your Snowflake account.
 
-**Important:** Increasing the default **maxLoginRetries** setting can significantly extend response times if the **Account Identifier** is incorrect. The system will repeatedly attempt to connect, potentially delaying feedback before ultimately failing with a generic error message: "Request to Snowflake failed.".
+If you're experiencing delays, double-check that your Account Identifier is correct. An incorrect identifier combined with an increasedMax Login Retries value will cause the system to repeatedly try connecting, resulting in longer wait times before it eventually fails with the error: "Request to Snowflake failed."
 `;
 
 export const customAuth = BlockAuth.CustomAuth({


### PR DESCRIPTION
Fixes OPS-1537.
![Screenshot 2025-04-09 at 17 18 55](https://github.com/user-attachments/assets/ad07ccb7-c46b-4fec-bdad-2305028d133f)
