### PR TITLE
Retrieve CLI Step Chat history only when blockName and actionName are available for the selectedStep

### DIFF
--- a/packages/react-ui/src/app/features/builder/ai-chat/lib/step-settings-ai-chat-hook.ts
+++ b/packages/react-ui/src/app/features/builder/ai-chat/lib/step-settings-ai-chat-hook.ts
@@ -41,11 +41,8 @@ export const useStepSettingsAiChat = (
         stepDetails.settings.actionName,
       );
     },
-    enabled: Boolean(
-      stepDetails?.settings?.blockName &&
-        stepDetails?.settings?.actionName &&
-        selectedStep,
-    ),
+    enabled:
+      !!stepDetails?.settings?.blockName && !!stepDetails?.settings?.actionName,
   });
 
   const {

--- a/packages/react-ui/src/app/features/builder/ai-chat/lib/step-settings-ai-chat-hook.ts
+++ b/packages/react-ui/src/app/features/builder/ai-chat/lib/step-settings-ai-chat-hook.ts
@@ -41,7 +41,12 @@ export const useStepSettingsAiChat = (
         stepDetails.settings.actionName,
       );
     },
-    enabled: !!stepDetails && !!selectedStep,
+    enabled: Boolean(
+      stepDetails &&
+        stepDetails.settings.blockName &&
+        stepDetails.settings.actionName &&
+        selectedStep,
+    ),
   });
 
   const {

--- a/packages/react-ui/src/app/features/builder/ai-chat/lib/step-settings-ai-chat-hook.ts
+++ b/packages/react-ui/src/app/features/builder/ai-chat/lib/step-settings-ai-chat-hook.ts
@@ -42,9 +42,8 @@ export const useStepSettingsAiChat = (
       );
     },
     enabled: Boolean(
-      stepDetails &&
-        stepDetails.settings.blockName &&
-        stepDetails.settings.actionName &&
+      stepDetails?.settings.blockName &&
+        stepDetails?.settings.actionName &&
         selectedStep,
     ),
   });

--- a/packages/react-ui/src/app/features/builder/ai-chat/lib/step-settings-ai-chat-hook.ts
+++ b/packages/react-ui/src/app/features/builder/ai-chat/lib/step-settings-ai-chat-hook.ts
@@ -42,8 +42,8 @@ export const useStepSettingsAiChat = (
       );
     },
     enabled: Boolean(
-      stepDetails?.settings.blockName &&
-        stepDetails?.settings.actionName &&
+      stepDetails?.settings?.blockName &&
+        stepDetails?.settings?.actionName &&
         selectedStep,
     ),
   });


### PR DESCRIPTION
Fixes OPS-1876.


This only affects the CLI step chat; there is a different endpoint for the AI assistant chat, which has a similar URL, `POST /v1/ai/conversation/open` which is not related at all to the spamming errors from [Production alerts](https://app.logz.io/#/dashboard/explore?switchToAccountId=1161904&query=(field%3A(name%3Aenvironment)%2Cinvalid%3A!f%2CisDisabled%3A!f%2Cnegate%3A!f%2Ctype%3AIS_ONE_OF%2Cvalue%3A!(demo%2Cstaging%2Canodot%2Canodot-demo%2Clegit-security%2Cprod))%2C(field%3A(name%3Aevent.actionType)%2Cinvalid%3A!f%2CisDisabled%3A!f%2Cnegate%3A!t%2Ctype%3AEXIST)%2C(field%3A(aggregatable%3A!t%2Cname%3A'(level%3A%20error%20OR%20message%3A%20%22*error*%22)%20AND%20(NOT%20level%3A%20debug)%20AND%20(NOT%20%22BLOCK_NOT_FOUND%22)%20AND%20(NOT%20%22A%20promise%20was%20rejected%22)%20AND%20(NOT%20%22Failed%20slack%20interactions%22)'%2Ctype%3Alucene)%2Cinvalid%3A!f%2CisDisabled%3A!f%2Cnegate%3A!f%2Ctype%3ALUCENE%2Cvalue%3A'(level%3A%20error%20OR%20message%3A%20%22*error*%22)%20AND%20(NOT%20level%3A%20debug)%20AND%20(NOT%20%22BLOCK_NOT_FOUND%22)%20AND%20(NOT%20%22A%20promise%20was%20rejected%22)%20AND%20(NOT%20%22Failed%20slack%20interactions%22)')&mode=CLASSIC&inputMode=LUCENE&yAxisScale=linear&timeInterval=auto&accounts=1161904&isFilterOpen=true&columns=!((id%3A_source%2Csize%3A150))&from=1748528220000&to=1748528520000&sort=-%40timestamp).
![Screenshot 2025-05-30 at 17 49 52](https://github.com/user-attachments/assets/4f136a2d-2167-4c1a-9f71-bf18134ec227)

See Loom [demo for this bugfix](https://www.loom.com/share/e9a96293dec94eb8b45ded5f289d24d2).
