### PR TITLE
Move `baseUrl` to `providerSettings` on AI page 

### DIFF
--- a/packages/react-ui/src/app/features/ai/ai-settings-form.tsx
+++ b/packages/react-ui/src/app/features/ai/ai-settings-form.tsx
@@ -41,8 +41,8 @@ export const EMPTY_FORM_VALUE: AiSettingsFormSchema = {
   provider: '',
   apiKey: '',
   baseUrl: '',
-  modelSettings: '',
-  providerSettings: '',
+  modelSettings: '{}',
+  providerSettings: '{}',
   model: '',
 };
 
@@ -69,15 +69,19 @@ const AiSettingsForm = ({
       return;
     }
 
-    const formValue: AiSettingsFormSchema = {
-      ...(savedSettings as unknown as AiSettingsFormSchema),
+    const formValue = {
+      ...savedSettings,
+      baseUrl: (savedSettings.providerSettings?.baseUrl as string) ?? '',
       providerSettings: savedSettings.providerSettings
-        ? JSON.stringify(savedSettings.providerSettings)
-        : '',
+        ? JSON.stringify({
+            ...savedSettings.providerSettings,
+            baseUrl: undefined,
+          })
+        : '{}',
       modelSettings: savedSettings.modelSettings
         ? JSON.stringify(savedSettings.modelSettings)
-        : '',
-    };
+        : '{}',
+    } as AiSettingsFormSchema;
 
     setInitialFormValue(formValue);
     form.reset(formValue);
@@ -125,9 +129,13 @@ const AiSettingsForm = ({
   const onSaveClick = () => {
     const formValue = form.getValues();
 
+    const providerSettings = parseJsonOrNull(formValue.providerSettings);
+
     const parsedValue = {
       ...formValue,
-      providerSettings: parseJsonOrNull(formValue.providerSettings),
+      providerSettings: providerSettings
+        ? { ...providerSettings, baseUrl: formValue.baseUrl }
+        : { baseUrl: formValue.baseUrl },
       modelSettings: parseJsonOrNull(formValue.modelSettings),
     };
 

--- a/packages/react-ui/src/app/features/ai/lib/ai-form-utils.ts
+++ b/packages/react-ui/src/app/features/ai/lib/ai-form-utils.ts
@@ -16,8 +16,8 @@ export const AI_SETTINGS_FORM_SCHEMA = Type.Object({
     minLength: 1,
   }),
   baseUrl: Type.String(),
-  providerSettings: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-  modelSettings: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  providerSettings: Type.String(),
+  modelSettings: Type.String(),
 });
 
 export type AiSettingsFormSchema = Static<typeof AI_SETTINGS_FORM_SCHEMA>;


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-1651.

We need baseUrl to be a part of providerSettings technically, but we want to separate them for the users 

<!--
Why was it changed?
Any relevant context or links?
Add refactoring notes (if applicable), preferably as comments in the code (if you refactored code, explain what was moved/changed and why).
-->

## Testing Checklist

Check all that apply:

- [X] I tested the feature thoroughly, including edge cases

- [X] I verified all affected areas still work as expected

- [X] Automated tests were added/updated if necessary

- [X] Changes are backwards compatible with any existing data, otherwise a migration script is provided

