### PR TITLE
Display tooltip to suggest a newer app version is not available

### DIFF
--- a/packages/react-ui/public/locales/en/translation.json
+++ b/packages/react-ui/public/locales/en/translation.json
@@ -414,6 +414,7 @@
   "Error loading version": "Error loading version",
   "Newer version is available": "Newer version is available",
   "Learn how to update": "Learn how to update",
+  "You are on the latest version": "You are on the latest version",
   "Error": "Error",
   "AI providers": "AI providers",
   "Customize the appearance of the app. Automatically switch between day and night themes.": "Customize the appearance of the app. Automatically switch between day and night themes.",

--- a/packages/react-ui/src/app/routes/settings/about/index.tsx
+++ b/packages/react-ui/src/app/routes/settings/about/index.tsx
@@ -7,6 +7,8 @@ import {
   CardHeader,
   CardTitle,
   LoadingSpinner,
+  TooltipProvider,
+  TooltipWrapper,
 } from '@openops/components/ui';
 import { t } from 'i18next';
 import { Link } from 'react-router-dom';
@@ -45,16 +47,26 @@ const AboutSettingsPage = () => {
             )}
           </div>
 
-          <Link
-            to="https://docs.openops.com/getting-started/updating-openops"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="self-end"
-          >
-            <Button disabled={!hasNewerVersionAvailable}>
-              {t('Learn how to update')}
-            </Button>
-          </Link>
+          <TooltipProvider>
+            <TooltipWrapper
+              tooltipText={
+                !hasNewerVersionAvailable
+                  ? t('You are on the latest version')
+                  : ''
+              }
+            >
+              <Link
+                to="https://docs.openops.com/getting-started/updating-openops"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="self-end"
+              >
+                <Button disabled={!hasNewerVersionAvailable}>
+                  {t('Learn how to update')}
+                </Button>
+              </Link>
+            </TooltipWrapper>
+          </TooltipProvider>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
Fixes OPS-1850.

<img width="1321" alt="Screenshot 2025-05-27 at 09 57 02" src="https://github.com/user-attachments/assets/bef00c94-0dc1-423a-98aa-9b902b1a959a" />
<img width="1332" alt="Screenshot 2025-05-27 at 10 00 07" src="https://github.com/user-attachments/assets/10198298-ad1e-464e-9e61-faa8b91fefdc" />
