### PR TITLE
Restrict chat messages to text type

### DIFF
--- a/packages/shared/src/lib/ai/chat/index.ts
+++ b/packages/shared/src/lib/ai/chat/index.ts
@@ -14,7 +14,15 @@ export const OpenChatResponse = Type.Object({
     Type.Array(
       Type.Object({
         role: Type.String(),
-        content: Type.String(),
+        content: Type.Union([
+          Type.String(),
+          Type.Array(
+            Type.Object({
+              type: Type.Literal('text'),
+              text: Type.String(),
+            }),
+          ),
+        ]),
       }),
     ),
   ),


### PR DESCRIPTION

Part of OPS-1588.

## Additional Notes
- We are only allowing text messages in the history, we will not save other types of messages
