### PR TITLE
Delete AI Chat conversation when user deletes step

### DIFF
--- a/packages/react-ui/src/app/features/builder/ai-chat/lib/chat-api.ts
+++ b/packages/react-ui/src/app/features/builder/ai-chat/lib/chat-api.ts
@@ -9,4 +9,7 @@ export const aiChatApi = {
       stepName,
     });
   },
+  delete(chatId: string) {
+    return api.delete<void>(`/v1/ai/chat/conversation/${chatId}`);
+  },
 };

--- a/packages/react-ui/src/app/features/builder/builder-hooks.ts
+++ b/packages/react-ui/src/app/features/builder/builder-hooks.ts
@@ -24,6 +24,7 @@ import {
   TriggerType,
 } from '@openops/shared';
 import { flowRunUtils } from '../flow-runs/lib/flow-run-utils';
+import { aiChatApi } from './ai-chat/lib/chat-api';
 import { DataSelectorSizeState } from './data-selector/data-selector-size-togglers';
 
 const flowUpdatesQueue = new PromiseQueue();
@@ -588,6 +589,22 @@ const updateFlowVersion = (
   ) {
     set({ selectedStep: undefined });
     set({ rightSidebar: RightSideBarType.NONE });
+    deleteChatRequest(state.flowVersion, operation.request.name);
+  }
+
+  async function deleteChatRequest(flowVersion: FlowVersion, stepName: string) {
+    try {
+      const stepDetails = flowHelper.getStep(flowVersion, stepName);
+      const blockName = stepDetails?.settings?.blockName;
+      const chat = await aiChatApi.open(
+        newFlowVersion.flowId,
+        blockName,
+        stepName,
+      );
+      await aiChatApi.delete(chat.chatId);
+    } catch (err) {
+      console.error(err);
+    }
   }
 
   const updateRequest = async () => {


### PR DESCRIPTION
Fixes OPS-1635.
Given the same workflow, when a user deletes the step with the name ' step_X` and recreates it, a step created later will also have the name `step_X`.
It's better to delete the AI Chat conversation in case the new step with the same name uses the same block as the previously deleted step.