### PR TITLE
Revert "Adjut types to make step ids mandatory (#555)"

### DIFF
--- a/packages/react-ui/src/app/features/builder/data-selector/index.tsx
+++ b/packages/react-ui/src/app/features/builder/data-selector/index.tsx
@@ -57,7 +57,7 @@ const DataSelector = ({
     dataSelectorUtils.getAllStepsMentionsFromCurrentSelectedData,
   );
 
-  const stepIds: string[] = pathToTargetStep.map((p) => p.id);
+  const stepIds: string[] = pathToTargetStep.map((p) => p.id!);
 
   const [forceRender, setForceRerender] = useState(0); // for cache updates
   const [initialLoad, setInitialLoad] = useState(true);

--- a/packages/react-ui/src/app/features/builder/test-step/test-action-section.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-action-section.tsx
@@ -92,7 +92,7 @@ const TestActionSection = React.memo(
           setErrorMessage(undefined);
 
           if (useNewExternalTestData) {
-            stepTestOutputCache.setStepData(formValues.id, {
+            stepTestOutputCache.setStepData(formValues.id!, {
               output: formattedResponse,
               lastTestDate: dayjs().toISOString(),
             });
@@ -123,7 +123,7 @@ const TestActionSection = React.memo(
 
     const handleTest = () => {
       if (useNewExternalTestData) {
-        stepTestOutputCache.resetExpandedForStep(formValues.id);
+        stepTestOutputCache.resetExpandedForStep(formValues.id!);
       }
       if (
         selectedStep.type === ActionType.BLOCK &&
@@ -140,7 +140,7 @@ const TestActionSection = React.memo(
     const confirmRiskyStep = () => {
       setRiskyStepConfirmationMessage(null);
       if (useNewExternalTestData) {
-        stepTestOutputCache.resetExpandedForStep(formValues.id);
+        stepTestOutputCache.resetExpandedForStep(formValues.id!);
       }
       mutate();
     };

--- a/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
@@ -187,7 +187,7 @@ const TestTriggerSection = React.memo(
 
     function updateCurrentSelectedData(data: TriggerEvent) {
       if (useNewExternalTestData) {
-        stepTestOutputCache.setStepData(formValues.id, {
+        stepTestOutputCache.setStepData(formValues.id!, {
           output: formatUtils.formatStepInputOrOutput(data.payload),
           lastTestDate: dayjs().toISOString(),
         });

--- a/packages/react-ui/src/app/features/builder/update-flow-version.ts
+++ b/packages/react-ui/src/app/features/builder/update-flow-version.ts
@@ -32,7 +32,7 @@ export const updateFlowVersion = (
     );
 
     if (stepToClear) {
-      stepTestOutputCache.clearStep(stepToClear.id);
+      stepTestOutputCache.clearStep(stepToClear.id!);
     }
 
     if (operation.request.name === state.selectedStep) {

--- a/packages/server/api/test/helpers/mocks/index.ts
+++ b/packages/server/api/test/helpers/mocks/index.ts
@@ -222,7 +222,6 @@ export const createMockFlowVersion = (
   flowVersion?: Partial<FlowVersion>,
 ): FlowVersion => {
   const emptyTrigger = {
-    id: 'trigger',
     type: TriggerType.EMPTY,
     name: 'trigger',
     settings: {},
@@ -247,7 +246,6 @@ export const createMockFlowVersion = (
 export const createMockTrigger = (): Trigger => {
   return {
     type: TriggerType.EMPTY,
-    id: 'trigger',
     name: 'trigger',
     settings: {},
     valid: false,

--- a/packages/server/api/test/integration/ce/flow-template/flow-template.controller.test.ts
+++ b/packages/server/api/test/integration/ce/flow-template/flow-template.controller.test.ts
@@ -60,7 +60,6 @@ describe('Flow templates API', () => {
       organizationId,
       services: ['ECS', 'EC2'],
       template: {
-        id: 'test-template',
         type: TriggerType.EMPTY,
         name: 'trigger',
         settings: {},

--- a/packages/server/api/test/integration/ce/flows/consumer/flow-consume.test.ts
+++ b/packages/server/api/test/integration/ce/flows/consumer/flow-consume.test.ts
@@ -69,7 +69,6 @@ describe('flow execution', () => {
       updatedBy: mockUser.id,
       state: FlowVersionState.LOCKED,
       trigger: {
-        id: 'everyHourTrigger',
         type: TriggerType.BLOCK,
         settings: {
           blockName: '@openops/block-schedule',

--- a/packages/server/api/test/integration/ce/flows/flow.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow.test.ts
@@ -905,7 +905,6 @@ async function createMockFlowTemplate(
     organizationId: params.organizationId ?? openOpsId(),
     services: ['ECS', 'EC2'],
     template: params.template || {
-      id: 'test-template',
       type: TriggerType.EMPTY,
       name: 'trigger',
       settings: {},

--- a/packages/shared/src/lib/flows/actions/action.ts
+++ b/packages/shared/src/lib/flows/actions/action.ts
@@ -19,7 +19,8 @@ export enum RiskLevel {
 }
 
 const commonActionProps = {
-  id: Type.String({}),
+  // todo - make this mandatory after migration
+  id: Type.Optional(Type.String({})),
   name: Type.String({}),
   valid: Type.Boolean({}),
   displayName: Type.String({}),

--- a/packages/shared/src/lib/flows/triggers/trigger.ts
+++ b/packages/shared/src/lib/flows/triggers/trigger.ts
@@ -10,7 +10,7 @@ export enum TriggerType {
 }
 
 const commonProps = {
-  id: Type.String({}),
+  id: Type.Optional(Type.String()),
   name: Type.String({}),
   valid: Type.Boolean({}),
   displayName: Type.String({}),

--- a/packages/shared/test/flow/flow-helper.test.ts
+++ b/packages/shared/test/flow/flow-helper.test.ts
@@ -30,7 +30,6 @@ const flowVersionWithBranching: FlowVersion = {
   updatedBy: '',
   displayName: 'Standup Reminder',
   trigger: {
-    id: 'trigger',
     name: 'trigger',
     type: TriggerType.BLOCK,
     valid: true,
@@ -225,7 +224,6 @@ const emptyScheduleFlowVersion: FlowVersion = {
   displayName: 'Standup Reminder',
   updatedBy: '',
   trigger: {
-    id: 'trigger',
     name: 'trigger',
     type: TriggerType.BLOCK,
     valid: true,
@@ -274,7 +272,6 @@ describe('Flow Helper', () => {
       flowId: 'lod6JEdKyPlvrnErdnrGa',
       displayName: 'Standup Reminder',
       trigger: {
-        id: 'trigger',
         name: 'trigger',
         type: TriggerType.BLOCK,
         valid: true,
@@ -321,7 +318,6 @@ describe('Flow Helper', () => {
     const updateRequest: FlowOperationRequest = {
       type: FlowOperationType.UPDATE_ACTION,
       request: {
-        id: 'step_1',
         name: 'step_1',
         type: ActionType.BRANCH,
         displayName: 'Branch',
@@ -346,7 +342,6 @@ describe('Flow Helper', () => {
       updateRequest,
     );
     const expectedFlowTrigger: Trigger = {
-      id: 'trigger',
       name: 'trigger',
       type: TriggerType.BLOCK,
       valid: true,
@@ -362,7 +357,6 @@ describe('Flow Helper', () => {
         triggerName: 'cron_expression',
       },
       nextAction: {
-        id: 'step_1',
         displayName: 'Branch',
         name: 'step_1',
         valid: true,
@@ -491,7 +485,6 @@ describe('Flow Helper', () => {
     resultFlow = flowHelper.apply(resultFlow, addCodeActionOnFalse);
     resultFlow = flowHelper.apply(resultFlow, addCodeActionOnAfter);
     const expectedTrigger: Trigger = {
-      id: 'trigger',
       name: 'trigger',
       type: TriggerType.BLOCK,
       valid: true,
@@ -606,7 +599,6 @@ describe('Flow Helper', () => {
     resultFlow = flowHelper.apply(resultFlow, addCodeActionOnAfter);
 
     const expectedTrigger: Trigger = {
-      id: 'trigger',
       name: 'trigger',
       type: TriggerType.BLOCK,
       valid: true,
@@ -674,7 +666,6 @@ describe('Flow Helper', () => {
       flowId: 'lod6JEdKyPlvrnErdnrGa',
       displayName: 'Standup Reminder',
       trigger: {
-        id: 'trigger',
         name: 'trigger',
         type: TriggerType.BLOCK,
         valid: true,
@@ -718,7 +709,6 @@ describe('Flow Helper', () => {
       request: {
         parentStep: 'trigger',
         action: {
-          id: 'step_1',
           name: 'step_1',
           type: ActionType.BLOCK,
           displayName: 'Get',
@@ -786,7 +776,6 @@ describe('Flow Helper', () => {
     const updateRequest: FlowOperationRequest = {
       type: FlowOperationType.UPDATE_ACTION,
       request: {
-        id: 'step_1',
         name: 'step_1',
         type: ActionType.BRANCH,
         displayName: 'Branch',
@@ -834,7 +823,6 @@ it('Duplicate Flow With Branch', () => {
     updatedBy: '',
     displayName: 'Standup Reminder',
     trigger: {
-      id: 'trigger',
       name: 'trigger',
       type: TriggerType.BLOCK,
       valid: true,
@@ -1008,7 +996,6 @@ it('Duplicate Flow With Branch', () => {
         stepLocationRelativeToParent:
           StepLocationRelativeToParent.INSIDE_TRUE_BRANCH,
         action: {
-          id: 'step_2',
           type: ActionType.BLOCK,
           name: 'step_2',
           displayName: 'Send Message Webhook',
@@ -1062,7 +1049,6 @@ it('Duplicate Flow With Loops using Import', () => {
     updatedBy: '',
     displayName: 'Flow 1',
     trigger: {
-      id: 'trigger',
       name: 'trigger',
       type: TriggerType.BLOCK,
       valid: true,
@@ -1130,7 +1116,6 @@ it('Duplicate Flow With Loops using Import', () => {
       request: {
         parentStep: 'trigger',
         action: {
-          id: 'step_1',
           name: 'step_1',
           type: ActionType.LOOP_ON_ITEMS,
           valid: false,
@@ -1217,7 +1202,6 @@ it('Should remove connections', () => {
     description: '',
     displayName: 'Untitled',
     trigger: {
-      id: 'trigger',
       name: 'trigger',
       type: 'TRIGGER',
       valid: true,
@@ -1379,7 +1363,6 @@ describe('getImportOperations', () => {
   });
 
   const mockTrigger: Trigger = {
-    id: 'trigger',
     name: 'trigger',
     type: TriggerType.BLOCK,
     valid: true,
@@ -1690,7 +1673,6 @@ describe('Split', () => {
     updatedBy: '',
     displayName: 'Flow 1',
     trigger: {
-      id: 'trigger',
       name: 'trigger',
       type: TriggerType.EMPTY,
       valid: false,
@@ -1761,7 +1743,6 @@ describe('Split', () => {
       updatedBy: '',
       displayName: 'Flow 1',
       trigger: {
-        id: 'trigger',
         name: 'trigger',
         type: TriggerType.EMPTY,
         valid: false,
@@ -1778,7 +1759,6 @@ describe('Split', () => {
     const operation: FlowOperationRequest = {
       type: FlowOperationType.UPDATE_ACTION,
       request: {
-        id: flowVersionWithSplit.trigger.nextAction.id,
         name: flowVersionWithSplit.trigger.nextAction.name,
         type: ActionType.SPLIT,
         displayName: 'Split',
@@ -1817,7 +1797,6 @@ describe('Split', () => {
       updatedBy: '',
       displayName: 'Flow 1',
       trigger: {
-        id: 'trigger',
         name: 'trigger',
         type: TriggerType.EMPTY,
         valid: false,
@@ -1826,7 +1805,7 @@ describe('Split', () => {
         nextAction: {
           displayName: 'Split',
           name: 'step_1',
-          valid: false,
+          valid: true,
           type: 'SPLIT',
           settings: {
             options: [
@@ -1874,7 +1853,6 @@ describe('Split', () => {
         parentStep: 'trigger',
         stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
         action: {
-          id: 'step_1',
           type: ActionType.SPLIT,
           branches: [
             {
@@ -1935,7 +1913,6 @@ describe('Split', () => {
       displayName: 'Standup Reminder',
       updatedBy: '',
       trigger: {
-        id: 'trigger',
         name: 'trigger',
         type: TriggerType.BLOCK,
         valid: true,
@@ -1953,7 +1930,6 @@ describe('Split', () => {
         displayName: 'Cron Expression',
         nextAction: {
           displayName: 'Split',
-          id: 'step_1',
           name: 'step_1',
           valid: false,
           type: 'SPLIT',
@@ -2101,7 +2077,6 @@ describe('Split', () => {
       ]);
 
       const mockCodeAction2: Action = {
-        id: 'step_30',
         type: ActionType.CODE,
         settings: {
           input: {},
@@ -2141,7 +2116,6 @@ describe('Split', () => {
                 packageJson: '{}',
               },
             },
-            id: 'step_30',
             name: 'step_30',
             valid: true,
             displayName: 'Code',
@@ -2321,7 +2295,6 @@ describe('Split', () => {
       const secondOperation: FlowOperationRequest = {
         type: FlowOperationType.UPDATE_ACTION,
         request: {
-          id: flowVersionWithSplit.trigger.nextAction.id,
           name: flowVersionWithSplit.trigger.nextAction.name,
           type: ActionType.SPLIT,
           displayName: 'Split',
@@ -2382,7 +2355,6 @@ describe('Split', () => {
       const secondOperation: FlowOperationRequest = {
         type: FlowOperationType.UPDATE_ACTION,
         request: {
-          id: flowVersionWithSplit.trigger.nextAction.id,
           name: flowVersionWithSplit.trigger.nextAction.name,
           type: ActionType.SPLIT,
           displayName: 'Split',
@@ -2424,7 +2396,6 @@ describe('Split', () => {
         updatedBy: '',
         displayName: 'Flow 1',
         trigger: {
-          id: 'trigger',
           name: 'trigger',
           type: TriggerType.EMPTY,
           valid: false,
@@ -2615,7 +2586,7 @@ describe('Split', () => {
           parentStep: string;
           action: Action;
         };
-        const expectedRequest = expectedOperation.request as unknown as {
+        const expectedRequest = expectedOperation.request as {
           parentStep: string;
           action: Action;
         };
@@ -2637,7 +2608,6 @@ describe('Split', () => {
         flowId: 'AUQ1poMROcB8JEhEtBFMl',
         displayName: 'Untitled',
         trigger: {
-          id: 'trigger',
           displayName: 'Select Trigger',
           name: 'trigger',
           valid: false,
@@ -2698,7 +2668,6 @@ describe('Split', () => {
           request: {
             parentStep: 'step_1',
             action: {
-              id: 'step_3',
               name: 'step_3',
               type: ActionType.BRANCH,
               valid: false,
@@ -2733,7 +2702,6 @@ describe('bulkAddActions', () => {
     description: '',
     displayName: 'Untitled',
     trigger: {
-      id: 'trigger',
       name: 'trigger',
       type: TriggerType.EMPTY,
       valid: false,
@@ -3301,7 +3269,6 @@ describe('duplicateStep', () => {
     valid: true,
     state: FlowVersionState.DRAFT,
     trigger: {
-      id: 'trigger',
       name: 'trigger',
       type: TriggerType.EMPTY,
       valid: true,


### PR DESCRIPTION
This reverts commit 5fdf8b74aea4f912c8e538625c1928f82dab3215.

<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-1698

## Additional Notes
Issue when creating templates:
![image](https://github.com/user-attachments/assets/f51055ee-02bf-457b-b790-cacfd339376b)

