### PR TITLE
Handle both files and directories when cleaning up unused files during package creation

### DIFF
--- a/packages/cli/src/lib/commands/create-block.ts
+++ b/packages/cli/src/lib/commands/create-block.ts
@@ -1,8 +1,10 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { readdir, rmdir, stat, unlink, writeFile } from 'fs/promises';
+import { readdir, stat, unlink, writeFile } from 'fs/promises';
 import inquirer from 'inquirer';
 import assert from 'node:assert';
+import { rm } from 'node:fs/promises';
+import nodePath from 'node:path';
 import { findBlockSourceDirectory } from '../utils/block-utils';
 import { exec } from '../utils/exec';
 import {
@@ -72,7 +74,7 @@ const removeUnusedFiles = async (blockName: string) => {
   const path = `packages/blocks/${blockName}/src/lib/`;
   const files = await readdir(path);
   for (const file of files) {
-    const fullPath = path.join(path, file);
+    const fullPath = nodePath.join(path, file);
     const stats = await stat(fullPath);
 
     if (stats.isDirectory()) {


### PR DESCRIPTION
Part of OPS-1931.

Say one creates a block called `@openops/acme` with the create block cli on the local machine, then discards the git changes. A later attempt to create another block with the same name would fail

```
Error: EPERM: operation not permitted, unlink 'packages/blocks/goodname/src/lib/common'
    at async unlink (node:internal/fs/promises:1066:10) {
  errno: -1,
  code: 'EPERM',
  syscall: 'unlink',
  path: 'packages/blocks/goodname/src/lib/common'
}```