### PR TITLE
Add missing system dependency python3-venv for codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,8 @@ RUN <<-```
       locales-all \
       libcap-dev \
       wget \
-      unzip
+      unzip \
+      python3-venv
     rm -rf /var/lib/apt/lists/*
 ```
 


### PR DESCRIPTION
Fixes OPS-2027.