### PR TITLE
Update analytics service image to the latest available

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       postgres:
         condition: service_healthy
   openops-analytics:
-    image: public.ecr.aws/openops/openops-analytics:0.12.18
+    image: public.ecr.aws/openops/openops-analytics:0.12.19
     restart: unless-stopped
     platform: linux/amd64 # Needed for M1 Macs until we have cross-platform CI builds(linux/adm64 and linux/arm64 images)
     environment:

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       OPS_COMPONENT: app
       OPS_VERSION: ${OPS_VERSION:-latest}
       OPS_OPENOPS_TABLES_VERSION: 0.1.10
-      OPS_ANALYTICS_VERSION: 0.12.18
+      OPS_ANALYTICS_VERSION: 0.12.19
     depends_on:
       openops-tables:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - 'redis_data:/data'
   analytics:
     container_name: analytics
-    image: public.ecr.aws/openops/openops-analytics:0.12.18
+    image: public.ecr.aws/openops/openops-analytics:0.12.19
     platform: linux/amd64 # Needed for M1 Macs until we have cross-platform CI builds(linux/adm64 and linux/arm64 images)
     ports: ['8088:8088']
     environment:


### PR DESCRIPTION
Part of OPS-1464.

I deployed the private ECR image first [on UX](https://github.com/openops-cloud/devops/commit/58970bfc4082b8e6e03d5dc0c00a244005b2ee4f) before creating a public analytics release: performed a sanity check and inspected logs to make sure seed code logged the expected things/