### PR TITLE
Fix create block CLI regression (#316)

### DIFF
--- a/packages/cli/src/lib/commands/create-block.ts
+++ b/packages/cli/src/lib/commands/create-block.ts
@@ -145,14 +145,14 @@ const updateEslintFile = async (blockName: string) => {
 };
 
 const updateJestConfigFile = async (blockName: string) => {
-  let jestConfig = await readJestConfig(`packages/blocks/${blockName}`);
-
-  jestConfig = jestConfig.replace(
-    /preset:\s'..\/..\/..\/jest.preset.js',/,
+  const jestConfigBuffer = await readJestConfig(`packages/blocks/${blockName}`);
+  const jestConfig = jestConfigBuffer.toString();
+  const updatedJestConfig = jestConfig.replace(
+    /preset:\s*['"].*jest\.preset\.js['"],?/,
     (match) => `${match}\n  setupFiles: ['../../../jest.env.js'],`,
   );
 
-  await writeJestConfig(`packages/blocks/${blockName}`, jestConfig);
+  await writeJestConfig(`packages/blocks/${blockName}`, updatedJestConfig);
 };
 
 const setupGeneratedLibrary = async (blockName: string) => {


### PR DESCRIPTION
Fixes OPS-1729. 
This PR fixes the regression from [ PR 316](https://this%20pr%20https//github.com/openops-cloud/openops/pull/316/files.)
It ensures `jest.config.ts` is read as a string before calling `.replace`.

With this fix, the CLI executes without error.
<img width="939" alt="Screenshot 2025-05-15 at 12 21 36" src="https://github.com/user-attachments/assets/8c003e1f-9e5b-4033-b260-629f08366666" />

