### PR TITLE
Fail the CI ^C a required cache is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           path: node_modules
           key: node-modules-cache-${{ hashFiles('package-lock.json', '.npmrc') }}
+          fail-on-cache-miss: true
       - name: Restore NX cache
         uses: actions/cache@v4
         with:
@@ -105,6 +106,7 @@ jobs:
         with:
           path: node_modules
           key: node-modules-cache-${{ hashFiles('package-lock.json', '.npmrc') }}
+          fail-on-cache-miss: true
       - name: Restore NX cache
         uses: actions/cache@v4
         with:
@@ -137,6 +139,7 @@ jobs:
         with:
           path: node_modules
           key: node-modules-cache-${{ hashFiles('package-lock.json', '.npmrc') }}
+          fail-on-cache-miss: true
       - name: Restore NX cache
         uses: actions/cache@v4
         with:
@@ -175,6 +178,7 @@ jobs:
         with:
           path: dist
           key: dist-${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
There's an [ongoing issue](https://github.com/actions/cache/issues/1621) with the GitHub cache action.

Rolling back to the last working version. We also need to have a clear failure when the cache is failing, so I added the required flag where needed.