### PR TITLE
Update icon and color for "Step contains sample data" indicator

### DIFF
--- a/packages/react-ui/src/app/features/builder/data-selector/data-selector-node-content.tsx
+++ b/packages/react-ui/src/app/features/builder/data-selector/data-selector-node-content.tsx
@@ -1,6 +1,6 @@
 import { BlockIcon, Button, TooltipWrapper } from '@openops/components/ui';
 import { t } from 'i18next';
-import { ChevronDown, ChevronUp, CircleAlert } from 'lucide-react';
+import { ChevronDown, ChevronUp, Info } from 'lucide-react';
 
 import { flowHelper } from '@openops/shared';
 
@@ -101,8 +101,8 @@ const DataSelectorNodeContent = ({
             tooltipText={t('Step contains sample data')}
             tooltipPlacement="bottom"
           >
-            <CircleAlert
-              className="min-w-4 w-4 h-4 text-warning-200"
+            <Info
+              className="min-w-4 w-4 h-4 text-blueAccent"
               role="img"
               aria-label={t('Step contains sample data')}
             />


### PR DESCRIPTION
Fixes OPS-1933.

![Screenshot 2025-06-10 at 10 59 02](https://github.com/user-attachments/assets/c2abbd67-0caf-4227-8ed3-126e21bda0af)
![Screenshot 2025-06-10 at 10 59 08](https://github.com/user-attachments/assets/2f22d98f-77ff-45cc-b3c6-21ceb371b537)
