### PR TITLE
Disable calls to MCP tools if no tool is selected

### DIFF
--- a/packages/server/api/src/app/ai/chat/ai-mcp-chat.controller.ts
+++ b/packages/server/api/src/app/ai/chat/ai-mcp-chat.controller.ts
@@ -236,13 +236,20 @@ async function streamMessages(
   tools?: ToolSet,
 ): Promise<void> {
   let stepCount = 0;
+
+  let toolChoice: 'auto' | 'none' | 'required' = 'auto';
+  if (!tools || Object.keys(tools).length === 0) {
+    toolChoice = 'none';
+    systemPrompt += `\n\nMCP tools are not available in this chat. Do not claim access or simulate responses from them under any circumstance.`;
+  }
+
   const result = streamText({
     model: languageModel,
     system: systemPrompt,
     messages,
     ...aiConfig.modelSettings,
     tools,
-    toolChoice: 'auto',
+    toolChoice,
     maxRetries: 1,
     maxSteps: MAX_RECURSION_DEPTH,
     async onStepFinish({ finishReason }): Promise<void> {


### PR DESCRIPTION

Fixes OPS-1859.

## Additional Notes
- I couldn't simulate this behaviour in a typical use case
To simulate this behaviour, I needed to pass the prompt informing that Analytics was available. But then the MCP initialisation failed, and no tools were selected.

Before:
<img width="388" alt="Screenshot 2025-06-09 at 16 57 09" src="https://github.com/user-attachments/assets/a5672236-94ef-4c9c-adaa-b3035b272f63" />

After:
<img width="401" alt="Screenshot 2025-06-09 at 16 52 46" src="https://github.com/user-attachments/assets/059efafd-28c0-4234-b156-d2cfff364548" />
