### PR TITLE
Skip chat deletion if step is missing blockName or actionName

### DIFF
--- a/packages/react-ui/src/app/features/builder/update-flow-version.ts
+++ b/packages/react-ui/src/app/features/builder/update-flow-version.ts
@@ -83,11 +83,17 @@ async function deleteChatRequest(flowVersion: FlowVersion, stepName: string) {
   try {
     const stepDetails = flowHelper.getStep(flowVersion, stepName);
     const blockName = stepDetails?.settings?.blockName;
+    const actionName = stepDetails?.settings?.actionName;
+
+    if (!blockName || !actionName) {
+      return;
+    }
+
     const chat = await aiChatApi.open(
       flowVersion.flowId,
       blockName,
       stepName,
-      stepDetails?.settings.actionName,
+      actionName,
     );
     await aiChatApi.delete(chat.chatId);
   } catch (err) {


### PR DESCRIPTION
Fixes OPS-1926.

I also increased the test coverage for FlowOperationType.DELETE_ACTION.

```
 PASS   react-ui  packages/react-ui/src/app/features/builder/tests/update-flow-version.test.ts
  updateFlowVersion
    ....
    deleteChatRequest
      ✓ should call deleteChatRequest when deleting selected step with block and action names (4 ms)
      ✓ should not call deleteChatRequest when deleting non-selected step (2 ms)
      ✓ should not call deleteChatRequest when step has no block name (3 ms)
      ✓ should not call deleteChatRequest when step has no action name (3 ms)
      ✓ should handle errors in deleteChatRequest gracefully (4 ms)
      ✓ should handle errors in aiChatApi.delete gracefully (4 ms)

```
https://github.com/user-attachments/assets/58de3b22-836d-4b51-89cd-0e95ea7cbd30
