### PR TITLE
Fix extra call when doing test step / trigger

### DIFF
--- a/packages/react-ui/src/app/features/builder/data-selector/data-selector-cache.ts
+++ b/packages/react-ui/src/app/features/builder/data-selector/data-selector-cache.ts
@@ -1,4 +1,8 @@
+import { QueryKeys } from '@/app/constants/query-keys';
+import { formatUtils } from '@/app/lib/utils';
 import { StepOutputWithData } from '@openops/shared';
+import { QueryClient } from '@tanstack/react-query';
+import dayjs from 'dayjs';
 
 /**
  * StepTestOutputCache manages test output and expanded state for steps in the Data Selector.
@@ -69,3 +73,28 @@ export class StepTestOutputCache {
 }
 
 export const stepTestOutputCache = new StepTestOutputCache();
+
+/**
+ * Utility to set step test output in both the cache and react-query client.
+ */
+export function setStepOutputCache({
+  stepId,
+  flowVersionId,
+  output,
+  queryClient,
+}: {
+  stepId: string;
+  flowVersionId: string;
+  output: unknown;
+  queryClient: QueryClient;
+}) {
+  const stepTestOutput: StepOutputWithData = {
+    output: formatUtils.formatStepInputOrOutput(output),
+    lastTestDate: dayjs().toISOString(),
+  };
+  stepTestOutputCache.setStepData(stepId, stepTestOutput);
+  queryClient.setQueryData(
+    [QueryKeys.stepTestOutput, flowVersionId, stepId],
+    stepTestOutput,
+  );
+}

--- a/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
@@ -133,8 +133,6 @@ const TestTriggerSection = React.memo(
           const lastResult = results[results.length - 1];
           updateSelectedData(lastResult);
 
-          // setStepOutputCache handles output and cache
-
           await triggerEventsApi.deleteWebhookSimulation(flowId);
         }
       },


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-1957

Put data from WS directly in the cache, we don't need an extra HTTP call
