### PR TITLE
Fix get a value from Storage block when testing a step

### DIFF
--- a/packages/blocks/store/src/lib/actions/common.ts
+++ b/packages/blocks/store/src/lib/actions/common.ts
@@ -15,15 +15,19 @@ export function getScopeAndKey(params: Params): {
       return { scope: StoreScope.PROJECT, key: params.key };
     case BlockStoreScope.FLOW:
       return { scope: StoreScope.FLOW, key: params.key };
-    case BlockStoreScope.RUN:
+    case BlockStoreScope.RUN: {
+      const runId = params.isTest ? 'test-run' : params.runId;
+
       return {
         scope: StoreScope.FLOW,
-        key: `run_${params.runId}/${params.key}`,
+        key: `run_${runId}/${params.key}`,
       };
+    }
   }
 }
 
 type Params = {
+  isTest: boolean;
   runId: string;
   key: string;
   scope: BlockStoreScope;

--- a/packages/blocks/store/src/lib/actions/store-add-to-list.ts
+++ b/packages/blocks/store/src/lib/actions/store-add-to-list.ts
@@ -33,6 +33,7 @@ export const storageAddtoList = createAction({
   async run(context) {
     const { key, scope } = getScopeAndKey({
       runId: context.run.id,
+      isTest: context.run.isTest,
       key: context.propsValue['key'],
       scope: context.propsValue.store_scope,
     });

--- a/packages/blocks/store/src/lib/actions/store-append-action.ts
+++ b/packages/blocks/store/src/lib/actions/store-append-action.ts
@@ -33,6 +33,7 @@ export const storageAppendAction = createAction({
   async run(context) {
     const { key, scope } = getScopeAndKey({
       runId: context.run.id,
+      isTest: context.run.isTest,
       key: context.propsValue['key'],
       scope: context.propsValue.store_scope,
     });

--- a/packages/blocks/store/src/lib/actions/store-get-action.ts
+++ b/packages/blocks/store/src/lib/actions/store-get-action.ts
@@ -28,6 +28,7 @@ export const storageGetAction = createAction({
   async run(context) {
     const { key, scope } = getScopeAndKey({
       runId: context.run.id,
+      isTest: context.run.isTest,
       key: context.propsValue['key'],
       scope: context.propsValue.store_scope,
     });

--- a/packages/blocks/store/src/lib/actions/store-put-action.ts
+++ b/packages/blocks/store/src/lib/actions/store-put-action.ts
@@ -28,6 +28,7 @@ export const storagePutAction = createAction({
   async run(context) {
     const { key, scope } = getScopeAndKey({
       runId: context.run.id,
+      isTest: context.run.isTest,
       key: context.propsValue['key'],
       scope: context.propsValue.store_scope,
     });

--- a/packages/blocks/store/src/lib/actions/store-remove-from-list.ts
+++ b/packages/blocks/store/src/lib/actions/store-remove-from-list.ts
@@ -29,6 +29,7 @@ export const storageRemoveFromList = createAction({
   async run(context) {
     const { key, scope } = getScopeAndKey({
       runId: context.run.id,
+      isTest: context.run.isTest,
       key: context.propsValue['key'],
       scope: context.propsValue.store_scope,
     });

--- a/packages/blocks/store/src/lib/actions/store-remove-value.ts
+++ b/packages/blocks/store/src/lib/actions/store-remove-value.ts
@@ -1,8 +1,4 @@
-import {
-  createAction,
-  Property,
-  Validators,
-} from '@openops/blocks-framework';
+import { createAction, Property, Validators } from '@openops/blocks-framework';
 import { common, getScopeAndKey } from './common';
 
 export const storageRemoveValue = createAction({

--- a/packages/blocks/store/src/lib/actions/store-remove-value.ts
+++ b/packages/blocks/store/src/lib/actions/store-remove-value.ts
@@ -1,7 +1,6 @@
 import {
   createAction,
   Property,
-  StoreScope,
   Validators,
 } from '@openops/blocks-framework';
 import { common, getScopeAndKey } from './common';
@@ -29,6 +28,7 @@ export const storageRemoveValue = createAction({
   async run(context) {
     const { key, scope } = getScopeAndKey({
       runId: context.run.id,
+      isTest: context.run.isTest,
       key: context.propsValue['key'],
       scope: context.propsValue.store_scope,
     });


### PR DESCRIPTION

Fixes OPS-1845.

## Additional Notes
- When we test a block, the flowRunId changes each time the button is clicked. We use the flowRunId to build the key for the storage service when using the RUN scope.
- Add a static value if we are testing a block.
