### PR TITLE
Enable connections provider

### DIFF
--- a/packages/server/api/src/app/flags/dev-flags.service.ts
+++ b/packages/server/api/src/app/flags/dev-flags.service.ts
@@ -26,7 +26,7 @@ async function getAll(): Promise<Flag[]> {
     },
     {
       id: FlagId.USE_CONNECTIONS_PROVIDER,
-      value: false,
+      value: true,
       created,
       updated,
     },


### PR DESCRIPTION
Part of OPS-1890

Enable so we can test on internal environments