### PR TITLE
Split Secret authentication type from secret properties 

### DIFF
--- a/packages/blocks/anodot/src/lib/anodot-auth-property.ts
+++ b/packages/blocks/anodot/src/lib/anodot-auth-property.ts
@@ -25,7 +25,7 @@ export const anadotAuth = BlockAuth.CustomAuth({
       displayName: 'Username',
       description: 'The username to use to connect to Umbrella',
     }),
-    password: BlockAuth.SecretText({
+    password: Property.SecretText({
       required: true,
       displayName: 'Password',
       description: 'The password to use to connect to Umbrella',

--- a/packages/blocks/databricks/src/lib/common/auth.ts
+++ b/packages/blocks/databricks/src/lib/common/auth.ts
@@ -32,7 +32,7 @@ export const databricksAuth = BlockAuth.CustomAuth({
       displayName: 'Client ID',
       required: true,
     }),
-    clientSecret: BlockAuth.SecretText({
+    clientSecret: Property.SecretText({
       displayName: 'Client Secret',
       required: true,
     }),

--- a/packages/blocks/framework/src/lib/property/authentication/custom-auth-prop.ts
+++ b/packages/blocks/framework/src/lib/property/authentication/custom-auth-prop.ts
@@ -7,15 +7,19 @@ import { TPropertyValue } from '../input/common';
 import { StaticDropdownProperty } from '../input/dropdown/static-dropdown';
 import { NumberProperty } from '../input/number-property';
 import { PropertyType } from '../input/property-type';
-import { LongTextProperty, ShortTextProperty } from '../input/text-property';
+import {
+  LongTextProperty,
+  SecretTextProperty,
+  ShortTextProperty,
+} from '../input/text-property';
 import { BaseBlockAuthSchema } from './common';
-import { SecretTextProperty } from './secret-text-property';
 
 const CustomAuthProps = Type.Record(
   Type.String(),
   Type.Union([
     ShortTextProperty,
     LongTextProperty,
+    SecretTextProperty,
     NumberProperty,
     CheckboxProperty,
     StaticDropdownProperty,

--- a/packages/blocks/framework/src/lib/property/authentication/index.ts
+++ b/packages/blocks/framework/src/lib/property/authentication/index.ts
@@ -3,20 +3,20 @@ import { PropertyType } from '../input/property-type';
 import { BasicAuthProperty } from './basic-auth-prop';
 import { CustomAuthProperty, CustomAuthProps } from './custom-auth-prop';
 import { OAuth2Property, OAuth2Props } from './oauth2-prop';
-import { SecretTextProperty } from './secret-text-property';
+import { SecretAuthProperty } from './secret-auth-property';
 
 export const BlockAuthProperty = Type.Union([
   BasicAuthProperty,
   CustomAuthProperty,
   OAuth2Property,
-  SecretTextProperty,
+  SecretAuthProperty,
 ]);
 
 export type BlockAuthProperty =
   | BasicAuthProperty
   | CustomAuthProperty<any, boolean>
   | OAuth2Property<any>
-  | SecretTextProperty<boolean>;
+  | SecretAuthProperty<boolean>;
 
 type AuthProperties<T> = Omit<Properties<T>, 'displayName'>;
 
@@ -26,17 +26,17 @@ type Properties<T> = Omit<
 >;
 
 export const BlockAuth = {
-  SecretText<R extends boolean>(
-    request: Properties<SecretTextProperty<R>>,
-  ): R extends true ? SecretTextProperty<true> : SecretTextProperty<false> {
+  SecretAuth<R extends boolean>(
+    request: Properties<SecretAuthProperty<R>>,
+  ): R extends true ? SecretAuthProperty<true> : SecretAuthProperty<false> {
     return {
       ...request,
       valueSchema: undefined,
       type: PropertyType.SECRET_TEXT,
       required: true,
     } as unknown as R extends true
-      ? SecretTextProperty<true>
-      : SecretTextProperty<false>;
+      ? SecretAuthProperty<true>
+      : SecretAuthProperty<false>;
   },
   OAuth2<T extends OAuth2Props>(
     request: AuthProperties<OAuth2Property<T>>,

--- a/packages/blocks/framework/src/lib/property/authentication/oauth2-prop.ts
+++ b/packages/blocks/framework/src/lib/property/authentication/oauth2-prop.ts
@@ -5,9 +5,8 @@ import { ValidationInputType } from '../../validators/types';
 import { TPropertyValue } from '../input/common';
 import { StaticDropdownProperty } from '../input/dropdown/static-dropdown';
 import { PropertyType } from '../input/property-type';
-import { ShortTextProperty } from '../input/text-property';
+import { SecretTextProperty, ShortTextProperty } from '../input/text-property';
 import { BaseBlockAuthSchema } from './common';
-import { SecretTextProperty } from './secret-text-property';
 
 export enum OAuth2AuthorizationMethod {
   HEADER = 'HEADER',

--- a/packages/blocks/framework/src/lib/property/authentication/secret-auth-property.ts
+++ b/packages/blocks/framework/src/lib/property/authentication/secret-auth-property.ts
@@ -1,10 +1,10 @@
 import { Type } from '@sinclair/typebox';
-import { ValidationInputType } from '../../validators/types';
+import { ValidationInputType } from '../../validators';
 import { TPropertyValue } from '../input/common';
 import { PropertyType } from '../input/property-type';
 import { BaseBlockAuthSchema } from './common';
 
-export const SecretTextProperty = Type.Composite([
+export const SecretAuthProperty = Type.Composite([
   BaseBlockAuthSchema,
   TPropertyValue(
     Type.Object({
@@ -14,7 +14,7 @@ export const SecretTextProperty = Type.Composite([
   ),
 ]);
 
-export type SecretTextProperty<R extends boolean> =
+export type SecretAuthProperty<R extends boolean> =
   BaseBlockAuthSchema<string> &
     TPropertyValue<
       string,

--- a/packages/blocks/framework/src/lib/property/index.ts
+++ b/packages/blocks/framework/src/lib/property/index.ts
@@ -16,7 +16,7 @@ export {
   OAuth2PropertyValue,
   OAuth2Props,
 } from './authentication/oauth2-prop';
-export { SecretTextProperty } from './authentication/secret-text-property';
+export { SecretAuthProperty } from './authentication/secret-auth-property';
 export { Property } from './input';
 export { ArrayProperty, ArraySubProps } from './input/array-property';
 export { CheckboxProperty } from './input/checkbox-property';
@@ -41,7 +41,11 @@ export { JsonProperty } from './input/json-property';
 export { NumberProperty } from './input/number-property';
 export { ObjectProperty } from './input/object-property';
 export { PropertyType } from './input/property-type';
-export { LongTextProperty, ShortTextProperty } from './input/text-property';
+export {
+  LongTextProperty,
+  SecretTextProperty,
+  ShortTextProperty,
+} from './input/text-property';
 export const BlockProperty = Type.Union([InputProperty, BlockAuthProperty]);
 export type BlockProperty = InputProperty | BlockAuthProperty;
 

--- a/packages/blocks/framework/src/lib/property/input/index.ts
+++ b/packages/blocks/framework/src/lib/property/input/index.ts
@@ -18,7 +18,11 @@ import { MarkDownProperty } from './markdown-property';
 import { NumberProperty } from './number-property';
 import { ObjectProperty } from './object-property';
 import { PropertyType } from './property-type';
-import { LongTextProperty, ShortTextProperty } from './text-property';
+import {
+  LongTextProperty,
+  SecretTextProperty,
+  ShortTextProperty,
+} from './text-property';
 
 export const InputProperty = Type.Union([
   ShortTextProperty,
@@ -228,5 +232,17 @@ export const Property = {
       valueSchema: undefined,
       type: PropertyType.FILE,
     } as unknown as R extends true ? FileProperty<true> : FileProperty<false>;
+  },
+  SecretText<R extends boolean>(
+    request: Properties<SecretTextProperty<R>>,
+  ): R extends true ? SecretTextProperty<true> : SecretTextProperty<false> {
+    return {
+      ...request,
+      valueSchema: undefined,
+      type: PropertyType.SECRET_TEXT,
+      defaultValidators: [Validators.string],
+    } as unknown as R extends true
+      ? SecretTextProperty<true>
+      : SecretTextProperty<false>;
   },
 };

--- a/packages/blocks/framework/src/lib/property/input/text-property.ts
+++ b/packages/blocks/framework/src/lib/property/input/text-property.ts
@@ -25,3 +25,16 @@ export const LongTextProperty = Type.Composite([
 export type LongTextProperty<R extends boolean> = BasePropertySchema &
   SupportsAISchema &
   TPropertyValue<string, PropertyType.LONG_TEXT, ValidationInputType.STRING, R>;
+
+export const SecretTextProperty = Type.Composite([
+  BasePropertySchema,
+  TPropertyValue(Type.String(), PropertyType.SECRET_TEXT),
+]);
+
+export type SecretTextProperty<R extends boolean> = BasePropertySchema &
+  TPropertyValue<
+    string,
+    PropertyType.SECRET_TEXT,
+    ValidationInputType.STRING,
+    R
+  >;

--- a/packages/blocks/jira-cloud/src/auth.ts
+++ b/packages/blocks/jira-cloud/src/auth.ts
@@ -28,7 +28,7 @@ You can generate your API token from:
       required: true,
       validators: [Validators.email],
     }),
-    apiToken: BlockAuth.SecretText({
+    apiToken: Property.SecretText({
       displayName: 'API Token',
       description: 'Your Jira API Token',
       required: true,

--- a/packages/blocks/monday/src/index.ts
+++ b/packages/blocks/monday/src/index.ts
@@ -17,7 +17,7 @@ const markdown = `
 5.Select **API** tab.\n
 6.Copy your personal token`;
 
-export const mondayAuth = BlockAuth.SecretText({
+export const mondayAuth = BlockAuth.SecretAuth({
   displayName: 'API v2 Token',
   description: markdown,
   required: true,

--- a/packages/blocks/sftp/src/index.ts
+++ b/packages/blocks/sftp/src/index.ts
@@ -22,7 +22,7 @@ export const sftpAuth = BlockAuth.CustomAuth({
       description: 'The username of the SFTP server',
       required: true,
     }),
-    password: BlockAuth.SecretText({
+    password: Property.SecretText({
       displayName: 'Password',
       description: 'The password of the SFTP server',
       required: true,

--- a/packages/blocks/smtp/src/index.ts
+++ b/packages/blocks/smtp/src/index.ts
@@ -16,7 +16,7 @@ export const smtpAuth = BlockAuth.CustomAuth({
       displayName: 'Email',
       required: true,
     }),
-    password: BlockAuth.SecretText({
+    password: Property.SecretText({
       displayName: 'Password',
       required: true,
     }),

--- a/packages/blocks/snowflake/src/lib/common/custom-auth.ts
+++ b/packages/blocks/snowflake/src/lib/common/custom-auth.ts
@@ -28,7 +28,7 @@ export const customAuth = BlockAuth.CustomAuth({
       required: true,
       description: 'The login name for your Snowflake user.',
     }),
-    password: BlockAuth.SecretText({
+    password: Property.SecretText({
       displayName: 'Password',
       description: 'Password for the user.',
       required: true,

--- a/packages/blocks/ternary/src/lib/common/auth.ts
+++ b/packages/blocks/ternary/src/lib/common/auth.ts
@@ -8,7 +8,7 @@ Ternary API documentation:
 https://docs.ternary.app/reference/using-the-api`,
   required: true,
   props: {
-    apiKey: BlockAuth.SecretText({
+    apiKey: Property.SecretText({
       displayName: 'API key',
       defaultValue: '',
       required: true,

--- a/packages/openops/src/lib/aws/auth.ts
+++ b/packages/openops/src/lib/aws/auth.ts
@@ -163,11 +163,11 @@ export function getAwsAccountsSingleSelectDropdown() {
 
 export const amazonAuth = BlockAuth.CustomAuth({
   props: {
-    accessKeyId: BlockAuth.SecretText({
+    accessKeyId: Property.SecretText({
       displayName: 'Access Key ID',
       required: true,
     }),
-    secretAccessKey: BlockAuth.SecretText({
+    secretAccessKey: Property.SecretText({
       displayName: 'Secret Access Key',
       required: true,
     }),

--- a/packages/openops/src/lib/azure/auth.ts
+++ b/packages/openops/src/lib/azure/auth.ts
@@ -35,7 +35,7 @@ export const azureAuth = BlockAuth.CustomAuth({
       required: true,
       description: 'The Azure Application (client) ID.',
     }),
-    clientSecret: BlockAuth.SecretText({
+    clientSecret: Property.SecretText({
       displayName: 'Client Secret',
       required: true,
       description: 'The secret associated with the Azure Application.',

--- a/packages/openops/src/lib/google-cloud/auth.ts
+++ b/packages/openops/src/lib/google-cloud/auth.ts
@@ -1,4 +1,4 @@
-import { BlockAuth } from '@openops/blocks-framework';
+import { BlockAuth, Property } from '@openops/blocks-framework';
 import { SharedSystemProp, system } from '@openops/server-shared';
 import fs from 'fs/promises';
 import os from 'os';
@@ -23,7 +23,7 @@ You can also visit [OpenOps documentation](https://docs.openops.com/introduction
 export const googleCloudAuth = BlockAuth.CustomAuth({
   description: markdown,
   props: {
-    keyFileContent: BlockAuth.SecretText({
+    keyFileContent: Property.SecretText({
       displayName: 'Key file content',
       description: 'Provide the content of the service-account key file.',
       required: true,

--- a/packages/react-ui/src/app/features/connections/components/create-edit-connection-dialog-content.tsx
+++ b/packages/react-ui/src/app/features/connections/components/create-edit-connection-dialog-content.tsx
@@ -12,7 +12,7 @@ import {
   OAuth2Property,
   OAuth2Props,
   PropertyType,
-  SecretTextProperty,
+  SecretAuthProperty,
 } from '@openops/blocks-framework';
 import {
   Button,
@@ -251,7 +251,7 @@ const CreateEditConnectionDialogContent = ({
             ></FormField>
             {auth?.type === PropertyType.SECRET_TEXT && (
               <SecretTextConnectionSettings
-                authProperty={block.auth as SecretTextProperty<boolean>}
+                authProperty={block.auth as SecretAuthProperty<boolean>}
               />
             )}
             {auth?.type === PropertyType.BASIC_AUTH && (

--- a/packages/react-ui/src/app/features/connections/components/secret-text-connection-settings.tsx
+++ b/packages/react-ui/src/app/features/connections/components/secret-text-connection-settings.tsx
@@ -9,11 +9,11 @@ import { Static, Type } from '@sinclair/typebox';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { SecretTextProperty } from '@openops/blocks-framework';
+import { SecretAuthProperty } from '@openops/blocks-framework';
 import { UpsertSecretTextRequest } from '@openops/shared';
 
 type SecretTextConnectionSettingsProps = {
-  authProperty: SecretTextProperty<boolean>;
+  authProperty: SecretAuthProperty<boolean>;
 };
 
 const SecretTextConnectionSettings = React.memo(


### PR DESCRIPTION
Part of OPS-1879.

## Additional Notes
- When we add the provider to the authentication type, we must also add it to the secret property. This would mean that simple properties would have to have a provider.
- With this PR, we end up with two types
  - SecretTextProperty -> text property that is hidden in the UI
  - SecretAuthProperty -> secret-based authentication
