### PR TITLE
Improves middleware error logging with detailed request context and error message

### DIFF
--- a/packages/server/api/src/app/helper/error-handler.ts
+++ b/packages/server/api/src/app/helper/error-handler.ts
@@ -19,14 +19,13 @@ export const errorHandler = async (
       params: error.error.params,
     });
   } else {
-    const requestSummary = (({
+    const requestSummary = (({ method, url, body, params, query }) => ({
       method,
       url,
-      headers,
       body,
       params,
       query,
-    }) => ({ method, url, headers, body, params, query }))(_request);
+    }))(_request);
 
     logger.error('Error handler caught an exception.', {
       message: error.message,


### PR DESCRIPTION
Fixes OPS-1814.

I deployed to test env and triggered the same error by omitting blockName in the request payload of 
`POST https://test.internal.openops.com/api/v1/app-connections`
See the [malformed log](https://app.logz.io/#/dashboard/explore?switchToAccountId=1161904&query=(field%3A(name%3Aenvironment)%2Cinvalid%3A!f%2CisDisabled%3A!f%2Cnegate%3A!f%2Ctype%3AIS_ONE_OF%2Cvalue%3A!(demo%2Cstaging%2Canodot%2Canodot-demo%2Clegit-security%2Cprod))%2C(field%3A(name%3Aevent.actionType)%2Cinvalid%3A!f%2CisDisabled%3A!f%2Cnegate%3A!t%2Ctype%3AEXIST)%2C(field%3A(aggregatable%3A!t%2Cname%3A'(level%3A%20error%20OR%20message%3A%20%22error%22)%20AND%20(NOT%20level%3A%20debug)%20AND%20(NOT%20%22BLOCK_NOT_FOUND%22)%20AND%20(NOT%20%22A%20promise%20was%20rejected%22)%20AND%20(NOT%20%22Failed%20slack%20interactions%22)'%2Ctype%3Alucene)%2Cinvalid%3A!f%2CisDisabled%3A!f%2Cnegate%3A!f%2Ctype%3ALUCENE%2Cvalue%3A'(level%3A%20error%20OR%20message%3A%20%22error%22)%20AND%20(NOT%20level%3A%20debug)%20AND%20(NOT%20%22BLOCK_NOT_FOUND%22)%20AND%20(NOT%20%22A%20promise%20was%20rejected%22)%20AND%20(NOT%20%22Failed%20slack%20interactions%22)')&mode=CLASSIC&inputMode=LUCENE&yAxisScale=linear&timeInterval=auto&accounts=1161904&isFilterOpen=true&columns=!((id%3A_source%2Csize%3A150))&from=1748349840000&to=1748350140000&sort=-%40timestamp) provided with the ticket.
See the [updated log](https://app.logz.io/#/dashboard/explore?switchToAccountId=1161904&query=(field%3A(analyzed%3A!f%2Cname%3A'%40timestamp'%2Ctype%3Adate)%2Cnegate%3A!f%2Ctype%3AIS_ONE_OF%2Cvalue%3A!('2025-05-28T07%3A14%3A36.532Z'))%2C(field%3A(aggregatable%3A!f%2Cname%3A'(level%3A%20error%20OR%20message%3A%20%22error%22)%20AND%20(NOT%20level%3A%20debug)%20AND%20(NOT%20%22BLOCK_NOT_FOUND%22)%20AND%20(NOT%20%22A%20promise%20was%20rejected%22)%20AND%20(NOT%20%22Failed%20slack%20interactions%22)'%2Ctype%3Alucene)%2Cinvalid%3A!f%2CisDisabled%3A!f%2Cnegate%3A!f%2Ctype%3ALUCENE%2Cvalue%3A'(level%3A%20error%20OR%20message%3A%20%22error%22)%20AND%20(NOT%20level%3A%20debug)%20AND%20(NOT%20%22BLOCK_NOT_FOUND%22)%20AND%20(NOT%20%22A%20promise%20was%20rejected%22)%20AND%20(NOT%20%22Failed%20slack%20interactions%22)')%2C(field%3A(name%3Aenvironment%2Ctype%3Astring)%2Cinvalid%3A!f%2CisDisabled%3A!f%2Cnegate%3A!f%2Ctype%3AIS_ONE_OF%2Cvalue%3A!(test))%2C(field%3A(name%3Aevent.actionType%2Ctype%3Astring)%2Cinvalid%3A!f%2CisDisabled%3A!f%2Cnegate%3A!t%2Ctype%3AEXIST)&mode=CLASSIC&inputMode=LUCENE&yAxisScale=linear&timeInterval=auto&accounts=1161904&isFilterOpen=true&columns=!((id%3A_source%2Csize%3A150))&from=1748349840000&to=now&sort=-%40timestamp).

You may have noticed the redundant information in the log; it's completely unrelated to this ticket, so I created another [one](https://linear.app/openops/issue/OPS-1865/app-connection-validation-message-includes-redundant-information)
![Screenshot 2025-05-28 at 10 41 42](https://github.com/user-attachments/assets/4a876992-cd19-420d-b207-ba95c72c0654).



