### PR TITLE
Add AI Streaming-specific setting for nginx.standard config

### DIFF
--- a/nginx.standard.conf
+++ b/nginx.standard.conf
@@ -77,6 +77,11 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
             proxy_set_header Host $host;
+
+            # --- AI Streaming-specific settings ---
+            proxy_buffering off;
+            proxy_cache off;
+            chunked_transfer_encoding on;
         }
 
         location ~* \.(css|js|jpg|jpeg|png|gif|ico|svg)$ {


### PR DESCRIPTION
Fixes CI-51.

It uses the same settings as the [`nginx.gateway`](https://github.com/openops-cloud/openops/commit/7f5f8ecdc87b4e31320c54d9b9010e6e31843143) configuration.


Demo on Openops test environment:
https://www.loom.com/share/ae81b67b4bb941fc81f232a0776b444a

