### PR TITLE
Fix resetting sample data on step updates

### DIFF
--- a/packages/react-ui/src/app/features/builder/test-step/index.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/index.tsx
@@ -11,10 +11,17 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@openops/components/ui';
-import { ActionType, FlagId, TriggerType } from '@openops/shared';
+import {
+  Action,
+  ActionType,
+  FlagId,
+  Trigger,
+  TriggerType,
+} from '@openops/shared';
 import { t } from 'i18next';
 import { Info } from 'lucide-react';
 import React from 'react';
+import { useFormContext } from 'react-hook-form';
 import { TestActionSection } from './test-action-section';
 import { TestTriggerSection } from './test-trigger-section';
 
@@ -32,8 +39,9 @@ enum TabListEnum {
 
 const TestStepContainer = React.memo(
   ({ flowVersionId, isSaving, type, flowId }: TestStepContainerProps) => {
+    const form = useFormContext<Action | Trigger>();
     const useSaveSelectedStepSampleData =
-      stepTestOutputHooks.useSaveSelectedStepSampleData();
+      stepTestOutputHooks.useSaveSelectedStepSampleData(form);
 
     const { data: showSampleData } = flagsHooks.useFlag<boolean>(
       FlagId.SHOW_SAMPLE_DATA,

--- a/packages/react-ui/src/app/features/builder/test-step/step-test-output-hooks.ts
+++ b/packages/react-ui/src/app/features/builder/test-step/step-test-output-hooks.ts
@@ -44,10 +44,6 @@ export const stepTestOutputHooks = {
     return stepTestOutputHooks.useStepTestOutput(flowVersionId, stepId!);
   },
   useSaveSelectedStepSampleData(form: UseFormReturn<Action | Trigger>) {
-    const { selectedStep } = useStepSettingsContext();
-    const [applyOperation] = useBuilderStateContext((state) => [
-      state.applyOperation,
-    ]);
     const { data: sampleDataSizeLimit } = flagsHooks.useFlag<number>(
       FlagId.SAMPLE_DATA_SIZE_LIMIT_KB,
     );
@@ -65,39 +61,12 @@ export const stepTestOutputHooks = {
           });
           return;
         }
-        const isTrigger = flowHelper.isTrigger(selectedStep.type);
-        const updatedStep = {
-          ...selectedStep,
-          settings: {
-            ...selectedStep.settings,
-            inputUiInfo: {
-              ...selectedStep.settings.inputUiInfo,
-              sampleData: sampleData,
-            },
-          },
-        };
-
-        const createOperation = () => {
-          if (isTrigger) {
-            return {
-              type: FlowOperationType.UPDATE_TRIGGER as const,
-              request: updatedStep as Trigger,
-            };
-          } else {
-            return {
-              type: FlowOperationType.UPDATE_ACTION as const,
-              request: updatedStep as Action,
-            };
-          }
-        };
-
-        applyOperation(createOperation(), () => toast(UNSAVED_CHANGES_TOAST));
 
         form.setValue('settings.inputUiInfo.sampleData', sampleData, {
           shouldValidate: true,
         });
       },
-      [applyOperation, selectedStep, sampleDataSizeLimit, form],
+      [sampleDataSizeLimit, form],
     );
   },
 };

--- a/packages/react-ui/src/app/features/builder/test-step/step-test-output-hooks.ts
+++ b/packages/react-ui/src/app/features/builder/test-step/step-test-output-hooks.ts
@@ -43,7 +43,7 @@ export const stepTestOutputHooks = {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return stepTestOutputHooks.useStepTestOutput(flowVersionId, stepId!);
   },
-  useSaveSelectedStepSampleData() {
+  useSaveSelectedStepSampleData(form: UseFormReturn<Action | Trigger>) {
     const { selectedStep } = useStepSettingsContext();
     const [applyOperation] = useBuilderStateContext((state) => [
       state.applyOperation,
@@ -92,8 +92,12 @@ export const stepTestOutputHooks = {
         };
 
         applyOperation(createOperation(), () => toast(UNSAVED_CHANGES_TOAST));
+
+        form.setValue('settings.inputUiInfo.sampleData', sampleData, {
+          shouldValidate: true,
+        });
       },
-      [applyOperation, selectedStep, sampleDataSizeLimit],
+      [applyOperation, selectedStep, sampleDataSizeLimit, form],
     );
   },
 };

--- a/packages/react-ui/src/app/features/builder/test-step/step-test-output-hooks.ts
+++ b/packages/react-ui/src/app/features/builder/test-step/step-test-output-hooks.ts
@@ -1,15 +1,7 @@
 import { flagsHooks } from '@/app/common/hooks/flags-hooks';
 import { QueryKeys } from '@/app/constants/query-keys';
-import { useBuilderStateContext } from '@/app/features/builder/builder-hooks';
-import { useStepSettingsContext } from '@/app/features/builder/step-settings/step-settings-context';
-import { toast, UNSAVED_CHANGES_TOAST } from '@openops/components/ui';
-import {
-  Action,
-  FlagId,
-  flowHelper,
-  FlowOperationType,
-  Trigger,
-} from '@openops/shared';
+import { toast } from '@openops/components/ui';
+import { Action, FlagId, Trigger } from '@openops/shared';
 import { useQuery } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { useCallback } from 'react';

--- a/packages/react-ui/src/app/features/builder/tests/step-test-output-hooks.test.tsx
+++ b/packages/react-ui/src/app/features/builder/tests/step-test-output-hooks.test.tsx
@@ -1,4 +1,4 @@
-import { FlowOperationType, flowHelper } from '@openops/shared';
+import { flowHelper } from '@openops/shared';
 import { act, renderHook } from '@testing-library/react';
 import { flagsHooks } from '../../../common/hooks/flags-hooks';
 import { useBuilderStateContext } from '../builder-hooks';
@@ -54,6 +54,11 @@ const mockStep = {
   valid: true,
 };
 
+const mockSetValue = jest.fn();
+const mockForm = {
+  setValue: mockSetValue,
+} as any;
+
 describe('stepTestOutputHooks.useSaveSelectedStepSampleData', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -71,7 +76,7 @@ describe('stepTestOutputHooks.useSaveSelectedStepSampleData', () => {
     mockFlowHelper.isTrigger.mockReturnValue(false);
 
     const { result } = renderHook(() =>
-      stepTestOutputHooks.useSaveSelectedStepSampleData(),
+      stepTestOutputHooks.useSaveSelectedStepSampleData(mockForm),
     );
 
     expect(typeof result.current).toBe('function');
@@ -82,23 +87,17 @@ describe('stepTestOutputHooks.useSaveSelectedStepSampleData', () => {
     mockFlowHelper.isTrigger.mockReturnValue(false);
 
     const { result } = renderHook(() =>
-      stepTestOutputHooks.useSaveSelectedStepSampleData(),
+      stepTestOutputHooks.useSaveSelectedStepSampleData(mockForm),
     );
 
     act(() => {
       result.current(testSampleData);
     });
 
-    expect(mockFlowHelper.isTrigger).toHaveBeenCalledWith(mockStep.type);
-    expect(mockApplyOperation).toHaveBeenCalledWith(
-      {
-        type: FlowOperationType.UPDATE_ACTION,
-        request: expect.objectContaining({
-          id: 'step-123',
-          name: 'test-step',
-        }),
-      },
-      expect.any(Function),
+    expect(mockSetValue).toHaveBeenCalledWith(
+      'settings.inputUiInfo.sampleData',
+      testSampleData,
+      { shouldValidate: true },
     );
   });
 
@@ -107,23 +106,17 @@ describe('stepTestOutputHooks.useSaveSelectedStepSampleData', () => {
     mockFlowHelper.isTrigger.mockReturnValue(true);
 
     const { result } = renderHook(() =>
-      stepTestOutputHooks.useSaveSelectedStepSampleData(),
+      stepTestOutputHooks.useSaveSelectedStepSampleData(mockForm),
     );
 
     act(() => {
       result.current(testSampleData);
     });
 
-    expect(mockFlowHelper.isTrigger).toHaveBeenCalledWith(mockStep.type);
-    expect(mockApplyOperation).toHaveBeenCalledWith(
-      {
-        type: FlowOperationType.UPDATE_TRIGGER,
-        request: expect.objectContaining({
-          id: 'step-123',
-          name: 'test-step',
-        }),
-      },
-      expect.any(Function),
+    expect(mockSetValue).toHaveBeenCalledWith(
+      'settings.inputUiInfo.sampleData',
+      testSampleData,
+      { shouldValidate: true },
     );
   });
 
@@ -132,18 +125,17 @@ describe('stepTestOutputHooks.useSaveSelectedStepSampleData', () => {
     mockFlowHelper.isTrigger.mockReturnValue(false);
 
     const { result } = renderHook(() =>
-      stepTestOutputHooks.useSaveSelectedStepSampleData(),
+      stepTestOutputHooks.useSaveSelectedStepSampleData(mockForm),
     );
 
     act(() => {
       result.current(testSampleData);
     });
 
-    const applyOperationCall = mockApplyOperation.mock.calls[0];
-    const operationRequest = applyOperationCall[0];
-
-    expect(operationRequest.request.settings.inputUiInfo.sampleData).toEqual(
+    expect(mockSetValue).toHaveBeenCalledWith(
+      'settings.inputUiInfo.sampleData',
       testSampleData,
+      { shouldValidate: true },
     );
   });
 
@@ -151,28 +143,28 @@ describe('stepTestOutputHooks.useSaveSelectedStepSampleData', () => {
     mockFlowHelper.isTrigger.mockReturnValue(false);
 
     const { result } = renderHook(() =>
-      stepTestOutputHooks.useSaveSelectedStepSampleData(),
+      stepTestOutputHooks.useSaveSelectedStepSampleData(mockForm),
     );
 
     act(() => {
       result.current(null);
     });
 
-    const applyOperationCall = mockApplyOperation.mock.calls[0];
-    const operationRequest = applyOperationCall[0];
-
-    expect(operationRequest.request.settings.inputUiInfo.sampleData).toBeNull();
+    expect(mockSetValue).toHaveBeenCalledWith(
+      'settings.inputUiInfo.sampleData',
+      null,
+      { shouldValidate: true },
+    );
 
     act(() => {
       result.current(undefined);
     });
 
-    const secondCall = mockApplyOperation.mock.calls[1];
-    const secondRequest = secondCall[0];
-
-    expect(
-      secondRequest.request.settings.inputUiInfo.sampleData,
-    ).toBeUndefined();
+    expect(mockSetValue).toHaveBeenCalledWith(
+      'settings.inputUiInfo.sampleData',
+      undefined,
+      { shouldValidate: true },
+    );
   });
 });
 


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-1994

## Additional Notes
Because the data is saved without updating the main settings form, every update the the step resulted in losing the sample data. We simply need to update the form and it will go through the same update process as the rest of the form updates.

https://github.com/openops-cloud/openops/blob/9d849da8a4a019f74ec3845ea04270ee2fe92a45/packages/react-ui/src/app/features/builder/step-settings/index.tsx#L204
