### PR TITLE
Specify platform: linux/amd64for services using Openops built Docker images

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     platform: linux/amd64
     restart: unless-stopped
     env_file: .env
-    command: ['cp -r /var/tmp-base/. /tmp/ && node main.js; exit $?']
+    command: ["cp -r /var/tmp-base/. /tmp/ && node main.js; exit $?"]
     environment:
       OPS_BASE_CODE_DIRECTORY: /tmp/codes
       OPS_COMPONENT: engine

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -13,6 +13,7 @@ services:
         condition: service_healthy
   openops-app:
     image: public.ecr.aws/openops/openops-app:${OPS_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     env_file: .env
     environment:
@@ -31,9 +32,10 @@ services:
         condition: service_healthy
   openops-engine:
     image: public.ecr.aws/openops/openops-engine:${OPS_VERSION:-latest}
+    platform: linux/amd64
     restart: unless-stopped
     env_file: .env
-    command: ["cp -r /var/tmp-base/. /tmp/ && node main.js; exit $?"]
+    command: ['cp -r /var/tmp-base/. /tmp/ && node main.js; exit $?']
     environment:
       OPS_BASE_CODE_DIRECTORY: /tmp/codes
       OPS_COMPONENT: engine
@@ -45,6 +47,7 @@ services:
       - ${HOST_CLOUDSDK_CONFIG:-openops_gcloud_cli_data}:/tmp/gcloud
   openops-tables:
     image: public.ecr.aws/openops/openops-tables:0.1.10
+    platform: linux/amd64
     restart: unless-stopped
     environment:
       BASEROW_PUBLIC_URL: ${OPS_OPENOPS_TABLES_PUBLIC_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   tables:
     container_name: tables
     image: public.ecr.aws/openops/openops-tables:0.1.10
+    platform: linux/amd64
     environment:
       BASEROW_PUBLIC_URL: ${OPS_OPENOPS_TABLES_PUBLIC_URL}
       BASEROW_PRIVATE_URL: http://localhost:3001


### PR DESCRIPTION
Fixes OPS-1601.

This PR prevents this error when attempting to install OpenOps release without sudo:
"Error response from daemon: image with reference public.ecr.aws/openops/openops-tables:0.1.10 was found but its platform (linux/amd64) does not match the specified platform (linux/arm64)"