### PR TITLE
Remove projectId from request payloads on various BE API endpoints

### DIFF
--- a/packages/react-ui/src/app/features/connections/components/connection-table.tsx
+++ b/packages/react-ui/src/app/features/connections/components/connection-table.tsx
@@ -1,7 +1,6 @@
 import { useAuthorization } from '@/app/common/hooks/authorization-hooks';
 import { blocksHooks } from '@/app/features/blocks/lib/blocks-hook';
 import { appConnectionsApi } from '@/app/features/connections/lib/app-connections-api';
-import { authenticationSession } from '@/app/lib/authentication-session';
 import { formatUtils } from '@/app/lib/utils';
 import {
   BlockIcon,
@@ -252,8 +251,6 @@ const fetchData = async (
   pagination: PaginationParams,
 ) => {
   return appConnectionsApi.list({
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    projectId: authenticationSession.getProjectId()!,
     cursor: pagination.cursor,
     limit: pagination.limit ?? 10,
     status: params.status,

--- a/packages/react-ui/src/app/features/connections/components/create-edit-connection-dialog-content.tsx
+++ b/packages/react-ui/src/app/features/connections/components/create-edit-connection-dialog-content.tsx
@@ -3,7 +3,6 @@ import { useDynamicFormValidationContext } from '@/app/features/builder/dynamic-
 import { appConnectionsApi } from '@/app/features/connections/lib/app-connections-api';
 import { appConnectionUtils } from '@/app/features/connections/lib/app-connections-utils';
 import { api } from '@/app/lib/api';
-import { authenticationSession } from '@/app/lib/authentication-session';
 import { typeboxResolver } from '@hookform/resolvers/typebox';
 import {
   BasicAuthProperty,
@@ -124,7 +123,6 @@ const CreateEditConnectionDialogContent = ({
       const formValues = form.getValues().request;
       if (!reconnect) {
         const connections = await appConnectionsApi.list({
-          projectId: authenticationSession.getProjectId()!,
           limit: 10000,
         });
         const existingConnection = connections.data.find(

--- a/packages/react-ui/src/app/features/flows/components/flow-actions-menu.tsx
+++ b/packages/react-ui/src/app/features/flows/components/flow-actions-menu.tsx
@@ -28,7 +28,6 @@ import { userSettingsHooks } from '@/app/common/hooks/user-settings-hooks';
 import { SEARCH_PARAMS } from '@/app/constants/search-params';
 import { ImportFlowDialog } from '@/app/features/flows/components/import-flow-dialog/import-flow-dialog';
 import { useRefetchFolderTree } from '@/app/features/folders/hooks/refetch-folder-tree';
-import { authenticationSession } from '@/app/lib/authentication-session';
 import { flowsApi } from '../lib/flows-api';
 import { flowsUtils } from '../lib/flows-utils';
 import { MoveFlowDialog } from './move-flow-dialog';
@@ -65,7 +64,6 @@ const FlowActionMenu: React.FC<FlowActionMenuProps> = ({
     mutationFn: async () => {
       const createdFlow = await flowsApi.create({
         displayName: flowVersion.displayName,
-        projectId: authenticationSession.getProjectId()!,
       });
       const updatedFlow = await flowsApi.update(createdFlow.id, {
         type: FlowOperationType.IMPORT_FLOW,

--- a/packages/react-ui/src/app/features/flows/components/import-flow-dialog/import-flow-dialog.tsx
+++ b/packages/react-ui/src/app/features/flows/components/import-flow-dialog/import-flow-dialog.tsx
@@ -21,7 +21,6 @@ import { userSettingsHooks } from '@/app/common/hooks/user-settings-hooks';
 import { SEARCH_PARAMS } from '@/app/constants/search-params';
 import { ImportFlowDialogContent } from '@/app/features/flows/components/import-flow-dialog/import-flow-dialog-content';
 import { templatesHooks } from '@/app/features/templates/lib/templates-hooks';
-import { authenticationSession } from '@/app/lib/authentication-session';
 
 const ImportFlowDialog = ({ children }: { children: React.ReactNode }) => {
   const navigate = useNavigate();
@@ -37,7 +36,6 @@ const ImportFlowDialog = ({ children }: { children: React.ReactNode }) => {
       if (importedWorkflow) {
         const newFlow = await flowsApi.create({
           displayName: importedWorkflow.name,
-          projectId: authenticationSession.getProjectId()!,
         });
         return await flowsApi.update(newFlow.id, {
           type: FlowOperationType.IMPORT_FLOW,

--- a/packages/react-ui/src/app/features/flows/lib/flows-hooks.ts
+++ b/packages/react-ui/src/app/features/flows/lib/flows-hooks.ts
@@ -21,7 +21,6 @@ export type FlowsSearchState = {
 async function fetchFlows(name: string, limit: number, signal: AbortSignal) {
   return flowsApi.list(
     {
-      projectId: authenticationSession.getProjectId()!,
       limit: limit,
       name: name,
       cursor: undefined,
@@ -33,14 +32,11 @@ async function fetchFlows(name: string, limit: number, signal: AbortSignal) {
 }
 
 export const flowsHooks = {
-  useFlows: (request: Omit<ListFlowsRequest, 'projectId'>) => {
+  useFlows: (request: ListFlowsRequest) => {
     return useQuery({
       queryKey: [QueryKeys.flows, authenticationSession.getProjectId()],
       queryFn: async () => {
-        return await flowsApi.list({
-          ...request,
-          projectId: authenticationSession.getProjectId()!,
-        });
+        return await flowsApi.list(request);
       },
       staleTime: 5 * 1000,
     });
@@ -81,7 +77,6 @@ export const flowsHooks = {
     >({
       mutationFn: async (folderId: string | undefined) => {
         const flow = await flowsApi.create({
-          projectId: authenticationSession.getProjectId()!,
           displayName: t('Untitled'),
           folderId: folderId,
         });

--- a/packages/react-ui/src/app/features/home/lib/home-hooks.ts
+++ b/packages/react-ui/src/app/features/home/lib/home-hooks.ts
@@ -10,7 +10,6 @@ import { useQuery } from '@tanstack/react-query';
 
 import { flowRunsApi } from '@/app/features/flow-runs/lib/flow-runs-api';
 import { flowsApi } from '@/app/features/flows/lib/flows-api';
-import { authenticationSession } from '@/app/lib/authentication-session';
 import { homeApi } from './home-api';
 
 export const useDashboardData = () => {
@@ -78,7 +77,6 @@ export const useWorkflowsOverview = (
 
 const fetchRuns = async () => {
   return flowRunsApi.list({
-    projectId: authenticationSession.getProjectId()!,
     limit: 10,
   });
 };
@@ -88,7 +86,6 @@ const fetchFlows = async (
   showPublihedFlowsWithDrafts?: boolean,
 ) => {
   return flowsApi.list({
-    projectId: authenticationSession.getProjectId()!,
     limit: limit,
     cursor: undefined,
   });

--- a/packages/react-ui/src/app/features/templates/components/connections-picker/connections-picker.tsx
+++ b/packages/react-ui/src/app/features/templates/components/connections-picker/connections-picker.tsx
@@ -3,7 +3,6 @@ import { Theme, useTheme } from '@/app/common/providers/theme-provider';
 import { DynamicFormValidationProvider } from '@/app/features/builder/dynamic-form-validation/dynamic-form-validation-context';
 import { CreateEditConnectionDialogContent } from '@/app/features/connections/components/create-edit-connection-dialog-content';
 import { appConnectionsHooks } from '@/app/features/connections/lib/app-connections-hooks';
-import { authenticationSession } from '@/app/lib/authentication-session';
 import { BlockMetadataModelSummary } from '@openops/blocks-framework';
 import {
   BlockIcon,
@@ -70,7 +69,6 @@ const ConnectionsPicker = ({
     isLoading,
     refetch,
   } = appConnectionsHooks.useGroupedConnections({
-    projectId: authenticationSession.getProjectId() ?? '',
     blockNames: integrations.map((integration) => integration.name),
     limit: 10000,
   });

--- a/packages/react-ui/src/app/routes/runs/index.tsx
+++ b/packages/react-ui/src/app/routes/runs/index.tsx
@@ -9,7 +9,6 @@ import { useRunsTableColumns } from '@/app/features/flow-runs/hooks/useRunsTable
 import { flowRunUtils } from '@/app/features/flow-runs/lib/flow-run-utils';
 import { flowRunsApi } from '@/app/features/flow-runs/lib/flow-runs-api';
 import { flowsHooks } from '@/app/features/flows/lib/flows-hooks';
-import { authenticationSession } from '@/app/lib/authentication-session';
 import { formatUtils } from '@/app/lib/utils';
 
 const fetchData = async (
@@ -23,7 +22,6 @@ const fetchData = async (
   const status = params.status;
   return flowRunsApi.list({
     status,
-    projectId: authenticationSession.getProjectId()!,
     flowId: params.flowId,
     cursor: pagination.cursor,
     limit: pagination.limit ?? 10,

--- a/packages/server/api/src/app/flows/flow-run/flow-run-controller.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-controller.ts
@@ -30,12 +30,10 @@ export const flowRunController: FastifyPluginCallbackTypebox = (
   done,
 ): void => {
   app.get('/', ListRequest, async (request) => {
-    // TODO project Id will be required after May 2024, this no longer needs to be optional
     const projectId =
-      request.query.projectId ??
-      (request.principal.type === PrincipalType.SERVICE
+      request.principal.type === PrincipalType.SERVICE
         ? undefined
-        : request.principal.projectId);
+        : request.principal.projectId;
     assertNotNullOrUndefined(projectId, 'projectId');
     return flowRunService.list({
       projectId,

--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -71,7 +71,6 @@ export const flowService = {
       userId,
       projectId,
       request: {
-        projectId,
         displayName,
       },
     });

--- a/packages/server/api/src/app/flows/folder/folder.module.ts
+++ b/packages/server/api/src/app/flows/folder/folder.module.ts
@@ -3,7 +3,6 @@ import {
   CreateFolderRequest,
   DeleteFolderRequest,
   ListFolderFlowsRequest,
-  ListFolderRequest,
   Permission,
   PrincipalType,
   SERVICE_KEY_SECURITY_OPENAPI,
@@ -105,19 +104,6 @@ const GetFolderParams = {
     }),
     description: 'Get a folder by id',
     security: [SERVICE_KEY_SECURITY_OPENAPI],
-  },
-};
-
-const ListFoldersParams = {
-  config: {
-    allowedPrincipals: [PrincipalType.USER, PrincipalType.SERVICE],
-    permission: Permission.READ_FLOW,
-  },
-  schema: {
-    tags: ['folders'],
-    description: 'List folders',
-    security: [SERVICE_KEY_SECURITY_OPENAPI],
-    querystring: ListFolderRequest,
   },
 };
 

--- a/packages/shared/src/lib/app-connection/dto/read-app-connection-request.ts
+++ b/packages/shared/src/lib/app-connection/dto/read-app-connection-request.ts
@@ -3,7 +3,6 @@ import { AppConnectionStatus } from '../app-connection';
 
 export const ListAppConnectionsRequestQuery = Type.Object({
   cursor: Type.Optional(Type.String({})),
-  projectId: Type.String(),
   blockNames: Type.Optional(Type.Array(Type.String({}))),
   name: Type.Optional(Type.String({})),
   status: Type.Optional(Type.Array(Type.Enum(AppConnectionStatus))),

--- a/packages/shared/src/lib/flow-run/dto/list-flow-runs-request.ts
+++ b/packages/shared/src/lib/flow-run/dto/list-flow-runs-request.ts
@@ -10,8 +10,6 @@ export const ListFlowRunsRequestQuery = Type.Object({
   cursor: Type.Optional(Type.String({})),
   createdAfter: Type.Optional(Type.String({})),
   createdBefore: Type.Optional(Type.String({})),
-  // TODO make this required after May 2024
-  projectId: Type.Optional(OpenOpsId),
 });
 
 export type ListFlowRunsRequestQuery = Static<typeof ListFlowRunsRequestQuery>;

--- a/packages/shared/src/lib/flows/dto/create-flow-request.ts
+++ b/packages/shared/src/lib/flows/dto/create-flow-request.ts
@@ -4,7 +4,6 @@ import { Trigger } from '../triggers/trigger';
 export const CreateEmptyFlowRequest = Type.Object({
   displayName: Type.String({}),
   folderId: Type.Optional(Type.String({})),
-  projectId: Type.String({}),
 });
 
 export type CreateEmptyFlowRequest = Static<typeof CreateEmptyFlowRequest>;

--- a/packages/shared/src/lib/flows/dto/list-flows-request.ts
+++ b/packages/shared/src/lib/flows/dto/list-flows-request.ts
@@ -9,7 +9,6 @@ export const ListFlowsRequest = Type.Object({
   cursor: Type.Optional(Type.String({})),
   status: Type.Optional(Type.Array(Type.Enum(FlowStatus))),
   versionState: Type.Optional(Type.Array(Type.Enum(FlowVersionState))),
-  projectId: Type.String({}),
   name: Type.Optional(Type.String({})),
 });
 

--- a/packages/shared/src/lib/flows/folders/folder-requests.ts
+++ b/packages/shared/src/lib/flows/folders/folder-requests.ts
@@ -1,5 +1,4 @@
 import { Static, Type } from '@sinclair/typebox';
-import { Cursor } from '../../common/seek-page';
 
 export const CreateFolderRequest = Type.Object({
   displayName: Type.String(),
@@ -21,17 +20,6 @@ export const DeleteFolderRequest = Type.Object({
 });
 
 export type DeleteFlowRequest = Static<typeof DeleteFolderRequest>;
-
-export const ListFolderRequest = Type.Object({
-  limit: Type.Optional(Type.Number({})),
-  cursor: Type.Optional(Type.String({})),
-  projectId: Type.String(),
-});
-
-export type ListFolderRequest = Omit<
-  Static<typeof ListFolderRequest>,
-  'cursor'
-> & { cursor: Cursor | undefined };
 
 export const ListFolderFlowsRequest = Type.Object({
   excludeUncategorizedFolder: Type.Optional(Type.Boolean()),


### PR DESCRIPTION
Fixes OPS-1861.

On the controllers of these API endpoints the projectId is fetched from request's principal.