### PR TITLE
Adjust docs prompt

### DIFF
--- a/ai-prompts/mcp.txt
+++ b/ai-prompts/mcp.txt
@@ -6,6 +6,7 @@ Core responsibilities:
 2. Maintain consistent context across interactions
 3. If needed, handle invoking different OpenOps MCP (model context protocol) tools and process and respond according to MCP protocol specifications
     - Mintlify Search
+4. Any questions about OpenOps, such as features, integrations, blocks, templates, should only be answered based on docs.openops.com
 
 Context handling:
 - Maintain awareness of current block context
@@ -16,7 +17,7 @@ Context handling:
 Response guidelines:
 - Invoke provided tools only when necessary
 - Respond short and concisely
-- Answer only questions that are related to OpenOps, FinOps, Cloud Providers, Cloud Infrastructure tools, and Cloud Ops.
+- Answer only questions that are related to OpenOps, FinOps, Cloud Providers, Cloud Infrastructure tools, and Cloud Ops
 - if there is a link provided to the OpenOps docs, use the correct URL in the response, it should start with https://docs.openops.com/
 
 Focus areas:


### PR DESCRIPTION
Fixes OPS-1779

After the fix:

```
how to I save on EC2 idle instances with OpenOps?

OpenOps can help you save on EC2 idle instances through automation and optimization. Here's how you can do it:

Identify Idle Instances: Create a workflow that uses AWS CloudWatch metrics to identify EC2 instances with low or no utilization.

Automate Shutdown/Start-up: Implement a workflow that automatically shuts down idle instances during non-business hours and starts them up when they are needed. This is particularly useful for instances used in development or testing environments.

Notifications: Set up a workflow that sends notifications when an instance has been idle for a certain period of time. This can prompt a manual review to determine if the instance is still needed.

Tagging: Use tagging to track the usage and costs of individual instances. This can help you identify which instances are being underutilized.

Reporting: Regularly generate reports on EC2 usage and costs to identify opportunities for further optimization.

Remember, the key to cost optimization is continuous monitoring and adjustment. OpenOps can automate these tasks, but you'll still need to review the reports and make strategic decisions.

For more detailed information on how to implement these steps in OpenOps, please refer to the OpenOps documentation at https://docs.openops.com/.
```