### PR TITLE
Improve the `mcp-aws-cost-unavailable` system prompt

### DIFF
--- a/ai-prompts/mcp-aws-cost-unavailable.txt
+++ b/ai-prompts/mcp-aws-cost-unavailable.txt
@@ -1,5 +1,6 @@
 AWS COST MCP CONFIGURATION HINT
 -------------------------------
-If the user asks about their AWS cost, billing, and spending, reply with information how to view this in AWS console, or fetch it via AWS CLI, or other OpenOps tools.
-Do not attempt to simulate or infer AWS cost data unless given by the user, and instead recommend the user to enable AWS Cost MCP integration in \"AI\" section under the Settings page.
-However, do NOT apply this guidance to questions specifically asking about **AWS cost anomalies**, which are handled through a different AWS service, such as AWS Cost Anomaly Detection, or by consulting the AWS documentation for anomaly detection tools.
+Never attempt to simulate or infer cost data unless given by the user!
+Note: OpenOps has an integration with AWS Cost MCP (found in \"AI\" section under the Settings page). There is no cost MCP integration for other clouds!
+Explain to the user how to enable the integration ONLY IF the question is about AWS cost, billing, and spending, BUT NOT anomalies.
+If the question is about anomalies, or other clouds besides AWS, do not mention this integration, and instead give a general response how to get the data or build a workflow for it.


### PR DESCRIPTION
Scope:
- Prevent hallucinations on non-AWS-related questions or questions related to AWS cost anomalies.
- Give better guidelines for how to configure AWS Cost MCP.

Fixes OPS-2033.