### PR TITLE
Fix step execution error when output is undefined

### DIFF
--- a/packages/server/api/src/app/flows/step-test-output/flow-step-test-output.service.ts
+++ b/packages/server/api/src/app/flows/step-test-output/flow-step-test-output.service.ts
@@ -88,14 +88,14 @@ export const flowStepTestOutputService = {
 async function decompressOutput(
   record: FlowStepTestOutput,
 ): Promise<FlowStepTestOutput> {
-  const x = record.output as Buffer;
-  if (x.length === 0) {
+  const outputBuffer = record.output as Buffer;
+  if (outputBuffer.length === 0) {
     return {
       ...record,
       output: undefined,
     };
   }
-  const decryptedOutput = await decompressAndDecrypt(record.output as Buffer);
+  const decryptedOutput = await decompressAndDecrypt(outputBuffer);
 
   return {
     ...record,


### PR DESCRIPTION

Fixes OPS-1925.

## Tested cases
- Return undefined;
- Return an empty string;
- Return 0;
- Return null;

