### PR TITLE
Add authProviderKey to create/edit connection default values to include it in request payloads

### DIFF
--- a/packages/react-ui/src/app/features/connections/lib/connections-utils.ts
+++ b/packages/react-ui/src/app/features/connections/lib/connections-utils.ts
@@ -112,6 +112,7 @@ export const createDefaultValues = (
         id: existingConnection?.id,
         name: suggestedConnectionName,
         blockName: block.name,
+        authProviderKey: block.auth?.authProviderKey,
         projectId,
         type: AppConnectionType.SECRET_TEXT,
         value: existingConnection
@@ -126,6 +127,7 @@ export const createDefaultValues = (
         id: existingConnection?.id,
         name: suggestedConnectionName,
         blockName: block.name,
+        authProviderKey: block.auth?.authProviderKey,
         projectId,
         type: AppConnectionType.BASIC_AUTH,
         value: existingConnection
@@ -141,6 +143,7 @@ export const createDefaultValues = (
         id: existingConnection?.id,
         name: suggestedConnectionName,
         blockName: block.name,
+        authProviderKey: block.auth?.authProviderKey,
         projectId,
         type: AppConnectionType.CUSTOM_AUTH,
         value: existingConnection
@@ -155,6 +158,7 @@ export const createDefaultValues = (
         id: existingConnection?.id,
         name: suggestedConnectionName,
         blockName: block.name,
+        authProviderKey: block.auth?.authProviderKey,
         projectId,
         type: AppConnectionType.CLOUD_OAUTH2,
         value: existingConnection


### PR DESCRIPTION
Fixes OPS-1915.

Since [PR 744](https://github.com/openops-cloud/openops/pull/744) `POST /api/v1/app-connections` accepts an optional `authProviderKey`.  The Patch endpoint also accepts it.

I tested these usecases:
- create new connection from /connections screen
- update existing connection from /connections screen
- create new connection from step settings connection picker
- update existing connection from  step settings connection picker (Reconnect)