### PR TITLE
Bump openops-tables version to latest public release

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       OPS_COMPONENT: app
       OPS_VERSION: ${OPS_VERSION:-latest}
-      OPS_OPENOPS_TABLES_VERSION: 0.2.1
+      OPS_OPENOPS_TABLES_VERSION: 0.2.2
       OPS_ANALYTICS_VERSION: 0.14.0
     depends_on:
       openops-tables:
@@ -44,7 +44,7 @@ services:
       - ${HOST_AZURE_CONFIG_DIR:-openops_azure_cli_data}:/tmp/azure
       - ${HOST_CLOUDSDK_CONFIG:-openops_gcloud_cli_data}:/tmp/gcloud
   openops-tables:
-    image: public.ecr.aws/openops/openops-tables:0.2.1
+    image: public.ecr.aws/openops/openops-tables:0.2.2
     restart: unless-stopped
     environment:
       BASEROW_PUBLIC_URL: ${OPS_OPENOPS_TABLES_PUBLIC_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   tables:
     container_name: tables
-    image: public.ecr.aws/openops/openops-tables:0.2.1
+    image: public.ecr.aws/openops/openops-tables:0.2.2
     environment:
       BASEROW_PUBLIC_URL: ${OPS_OPENOPS_TABLES_PUBLIC_URL}
       BASEROW_PRIVATE_URL: http://localhost:3001


### PR DESCRIPTION
Fixes OPS-1207, OPS-1844.
A version of the platform with openops-tables:0.2.2 has been deployed on the test env (https://github.com/openops-cloud/devops/actions/runs/15272517999), and I used the environment to test the tickets above.