### PR TITLE
Exclude Verdaccio install for blocks generated with create-block CLI

### DIFF
--- a/packages/cli/src/lib/commands/create-block.ts
+++ b/packages/cli/src/lib/commands/create-block.ts
@@ -57,7 +57,6 @@ const nxGenerateNodeLibrary = async (
     `--directory=packages/blocks/${blockName}`,
     `--name=blocks-${blockName}`,
     `--importPath=${packageName}`,
-    '--publishable',
     '--buildable',
     '--projectNameAndRootFormat=as-provided',
     '--strict',


### PR DESCRIPTION
Part of OPS-1931.

![Screenshot 2025-06-20 at 16 54 11](https://github.com/user-attachments/assets/d6119928-59ad-4156-8daf-8e3a9848775f)
