### PR TITLE
Add CLI prompts to add boilerplate code for Authentication and opinionated folder structure

### DIFF
--- a/packages/cli/src/lib/commands/create-block.ts
+++ b/packages/cli/src/lib/commands/create-block.ts
@@ -55,7 +55,7 @@ export const createBlock = async (
   if (createOpinionatedStructure) {
     console.log(
       chalk.blue(
-        `📁 Opinionated folder structure created with sample actions, tests, and service layer`,
+        `📁 Opinionated folder structure created with sample actions and custom API call action`,
       ),
     );
   }

--- a/packages/cli/src/lib/commands/create-block.ts
+++ b/packages/cli/src/lib/commands/create-block.ts
@@ -42,8 +42,6 @@ export const createBlock = async (
   authType: string,
   createOpinionatedStructure: boolean,
 ) => {
-  await validateBlockName(blockName);
-  await validatePackageName(packageName);
   await checkIfBlockExists(blockName);
   await nxGenerateNodeLibrary(blockName, packageName);
   await setupGeneratedLibrary(blockName, authType, createOpinionatedStructure);
@@ -71,13 +69,7 @@ export const createBlockCommand = new Command('create')
         type: 'input',
         name: 'blockName',
         message: 'Enter the block name:',
-        validate: (input: string) => {
-          const blockNamePattern = /^[A-Za-z0-9-]+$/;
-          if (!blockNamePattern.test(input)) {
-            return 'Block names can only contain lowercase letters, numbers, and hyphens.';
-          }
-          return true;
-        },
+        validate: validateBlockName,
       },
       {
         type: 'input',
@@ -85,13 +77,7 @@ export const createBlockCommand = new Command('create')
         message: 'Enter the package name:',
         default: (answers: any) => `@openops/block-${answers.blockName}`,
         when: (answers: any) => answers.blockName !== undefined,
-        validate: (input: string) => {
-          const packageNamePattern = /^(?:@[a-zA-Z0-9-]+\/)?[a-zA-Z0-9-]+$/;
-          if (!packageNamePattern.test(input)) {
-            return 'Package names can only contain lowercase letters, numbers, and hyphens.';
-          }
-          return true;
-        },
+        validate: validatePackageName,
       },
       {
         type: 'list',

--- a/packages/cli/src/lib/commands/create-block.ts
+++ b/packages/cli/src/lib/commands/create-block.ts
@@ -1,179 +1,66 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { readdir, unlink, writeFile } from 'fs/promises';
 import inquirer from 'inquirer';
-import assert from 'node:assert';
-import { findBlockSourceDirectory } from '../utils/block-utils';
-import { exec } from '../utils/exec';
 import {
-  readJestConfig,
-  readPackageEslint,
-  readProjectJson,
-  writeJestConfig,
-  writePackageEslint,
-  writeProjectJson,
-} from '../utils/files';
+  nxGenerateNodeLibrary,
+  removeUnusedFiles,
+  updateEslintFile,
+  updateJestConfigFile,
+  updateProjectJsonConfig,
+} from '../utils/block-generators';
+import {
+  generateAuthFile,
+  generateIndexTsFile,
+  generateOpinionatedStructure,
+} from '../utils/block-templates';
+import {
+  checkIfBlockExists,
+  validateBlockName,
+  validatePackageName,
+} from '../utils/block-validators';
 
-const validateBlockName = async (blockName: string) => {
-  console.log(chalk.yellow('Validating block name....'));
-  const blockNamePattern = /^[A-Za-z0-9-]+$/;
-  if (!blockNamePattern.test(blockName)) {
-    console.log(
-      chalk.red(
-        `🚨 Invalid block name: ${blockName}. Block names can only contain lowercase letters, numbers, and hyphens.`,
-      ),
-    );
-    process.exit(1);
-  }
-};
-
-const validatePackageName = async (packageName: string) => {
-  console.log(chalk.yellow('Validating package name....'));
-  const packageNamePattern = /^(?:@[a-zA-Z0-9-]+\/)?[a-zA-Z0-9-]+$/;
-  if (!packageNamePattern.test(packageName)) {
-    console.log(
-      chalk.red(
-        `🚨 Invalid package name: ${packageName}. Package names can only contain lowercase letters, numbers, and hyphens.`,
-      ),
-    );
-    process.exit(1);
-  }
-};
-
-const checkIfBlockExists = async (blockName: string) => {
-  const path = await findBlockSourceDirectory(blockName);
-  if (path) {
-    console.log(chalk.red(`🚨 Block already exists at ${path}`));
-    process.exit(1);
-  }
-};
-
-const nxGenerateNodeLibrary = async (
+const setupGeneratedLibrary = async (
   blockName: string,
-  packageName: string,
+  authType: string,
+  createOpinionatedStructure: boolean,
 ) => {
-  const nxGenerateCommand = [
-    `npx nx generate @nx/node:library`,
-    `--directory=packages/blocks/${blockName}`,
-    `--name=blocks-${blockName}`,
-    `--importPath=${packageName}`,
-    '--buildable',
-    '--projectNameAndRootFormat=as-provided',
-    '--strict',
-    '--unitTestRunner=jest',
-  ].join(' ');
-
-  console.log(chalk.blue(`🛠️ Executing nx command: ${nxGenerateCommand}`));
-
-  await exec(nxGenerateCommand);
-};
-
-const removeUnusedFiles = async (blockName: string) => {
-  const path = `packages/blocks/${blockName}/src/lib/`;
-  const files = await readdir(path);
-  for (const file of files) {
-    await unlink(path + file);
-  }
-};
-function capitalizeFirstLetter(str: string): string {
-  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
-}
-const generateIndexTsFile = async (blockName: string) => {
-  const blockNameCamelCase = blockName
-    .split('-')
-    .map((s, i) => {
-      if (i === 0) {
-        return s;
-      }
-
-      return s[0].toUpperCase() + s.substring(1);
-    })
-    .join('');
-
-  const indexTemplate = `
-    import { createBlock, BlockAuth } from "@openops/blocks-framework";
-    export const ${blockNameCamelCase} = createBlock({
-      displayName: "${capitalizeFirstLetter(blockName)}",
-      auth: BlockAuth.None(),
-      minimumSupportedRelease: '0.20.0',
-      logoUrl: "https://static.openops.com/blocks/${blockName}.png",
-      authors: [],
-      actions: [],
-      triggers: [],
-    });
-    `;
-
-  await writeFile(`packages/blocks/${blockName}/src/index.ts`, indexTemplate);
-};
-const updateProjectJsonConfig = async (blockName: string) => {
-  const projectJson = await readProjectJson(`packages/blocks/${blockName}`);
-
-  assert(
-    projectJson.targets?.build?.options,
-    '[updateProjectJsonConfig] targets.build.options is required',
-  );
-
-  projectJson.targets.build.options.buildableProjectDepsInPackageJsonType =
-    'dependencies';
-  projectJson.targets.build.options.updateBuildableProjectDepsInPackageJson =
-    true;
-
-  const lintFilePatterns = projectJson.targets.lint?.options?.lintFilePatterns;
-
-  if (lintFilePatterns) {
-    const patternIndex = lintFilePatterns.findIndex((item) =>
-      item.endsWith('package.json'),
-    );
-    if (patternIndex !== -1) lintFilePatterns?.splice(patternIndex, 1);
-  } else {
-    projectJson.targets.lint = {
-      executor: '@nx/eslint:lint',
-      outputs: ['{options.outputFile}'],
-    };
-  }
-
-  await writeProjectJson(`packages/blocks/${blockName}`, projectJson);
-};
-const updateEslintFile = async (blockName: string) => {
-  const eslintFile = await readPackageEslint(`packages/blocks/${blockName}`);
-  eslintFile.overrides.splice(
-    eslintFile.overrides.findIndex((rule: any) => rule.files[0] == '*.json'),
-    1,
-  );
-  await writePackageEslint(`packages/blocks/${blockName}`, eslintFile);
-};
-
-const updateJestConfigFile = async (blockName: string) => {
-  const jestConfigBuffer = await readJestConfig(`packages/blocks/${blockName}`);
-  const jestConfig = jestConfigBuffer.toString();
-  const updatedJestConfig = jestConfig.replace(
-    /preset:\s*['"].*jest\.preset\.js['"],?/,
-    (match) => `${match}\n  setupFiles: ['../../../jest.env.js'],`,
-  );
-
-  await writeJestConfig(`packages/blocks/${blockName}`, updatedJestConfig);
-};
-
-const setupGeneratedLibrary = async (blockName: string) => {
   await removeUnusedFiles(blockName);
-  await generateIndexTsFile(blockName);
+  await generateIndexTsFile(blockName, authType);
+  await generateAuthFile(blockName, authType);
   await updateProjectJsonConfig(blockName);
   await updateEslintFile(blockName);
   await updateJestConfigFile(blockName);
+
+  if (createOpinionatedStructure) {
+    await generateOpinionatedStructure(blockName, authType);
+  }
 };
 
-export const createBlock = async (blockName: string, packageName: string) => {
+export const createBlock = async (
+  blockName: string,
+  packageName: string,
+  authType: string,
+  createOpinionatedStructure: boolean,
+) => {
   await validateBlockName(blockName);
   await validatePackageName(packageName);
   await checkIfBlockExists(blockName);
   await nxGenerateNodeLibrary(blockName, packageName);
-  await setupGeneratedLibrary(blockName);
+  await setupGeneratedLibrary(blockName, authType, createOpinionatedStructure);
   console.log(chalk.green('✨  Done!'));
   console.log(
     chalk.yellow(
       `The block has been generated at: packages/blocks/${blockName}`,
     ),
   );
+
+  if (createOpinionatedStructure) {
+    console.log(
+      chalk.blue(
+        `📁 Opinionated folder structure created with sample actions, tests, and service layer`,
+      ),
+    );
+  }
 };
 
 export const createBlockCommand = new Command('create')
@@ -184,6 +71,13 @@ export const createBlockCommand = new Command('create')
         type: 'input',
         name: 'blockName',
         message: 'Enter the block name:',
+        validate: (input: string) => {
+          const blockNamePattern = /^[A-Za-z0-9-]+$/;
+          if (!blockNamePattern.test(input)) {
+            return 'Block names can only contain lowercase letters, numbers, and hyphens.';
+          }
+          return true;
+        },
       },
       {
         type: 'input',
@@ -191,9 +85,51 @@ export const createBlockCommand = new Command('create')
         message: 'Enter the package name:',
         default: (answers: any) => `@openops/block-${answers.blockName}`,
         when: (answers: any) => answers.blockName !== undefined,
+        validate: (input: string) => {
+          const packageNamePattern = /^(?:@[a-zA-Z0-9-]+\/)?[a-zA-Z0-9-]+$/;
+          if (!packageNamePattern.test(input)) {
+            return 'Package names can only contain lowercase letters, numbers, and hyphens.';
+          }
+          return true;
+        },
+      },
+      {
+        type: 'list',
+        name: 'authType',
+        message: 'Select authentication type:',
+        choices: [
+          { name: 'None (No authentication)', value: 'none' },
+          { name: 'Secret (API Key)', value: 'secret' },
+          { name: 'Custom (Custom properties)', value: 'custom' },
+          { name: 'OAuth2 (OAuth2 flow)', value: 'oauth2' },
+        ],
+        default: 'none',
+        pageSize: 4,
+        loop: false,
+      },
+      {
+        type: 'list',
+        name: 'createOpinionatedStructure',
+        message:
+          'Create opinionated folder structure with stubs for actions, tests, and common service layer?',
+        choices: [
+          {
+            name: 'Yes - Create full folder structure with stubs',
+            value: true,
+          },
+          { name: 'No - Create minimal structure only', value: false },
+        ],
+        default: true,
+        pageSize: 2,
+        loop: false,
       },
     ];
 
     const answers = await inquirer.prompt(questions);
-    createBlock(answers.blockName, answers.packageName);
+    createBlock(
+      answers.blockName,
+      answers.packageName,
+      answers.authType,
+      answers.createOpinionatedStructure,
+    );
   });

--- a/packages/cli/src/lib/utils/block-generators.ts
+++ b/packages/cli/src/lib/utils/block-generators.ts
@@ -71,10 +71,12 @@ export const updateProjectJsonConfig = async (blockName: string) => {
 
 export const updateEslintFile = async (blockName: string) => {
   const eslintFile = await readPackageEslint(`packages/blocks/${blockName}`);
-  eslintFile.overrides.splice(
-    eslintFile.overrides.findIndex((rule: any) => rule.files[0] == '*.json'),
-    1,
+  const ruleIndex = eslintFile.overrides.findIndex(
+    (rule: any) => rule.files[0] == '*.json',
   );
+  if (ruleIndex !== -1) {
+    eslintFile.overrides.splice(ruleIndex, 1);
+  }
   await writePackageEslint(`packages/blocks/${blockName}`, eslintFile);
 };
 

--- a/packages/cli/src/lib/utils/block-generators.ts
+++ b/packages/cli/src/lib/utils/block-generators.ts
@@ -1,0 +1,90 @@
+import chalk from 'chalk';
+import { readdir, unlink, writeFile } from 'fs/promises';
+import { exec } from '../utils/exec';
+import {
+  readJestConfig,
+  readPackageEslint,
+  readProjectJson,
+  writeJestConfig,
+  writePackageEslint,
+  writeProjectJson,
+} from '../utils/files';
+
+export const nxGenerateNodeLibrary = async (
+  blockName: string,
+  packageName: string,
+) => {
+  const nxGenerateCommand = [
+    `npx nx generate @nx/node:library`,
+    `--directory=packages/blocks/${blockName}`,
+    `--name=blocks-${blockName}`,
+    `--importPath=${packageName}`,
+    '--buildable',
+    '--projectNameAndRootFormat=as-provided',
+    '--strict',
+    '--unitTestRunner=jest',
+  ].join(' ');
+
+  console.log(chalk.blue(`🛠️ Executing nx command: ${nxGenerateCommand}`));
+
+  await exec(nxGenerateCommand);
+};
+
+export const removeUnusedFiles = async (blockName: string) => {
+  const path = `packages/blocks/${blockName}/src/lib/`;
+  const files = await readdir(path);
+  for (const file of files) {
+    await unlink(path + file);
+  }
+};
+
+export const updateProjectJsonConfig = async (blockName: string) => {
+  const projectJson = await readProjectJson(`packages/blocks/${blockName}`);
+
+  if (!projectJson.targets?.build?.options) {
+    throw new Error(
+      '[updateProjectJsonConfig] targets.build.options is required',
+    );
+  }
+
+  projectJson.targets.build.options.buildableProjectDepsInPackageJsonType =
+    'dependencies';
+  projectJson.targets.build.options.updateBuildableProjectDepsInPackageJson =
+    true;
+
+  const lintFilePatterns = projectJson.targets.lint?.options?.lintFilePatterns;
+
+  if (lintFilePatterns) {
+    const patternIndex = lintFilePatterns.findIndex((item) =>
+      item.endsWith('package.json'),
+    );
+    if (patternIndex !== -1) lintFilePatterns?.splice(patternIndex, 1);
+  } else {
+    projectJson.targets.lint = {
+      executor: '@nx/eslint:lint',
+      outputs: ['{options.outputFile}'],
+    };
+  }
+
+  await writeProjectJson(`packages/blocks/${blockName}`, projectJson);
+};
+
+export const updateEslintFile = async (blockName: string) => {
+  const eslintFile = await readPackageEslint(`packages/blocks/${blockName}`);
+  eslintFile.overrides.splice(
+    eslintFile.overrides.findIndex((rule: any) => rule.files[0] == '*.json'),
+    1,
+  );
+  await writePackageEslint(`packages/blocks/${blockName}`, eslintFile);
+};
+
+export const updateJestConfigFile = async (blockName: string) => {
+  const jestConfigBuffer = await readJestConfig(`packages/blocks/${blockName}`);
+  const jestConfig = jestConfigBuffer.toString();
+  const updatedJestConfig = jestConfig.replace(
+    /preset:\s*['"].*jest\.preset\.js['"],?/,
+    (match) => `${match}\n  setupFiles: ['../../../jest.env.js'],`,
+  );
+
+  await writeJestConfig(`packages/blocks/${blockName}`, updatedJestConfig);
+};

--- a/packages/cli/src/lib/utils/block-templates.ts
+++ b/packages/cli/src/lib/utils/block-templates.ts
@@ -66,29 +66,13 @@ export const generateAuthFile = async (blockName: string, authType: string) => {
     case 'secret':
       authTemplate = `import { BlockAuth } from '@openops/blocks-framework';
 
-const markdown = \`
-To get your ${capitalizeFirstLetter(blockName)} API key:
-
-1. Log into your ${capitalizeFirstLetter(blockName)} account
-2. Navigate to Settings > API Keys
-3. Select "Create New API Key"
-4. Enter a name and description for your key
-5. Copy the API key displayed (it will not be shown again)
-
-> ⚠️ WARNING: The API key will not be shown again after creation.
-
-For more information, visit the [${capitalizeFirstLetter(
-        blockName,
-      )} API documentation](https://docs.${blockName}.com/api).
-\`;
-
 export const ${blockNameCamelCase}Auth = BlockAuth.SecretAuth({
   displayName: 'API Key',
   required: true,
   authProviderKey: '${blockName}',
   authProviderDisplayName: '${capitalizeFirstLetter(blockName)}',
   authProviderLogoUrl: 'https://static.openops.com/blocks/${blockName}.png',
-  description: markdown,
+  description: '',
 });
 `;
       break;
@@ -169,7 +153,8 @@ export const generateOpinionatedStructure = async (
   await mkdir(`packages/blocks/${blockName}/test/actions`, { recursive: true });
   await mkdir(`packages/blocks/${blockName}/test/common`, { recursive: true });
 
-  const actionTemplate = `import { createAction, Property } from '@openops/blocks-framework';
+  const actionTemplate = `
+import { createAction, Property } from '@openops/blocks-framework';
 ${
   authType !== 'none'
     ? `import { ${blockNameCamelCase}Auth } from '../auth';`
@@ -285,7 +270,8 @@ export class ${capitalizeFirstLetter(blockName)}Service {
     serviceTemplate,
   );
 
-  const actionTestTemplate = `import { sampleAction } from '../../src/lib/actions/sample-action';
+  const actionTestTemplate = `
+import { sampleAction } from '../../src/lib/actions/sample-action';
 
 describe('sampleAction', () => {
   it('should process input correctly', async () => {
@@ -341,9 +327,10 @@ describe('sampleAction', () => {
     actionTestTemplate,
   );
 
-  const serviceTestTemplate = `import { ${
-    authType !== 'none' ? `OAuth2PropertyValue, ` : ''
-  }Property } from '@openops/blocks-framework';
+  const serviceTestTemplate = `
+import { ${
+    authType !== 'none' ? `OAuth2PropertyValue ` : ''
+  } } from '@openops/blocks-framework';
 import axios from 'axios';
 import { ${capitalizeFirstLetter(
     blockName,

--- a/packages/cli/src/lib/utils/block-templates.ts
+++ b/packages/cli/src/lib/utils/block-templates.ts
@@ -46,7 +46,7 @@ export const generateIndexTsFile = async (
 
 export const generateAuthFile = async (blockName: string, authType: string) => {
   if (authType === 'none') {
-    return; // No auth file needed for none
+    return;
   }
 
   const blockNameCamelCase = blockName
@@ -138,7 +138,6 @@ export const ${blockNameCamelCase}Auth = BlockAuth.OAuth2({
       break;
   }
 
-  // Create lib directory if it doesn't exist
   const { mkdir } = await import('fs/promises');
   await mkdir(`packages/blocks/${blockName}/src/lib`, { recursive: true });
   await writeFile(`packages/blocks/${blockName}/src/lib/auth.ts`, authTemplate);
@@ -161,7 +160,6 @@ export const generateOpinionatedStructure = async (
 
   const { mkdir } = await import('fs/promises');
 
-  // Create directory structure
   await mkdir(`packages/blocks/${blockName}/src/lib/actions`, {
     recursive: true,
   });
@@ -171,7 +169,6 @@ export const generateOpinionatedStructure = async (
   await mkdir(`packages/blocks/${blockName}/test/actions`, { recursive: true });
   await mkdir(`packages/blocks/${blockName}/test/common`, { recursive: true });
 
-  // Generate sample action
   const actionTemplate = `import { createAction, Property } from '@openops/blocks-framework';
 ${
   authType !== 'none'
@@ -208,7 +205,6 @@ export const sampleAction = createAction({
     actionTemplate,
   );
 
-  // Generate common service
   const serviceTemplate = `import { ${
     authType !== 'none' ? `OAuth2PropertyValue, ` : ''
   }Property } from '@openops/blocks-framework';
@@ -289,7 +285,6 @@ export class ${capitalizeFirstLetter(blockName)}Service {
     serviceTemplate,
   );
 
-  // Generate action test
   const actionTestTemplate = `import { sampleAction } from '../../src/lib/actions/sample-action';
 
 describe('sampleAction', () => {
@@ -346,7 +341,6 @@ describe('sampleAction', () => {
     actionTestTemplate,
   );
 
-  // Generate service test
   const serviceTestTemplate = `import { ${
     authType !== 'none' ? `OAuth2PropertyValue, ` : ''
   }Property } from '@openops/blocks-framework';
@@ -450,7 +444,6 @@ describe('${capitalizeFirstLetter(blockName)}Service', () => {
     serviceTestTemplate,
   );
 
-  // Update index.ts to include the sample action
   const updatedIndexTemplate = `import { createBlock, BlockAuth } from "@openops/blocks-framework";
 ${
   authType !== 'none'

--- a/packages/cli/src/lib/utils/block-templates.ts
+++ b/packages/cli/src/lib/utils/block-templates.ts
@@ -1,7 +1,20 @@
+import { exec } from 'child_process';
 import { writeFile } from 'fs/promises';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
 
 export function capitalizeFirstLetter(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+}
+
+async function formatBlockFolder(blockName: string): Promise<void> {
+  try {
+    const blockPath = `packages/blocks/${blockName}`;
+    await execAsync(`npx prettier --write "${blockPath}/**/*.{ts,js,json}"`);
+  } catch (error) {
+    console.warn(`⚠️ Failed to format ${blockName} block:`, error);
+  }
 }
 
 export const generateIndexTsFile = async (
@@ -127,6 +140,7 @@ export const ${blockNameCamelCase}Auth = BlockAuth.OAuth2({
 
   const { mkdir } = await import('fs/promises');
   await mkdir(`packages/blocks/${blockName}/src/lib`, { recursive: true });
+
   await writeFile(`packages/blocks/${blockName}/src/lib/auth.ts`, authTemplate);
 };
 
@@ -461,4 +475,6 @@ export const ${blockNameCamelCase} = createBlock({
     `packages/blocks/${blockName}/src/index.ts`,
     updatedIndexTemplate,
   );
+
+  await formatBlockFolder(blockName);
 };

--- a/packages/cli/src/lib/utils/block-templates.ts
+++ b/packages/cli/src/lib/utils/block-templates.ts
@@ -28,18 +28,18 @@ export const generateIndexTsFile = async (
   }
 
   const indexTemplate = `
-    import { createBlock, BlockAuth } from "@openops/blocks-framework";
-    ${authImport}
-    export const ${blockNameCamelCase} = createBlock({
-      displayName: "${capitalizeFirstLetter(blockName)}",
-      auth: ${authConfig},
-      minimumSupportedRelease: '0.20.0',
-      logoUrl: "https://static.openops.com/blocks/${blockName}.png",
-      authors: [],
-      actions: [],
-      triggers: [],
-    });
-    `;
+  import { createBlock, BlockAuth } from "@openops/blocks-framework";
+  ${authImport}
+  export const ${blockNameCamelCase} = createBlock({
+    displayName: "${capitalizeFirstLetter(blockName)}",
+    auth: ${authConfig},
+    minimumSupportedRelease: '0.20.0',
+    logoUrl: "https://static.openops.com/blocks/${blockName}.png",
+    authors: [],
+    actions: [],
+    triggers: [],
+  });
+  `;
 
   await writeFile(`packages/blocks/${blockName}/src/index.ts`, indexTemplate);
 };
@@ -64,7 +64,8 @@ export const generateAuthFile = async (blockName: string, authType: string) => {
 
   switch (authType) {
     case 'secret':
-      authTemplate = `import { BlockAuth } from '@openops/blocks-framework';
+      authTemplate = `
+import { BlockAuth } from '@openops/blocks-framework';
 
 export const ${blockNameCamelCase}Auth = BlockAuth.SecretAuth({
   displayName: 'API Key',
@@ -78,7 +79,8 @@ export const ${blockNameCamelCase}Auth = BlockAuth.SecretAuth({
       break;
 
     case 'custom':
-      authTemplate = `import { BlockAuth, Property } from '@openops/blocks-framework';
+      authTemplate = `
+import { BlockAuth, Property } from '@openops/blocks-framework';
 
 export const ${blockNameCamelCase}Auth = BlockAuth.CustomAuth({
   authProviderKey: '${blockName}',
@@ -106,7 +108,8 @@ export const ${blockNameCamelCase}Auth = BlockAuth.CustomAuth({
       break;
 
     case 'oauth2':
-      authTemplate = `import { BlockAuth } from '@openops/blocks-framework';
+      authTemplate = `
+import { BlockAuth } from '@openops/blocks-framework';
 
 export const ${blockNameCamelCase}Auth = BlockAuth.OAuth2({
   authProviderKey: '${blockName}',
@@ -190,7 +193,8 @@ export const sampleAction = createAction({
     actionTemplate,
   );
 
-  const serviceTemplate = `import { ${
+  const serviceTemplate = `
+import { ${
     authType !== 'none' ? 'OAuth2PropertyValue' : ''
   } } from '@openops/blocks-framework';
 import axios, { AxiosRequestConfig } from 'axios';
@@ -431,7 +435,8 @@ describe('${capitalizeFirstLetter(blockName)}Service', () => {
     serviceTestTemplate,
   );
 
-  const updatedIndexTemplate = `import { createBlock } from "@openops/blocks-framework";
+  const updatedIndexTemplate = `
+import { createBlock } from "@openops/blocks-framework";
 ${
   authType !== 'none'
     ? `import { ${blockNameCamelCase}Auth } from './lib/auth';`

--- a/packages/cli/src/lib/utils/block-templates.ts
+++ b/packages/cli/src/lib/utils/block-templates.ts
@@ -1,0 +1,471 @@
+import { writeFile } from 'fs/promises';
+
+export function capitalizeFirstLetter(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+}
+
+export const generateIndexTsFile = async (
+  blockName: string,
+  authType: string,
+) => {
+  const blockNameCamelCase = blockName
+    .split('-')
+    .map((s, i) => {
+      if (i === 0) {
+        return s;
+      }
+
+      return s[0].toUpperCase() + s.substring(1);
+    })
+    .join('');
+
+  let authImport = '';
+  let authConfig = 'BlockAuth.None()';
+
+  if (authType !== 'none') {
+    authImport = `import { ${blockNameCamelCase}Auth } from './lib/auth';`;
+    authConfig = `${blockNameCamelCase}Auth`;
+  }
+
+  const indexTemplate = `
+    import { createBlock, BlockAuth } from "@openops/blocks-framework";
+    ${authImport}
+    export const ${blockNameCamelCase} = createBlock({
+      displayName: "${capitalizeFirstLetter(blockName)}",
+      auth: ${authConfig},
+      minimumSupportedRelease: '0.20.0',
+      logoUrl: "https://static.openops.com/blocks/${blockName}.png",
+      authors: [],
+      actions: [],
+      triggers: [],
+    });
+    `;
+
+  await writeFile(`packages/blocks/${blockName}/src/index.ts`, indexTemplate);
+};
+
+export const generateAuthFile = async (blockName: string, authType: string) => {
+  if (authType === 'none') {
+    return; // No auth file needed for none
+  }
+
+  const blockNameCamelCase = blockName
+    .split('-')
+    .map((s, i) => {
+      if (i === 0) {
+        return s;
+      }
+
+      return s[0].toUpperCase() + s.substring(1);
+    })
+    .join('');
+
+  let authTemplate = '';
+
+  switch (authType) {
+    case 'secret':
+      authTemplate = `import { BlockAuth } from '@openops/blocks-framework';
+
+const markdown = \`
+To get your ${capitalizeFirstLetter(blockName)} API key:
+
+1. Log into your ${capitalizeFirstLetter(blockName)} account
+2. Navigate to Settings > API Keys
+3. Select "Create New API Key"
+4. Enter a name and description for your key
+5. Copy the API key displayed (it will not be shown again)
+
+> ⚠️ WARNING: The API key will not be shown again after creation.
+
+For more information, visit the [${capitalizeFirstLetter(
+        blockName,
+      )} API documentation](https://docs.${blockName}.com/api).
+\`;
+
+export const ${blockNameCamelCase}Auth = BlockAuth.SecretAuth({
+  displayName: 'API Key',
+  required: true,
+  authProviderKey: '${blockName}',
+  authProviderDisplayName: '${capitalizeFirstLetter(blockName)}',
+  authProviderLogoUrl: 'https://static.openops.com/blocks/${blockName}.png',
+  description: markdown,
+});
+`;
+      break;
+
+    case 'custom':
+      authTemplate = `import { BlockAuth, Property } from '@openops/blocks-framework';
+
+export const ${blockNameCamelCase}Auth = BlockAuth.CustomAuth({
+  authProviderKey: '${blockName}',
+  authProviderDisplayName: '${capitalizeFirstLetter(blockName)}',
+  authProviderLogoUrl: 'https://static.openops.com/blocks/${blockName}.png',
+  description: 'Configure your ${capitalizeFirstLetter(blockName)} connection',
+  required: true,
+  props: {
+    apiKey: Property.SecretText({
+      displayName: 'API Key',
+      required: true,
+    }),
+    baseUrl: Property.ShortText({
+      displayName: 'Base URL',
+      description: 'The base URL for ${capitalizeFirstLetter(blockName)} API',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    // Add validation logic here
+    return { valid: true };
+  },
+});
+`;
+      break;
+
+    case 'oauth2':
+      authTemplate = `import { BlockAuth } from '@openops/blocks-framework';
+
+export const ${blockNameCamelCase}Auth = BlockAuth.OAuth2({
+  authProviderKey: '${blockName}',
+  authProviderDisplayName: '${capitalizeFirstLetter(blockName)}',
+  authProviderLogoUrl: 'https://static.openops.com/blocks/${blockName}.png',
+  description: 'Connect to ${capitalizeFirstLetter(blockName)} using OAuth2',
+  required: true,
+  authUrl: 'https://${blockName}.com/oauth/authorize',
+  tokenUrl: 'https://${blockName}.com/oauth/token',
+  scope: ['read', 'write'],
+});
+`;
+      break;
+  }
+
+  // Create lib directory if it doesn't exist
+  const { mkdir } = await import('fs/promises');
+  await mkdir(`packages/blocks/${blockName}/src/lib`, { recursive: true });
+  await writeFile(`packages/blocks/${blockName}/src/lib/auth.ts`, authTemplate);
+};
+
+export const generateOpinionatedStructure = async (
+  blockName: string,
+  authType: string,
+) => {
+  const blockNameCamelCase = blockName
+    .split('-')
+    .map((s, i) => {
+      if (i === 0) {
+        return s;
+      }
+
+      return s[0].toUpperCase() + s.substring(1);
+    })
+    .join('');
+
+  const { mkdir } = await import('fs/promises');
+
+  // Create directory structure
+  await mkdir(`packages/blocks/${blockName}/src/lib/actions`, {
+    recursive: true,
+  });
+  await mkdir(`packages/blocks/${blockName}/src/lib/common`, {
+    recursive: true,
+  });
+  await mkdir(`packages/blocks/${blockName}/test/actions`, { recursive: true });
+  await mkdir(`packages/blocks/${blockName}/test/common`, { recursive: true });
+
+  // Generate sample action
+  const actionTemplate = `import { createAction, Property } from '@openops/blocks-framework';
+${
+  authType !== 'none'
+    ? `import { ${blockNameCamelCase}Auth } from '../auth';`
+    : ''
+}
+
+export const sampleAction = createAction({
+  name: 'sample_action',
+  displayName: 'Sample Action',
+  description: 'A sample action for ${capitalizeFirstLetter(blockName)}',
+  ${authType !== 'none' ? `auth: ${blockNameCamelCase}Auth,` : ''}
+  props: {
+    input: Property.ShortText({
+      displayName: 'Input',
+      description: 'Sample input field',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { input } = context.propsValue;
+    
+    // Add your action logic here
+    return {
+      success: true,
+      message: \`Processed: \${input}\`,
+    };
+  },
+});
+`;
+
+  await writeFile(
+    `packages/blocks/${blockName}/src/lib/actions/sample-action.ts`,
+    actionTemplate,
+  );
+
+  // Generate common service
+  const serviceTemplate = `import { ${
+    authType !== 'none' ? `OAuth2PropertyValue, ` : ''
+  }Property } from '@openops/blocks-framework';
+
+export interface ${capitalizeFirstLetter(blockName)}ServiceConfig {
+  ${authType !== 'none' ? `auth: OAuth2PropertyValue;` : ''}
+  baseUrl?: string;
+}
+
+export class ${capitalizeFirstLetter(blockName)}Service {
+  private config: ${capitalizeFirstLetter(blockName)}ServiceConfig;
+
+  constructor(config: ${capitalizeFirstLetter(blockName)}ServiceConfig) {
+    this.config = config;
+  }
+
+  async makeRequest(endpoint: string, options: any = {}) {
+    // Add your HTTP client logic here
+    // Example using fetch or axios
+    const url = \`\${this.config.baseUrl || 'https://api.${blockName}.com'}\${endpoint}\`;
+    
+    // Add authentication headers based on auth type
+    const headers = {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    };
+
+    // Add auth headers based on type
+    ${
+      authType === 'secret'
+        ? `if (this.config.auth?.access_token) {
+      headers['Authorization'] = \`Bearer \${this.config.auth.access_token}\`;
+    }`
+        : ''
+    }
+    ${
+      authType === 'oauth2'
+        ? `if (this.config.auth?.access_token) {
+      headers['Authorization'] = \`Bearer \${this.config.auth.access_token}\`;
+    }`
+        : ''
+    }
+    ${
+      authType === 'custom'
+        ? `if (this.config.auth?.access_token) {
+      headers['Authorization'] = \`Bearer \${this.config.auth.access_token}\`;
+    }`
+        : ''
+    }
+
+    // Make the request
+    const response = await fetch(url, {
+      method: options.method || 'GET',
+      headers,
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    if (!response.ok) {
+      throw new Error(\`HTTP \${response.status}: \${response.statusText}\`);
+    }
+
+    return response.json();
+  }
+
+  // Add your service methods here
+  async getData() {
+    return this.makeRequest('/data');
+  }
+
+  async createData(data: any) {
+    return this.makeRequest('/data', {
+      method: 'POST',
+      body: data,
+    });
+  }
+}
+`;
+
+  await writeFile(
+    `packages/blocks/${blockName}/src/lib/common/${blockName}-service.ts`,
+    serviceTemplate,
+  );
+
+  // Generate action test
+  const actionTestTemplate = `import { sampleAction } from '../../src/lib/actions/sample-action';
+
+describe('sampleAction', () => {
+  it('should process input correctly', async () => {
+    const mockContext = {
+      propsValue: {
+        input: 'test input',
+      },
+      ${
+        authType !== 'none'
+          ? `auth: {
+        access_token: 'mock-access-token',
+        data: {},
+      },`
+          : ''
+      }
+    };
+
+    const result = await sampleAction.run(mockContext as any);
+
+    expect(result).toEqual({
+      success: true,
+      message: 'Processed: test input',
+    });
+  });
+
+  it('should handle empty input', async () => {
+    const mockContext = {
+      propsValue: {
+        input: '',
+      },
+      ${
+        authType !== 'none'
+          ? `auth: {
+        access_token: 'mock-access-token',
+        data: {},
+      },`
+          : ''
+      }
+    };
+
+    const result = await sampleAction.run(mockContext as any);
+
+    expect(result).toEqual({
+      success: true,
+      message: 'Processed: ',
+    });
+  });
+});
+`;
+
+  await writeFile(
+    `packages/blocks/${blockName}/test/actions/sample-action.test.ts`,
+    actionTestTemplate,
+  );
+
+  // Generate service test
+  const serviceTestTemplate = `import { ${
+    authType !== 'none' ? `OAuth2PropertyValue, ` : ''
+  }Property } from '@openops/blocks-framework';
+import { ${capitalizeFirstLetter(
+    blockName,
+  )}Service } from '../../src/lib/common/${blockName}-service';
+
+describe('${capitalizeFirstLetter(blockName)}Service', () => {
+  let service: ${capitalizeFirstLetter(blockName)}Service;
+
+  beforeEach(() => {
+    ${
+      authType !== 'none'
+        ? `const mockAuth: OAuth2PropertyValue = {
+      access_token: 'mock-access-token',
+      data: {},
+    };
+
+    service = new ${capitalizeFirstLetter(blockName)}Service({
+      auth: mockAuth,
+      baseUrl: 'https://api.test.com',
+    });`
+        : `service = new ${capitalizeFirstLetter(blockName)}Service({
+      baseUrl: 'https://api.test.com',
+    });`
+    }
+  });
+
+  it('should be instantiated correctly', () => {
+    expect(service).toBeInstanceOf(${capitalizeFirstLetter(blockName)}Service);
+  });
+
+  it('should make requests with correct configuration', async () => {
+    // Mock fetch or your HTTP client
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: 'test' }),
+    });
+
+    await service.getData();
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.test.com/data',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          ${
+            authType !== 'none'
+              ? `'Authorization': 'Bearer mock-access-token',`
+              : ''
+          }
+        }),
+      })
+    );
+  });
+
+  ${
+    authType !== 'none'
+      ? `it('should handle requests without auth token', async () => {
+    const serviceWithoutAuth = new ${capitalizeFirstLetter(blockName)}Service({
+      auth: { data: {} } as OAuth2PropertyValue,
+      baseUrl: 'https://api.test.com',
+    });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: 'test' }),
+    });
+
+    await serviceWithoutAuth.getData();
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.test.com/data',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      })
+    );
+  });`
+      : ''
+  }
+});
+`;
+
+  await writeFile(
+    `packages/blocks/${blockName}/test/common/${blockName}-service.test.ts`,
+    serviceTestTemplate,
+  );
+
+  // Update index.ts to include the sample action
+  const updatedIndexTemplate = `import { createBlock, BlockAuth } from "@openops/blocks-framework";
+${
+  authType !== 'none'
+    ? `import { ${blockNameCamelCase}Auth } from './lib/auth';`
+    : ''
+}
+import { sampleAction } from './lib/actions/sample-action';
+
+export const ${blockNameCamelCase} = createBlock({
+  displayName: "${capitalizeFirstLetter(blockName)}",
+  auth: ${
+    authType !== 'none' ? `${blockNameCamelCase}Auth` : 'BlockAuth.None()'
+  },
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: "https://static.openops.com/blocks/${blockName}.png",
+  authors: [],
+  actions: [sampleAction],
+  triggers: [],
+});
+`;
+
+  await writeFile(
+    `packages/blocks/${blockName}/src/index.ts`,
+    updatedIndexTemplate,
+  );
+};

--- a/packages/cli/src/lib/utils/block-templates.ts
+++ b/packages/cli/src/lib/utils/block-templates.ts
@@ -206,8 +206,8 @@ export const sampleAction = createAction({
   );
 
   const serviceTemplate = `import { ${
-    authType !== 'none' ? `OAuth2PropertyValue, ` : ''
-  }Property } from '@openops/blocks-framework';
+    authType !== 'none' ? 'OAuth2PropertyValue' : ''
+  } } from '@openops/blocks-framework';
 import axios, { AxiosRequestConfig } from 'axios';
 
 export interface ${capitalizeFirstLetter(blockName)}ServiceConfig {
@@ -444,7 +444,7 @@ describe('${capitalizeFirstLetter(blockName)}Service', () => {
     serviceTestTemplate,
   );
 
-  const updatedIndexTemplate = `import { createBlock, BlockAuth } from "@openops/blocks-framework";
+  const updatedIndexTemplate = `import { createBlock } from "@openops/blocks-framework";
 ${
   authType !== 'none'
     ? `import { ${blockNameCamelCase}Auth } from './lib/auth';`

--- a/packages/cli/src/lib/utils/block-validators.ts
+++ b/packages/cli/src/lib/utils/block-validators.ts
@@ -1,0 +1,36 @@
+import chalk from 'chalk';
+
+export const validateBlockName = async (blockName: string) => {
+  console.log(chalk.yellow('Validating block name....'));
+  const blockNamePattern = /^[A-Za-z0-9-]+$/;
+  if (!blockNamePattern.test(blockName)) {
+    console.log(
+      chalk.red(
+        `🚨 Invalid block name: ${blockName}. Block names can only contain lowercase letters, numbers, and hyphens.`,
+      ),
+    );
+    process.exit(1);
+  }
+};
+
+export const validatePackageName = async (packageName: string) => {
+  console.log(chalk.yellow('Validating package name....'));
+  const packageNamePattern = /^(?:@[a-zA-Z0-9-]+\/)?[a-zA-Z0-9-]+$/;
+  if (!packageNamePattern.test(packageName)) {
+    console.log(
+      chalk.red(
+        `🚨 Invalid package name: ${packageName}. Package names can only contain lowercase letters, numbers, and hyphens.`,
+      ),
+    );
+    process.exit(1);
+  }
+};
+
+export const checkIfBlockExists = async (blockName: string) => {
+  const { findBlockSourceDirectory } = await import('../utils/block-utils');
+  const path = await findBlockSourceDirectory(blockName);
+  if (path) {
+    console.log(chalk.red(`🚨 Block already exists at ${path}`));
+    process.exit(1);
+  }
+};

--- a/packages/cli/src/lib/utils/block-validators.ts
+++ b/packages/cli/src/lib/utils/block-validators.ts
@@ -1,29 +1,21 @@
 import chalk from 'chalk';
 
-export const validateBlockName = async (blockName: string) => {
+export const validateBlockName = (blockName: string) => {
   console.log(chalk.yellow('Validating block name....'));
   const blockNamePattern = /^[A-Za-z0-9-]+$/;
   if (!blockNamePattern.test(blockName)) {
-    console.log(
-      chalk.red(
-        `🚨 Invalid block name: ${blockName}. Block names can only contain lowercase letters, numbers, and hyphens.`,
-      ),
-    );
-    process.exit(1);
+    return `🚨 Invalid block name: ${blockName}. Block names can only contain lowercase letters, numbers, and hyphens.`;
   }
+  return true;
 };
 
-export const validatePackageName = async (packageName: string) => {
+export const validatePackageName = (packageName: string) => {
   console.log(chalk.yellow('Validating package name....'));
   const packageNamePattern = /^(?:@[a-zA-Z0-9-]+\/)?[a-zA-Z0-9-]+$/;
   if (!packageNamePattern.test(packageName)) {
-    console.log(
-      chalk.red(
-        `🚨 Invalid package name: ${packageName}. Package names can only contain lowercase letters, numbers, and hyphens.`,
-      ),
-    );
-    process.exit(1);
+    return `🚨 Invalid package name: ${packageName}. Package names can only contain lowercase letters, numbers, and hyphens.`;
   }
+  return true;
 };
 
 export const checkIfBlockExists = async (blockName: string) => {


### PR DESCRIPTION
Fixes OPS-1931.

Because create-block was getting too big with the additional boilerplate template code, I created new modules and moved some of the code there.