### PR TITLE
Remove resize observer on messages height logic

### DIFF
--- a/packages/ui-components/src/components/custom/markdown.tsx
+++ b/packages/ui-components/src/components/custom/markdown.tsx
@@ -60,32 +60,24 @@ const LanguageText = ({
     const textarea = textareaRef.current;
 
     if (textarea) {
-      const resizeObserver = new ResizeObserver(() => {
-        const lineCount = textarea.value.split('\n').length;
-        const isSingleLine = lineCount === 1;
+      const lineCount = textarea.value.split('\n').length;
+      const isSingleLine = lineCount === 1;
 
-        textarea.style.height = 'auto';
-        const newHeight = isSingleLine
-          ? textarea.scrollHeight
-          : textarea.scrollHeight + 16; // adding the extra padding
-        textarea.style.height = `${newHeight}px`;
+      textarea.style.height = 'auto';
+      const newHeight = isSingleLine
+        ? textarea.scrollHeight
+        : textarea.scrollHeight + 16; // adding the extra padding
+      textarea.style.height = `${newHeight}px`;
 
-        if (isSingleLine) {
-          textarea.style.lineHeight = `32px`;
-          textarea.style.paddingTop = '0';
-          textarea.style.paddingBottom = '0';
-        } else {
-          textarea.style.lineHeight = '';
-          textarea.style.paddingTop = '8px';
-          textarea.style.paddingBottom = '8px';
-        }
-      });
-
-      resizeObserver.observe(textarea);
-
-      return () => {
-        resizeObserver.disconnect();
-      };
+      if (isSingleLine) {
+        textarea.style.lineHeight = `32px`;
+        textarea.style.paddingTop = '0';
+        textarea.style.paddingBottom = '0';
+      } else {
+        textarea.style.lineHeight = '';
+        textarea.style.paddingTop = '8px';
+        textarea.style.paddingBottom = '8px';
+      }
     }
   }, [content]);
 


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-1615

## Additional Notes

This was causing a flicker, right now it's better to have it without the Resize observer, and later this component will be changed to a code highlighter.

