### PR TITLE
Add try catch in sendJiraRequest to not return the whole error object.

### DIFF
--- a/packages/blocks/jira-cloud/src/lib/common/index.ts
+++ b/packages/blocks/jira-cloud/src/lib/common/index.ts
@@ -24,14 +24,14 @@ export async function sendJiraRequest(
     });
   } catch (e) {
     if (e instanceof HttpError) {
-      const errorBody = e.response?.body || {};
+      const errorBody = e.response?.body ?? {};
       const fullError = JSON.stringify(errorBody);
 
       if (
         fullError.includes('It is not on the appropriate screen, or unknown.')
       ) {
         throw Error(
-          `Jira Error: The field you're trying to set (e.g., 'priority') is not configured on the project's create/edit screen. You need to add it in Jira's screen settings.\n\nOriginal error: ${fullError}`,
+          `One or more fields you're trying to set is not configured on the project's create/edit screen. You need to add it in Jira's screen settings.\n\nOriginal error: ${fullError}`,
         );
       }
 

--- a/packages/blocks/jira-cloud/test/common/index.test.ts
+++ b/packages/blocks/jira-cloud/test/common/index.test.ts
@@ -124,7 +124,7 @@ describe('sendJiraRequest', () => {
     });
 
     const expectedRawError = JSON.stringify(axiosError.response.data);
-    const expectedMessage = `Jira Error: The field you're trying to set (e.g., 'priority') is not configured on the project's create/edit screen. You need to add it in Jira's screen settings.\n\nOriginal error: ${expectedRawError}`;
+    const expectedMessage = `One or more fields you're trying to set is not configured on the project's create/edit screen. You need to add it in Jira's screen settings.\n\nOriginal error: ${expectedRawError}`;
 
     await expect(sendJiraRequest(baseRequest)).rejects.toThrow(expectedMessage);
   });


### PR DESCRIPTION
Fixes OPC-57

![image](https://github.com/user-attachments/assets/2fb9ad48-40bd-4b79-ab03-ddc1a05fba7e)