### PR TITLE
Initialize sidebar state as expanded in the global state when navigating to builder page

### DIFF
--- a/packages/react-ui/src/app/routes/flows/id/index.tsx
+++ b/packages/react-ui/src/app/routes/flows/id/index.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { Navigate, useParams, useSearchParams } from 'react-router-dom';
 
+import { useDefaultSidebarState } from '@/app/common/hooks/use-default-sidebar-state';
 import { SEARCH_PARAMS } from '@/app/constants/search-params';
 import { BuilderPage } from '@/app/features/builder';
 import { BuilderStateProvider } from '@/app/features/builder/builder-state-provider';
@@ -13,6 +14,7 @@ import { AxiosError } from 'axios';
 const FlowBuilderPage = () => {
   const { flowId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
+  useDefaultSidebarState('expanded');
 
   useEffect(() => {
     const viewOnly = new URLSearchParams(window.location.search).get(


### PR DESCRIPTION
Fixes OPS-1806.

The Side menu footer is [correctly connected to the app global state](https://github.com/openops-cloud/openops/blob/main/packages/react-ui/src/app/features/navigation/side-menu/side-menu-footer.tsx#L34C9-L34C27), the reason why it still "thinks" the sidebar is in minimized state is because the store is not properly being updated although visually speaking the left sidebar expands.

Demo:
https://www.loom.com/share/907e4a1d107a43ccb1928a2a4425df0a