### PR TITLE
Replace `JsonViewer` with `TestStepDataViewer`

### DIFF
--- a/packages/react-ui/src/app/features/builder/data-selector/data-selector-cache.ts
+++ b/packages/react-ui/src/app/features/builder/data-selector/data-selector-cache.ts
@@ -4,11 +4,13 @@ import { StepOutputWithData } from '@openops/shared';
 import { QueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 
+type StepOutputData = Omit<StepOutputWithData, 'input'>;
+
 /**
  * StepTestOutputCache manages test output and expanded state for steps in the Data Selector.
  */
 export class StepTestOutputCache {
-  private stepData: Record<string, StepOutputWithData> = {};
+  private stepData: Record<string, StepOutputData> = {};
   private expandedNodes: Record<string, boolean> = {};
 
   /**
@@ -21,7 +23,7 @@ export class StepTestOutputCache {
   /**
    * Set test output for a step.
    */
-  setStepData(stepId: string, data: StepOutputWithData) {
+  setStepData(stepId: string, data: StepOutputData) {
     this.stepData[stepId] = data;
   }
 
@@ -81,20 +83,22 @@ export function setStepOutputCache({
   stepId,
   flowVersionId,
   output,
+  input,
   queryClient,
 }: {
   stepId: string;
   flowVersionId: string;
   output: unknown;
+  input: unknown;
   queryClient: QueryClient;
 }) {
-  const stepTestOutput: StepOutputWithData = {
+  const stepTestOutput: StepOutputData = {
     output: formatUtils.formatStepInputOrOutput(output),
     lastTestDate: dayjs().toISOString(),
   };
   stepTestOutputCache.setStepData(stepId, stepTestOutput);
-  queryClient.setQueryData(
-    [QueryKeys.stepTestOutput, flowVersionId, stepId],
-    stepTestOutput,
-  );
+  queryClient.setQueryData([QueryKeys.stepTestOutput, flowVersionId, stepId], {
+    ...stepTestOutput,
+    input: formatUtils.formatStepInputOrOutput(input),
+  });
 }

--- a/packages/react-ui/src/app/features/builder/run-details/flow-step-input-output.tsx
+++ b/packages/react-ui/src/app/features/builder/run-details/flow-step-input-output.tsx
@@ -1,4 +1,4 @@
-import { JsonViewer, ScrollArea } from '@openops/components/ui';
+import { ScrollArea, TestStepDataViewer } from '@openops/components/ui';
 import { t } from 'i18next';
 import { Timer } from 'lucide-react';
 import React from 'react';
@@ -55,13 +55,11 @@ const FlowStepInputOutput = React.memo(
                 </>
               )}
             </div>
-            <JsonViewer
-              title={t('Input')}
-              json={stepDetails.input}
+            <TestStepDataViewer
+              inputJson={stepDetails.input}
+              outputJson={stepOutput}
               theme={theme}
             />
-            <div className="mt-4"></div>
-            <JsonViewer title={t('Output')} json={stepOutput} theme={theme} />
           </div>
         )}
       </ScrollArea>

--- a/packages/react-ui/src/app/features/builder/test-step/index.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/index.tsx
@@ -1,11 +1,11 @@
 import { useStepSettingsContext } from '@/app/features/builder/step-settings/step-settings-context';
 import { stepTestOutputHooks } from '@/app/features/builder/test-step/step-test-output-hooks';
 import {
-  JsonViewer,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  TestStepDataViewer,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -85,10 +85,9 @@ const TestStepContainer = React.memo(
             )}
           </TabsContent>
           <TabsContent value={TabListEnum.SAMPLE_STEP_OUTPUT}>
-            <JsonViewer
-              title={t('Output')}
+            <TestStepDataViewer
+              outputJson={selectedStep?.settings?.inputUiInfo?.sampleData ?? ''}
               onChange={useSaveSelectedStepSampleData}
-              json={selectedStep?.settings?.inputUiInfo?.sampleData ?? ''}
               readonly={false}
             />
           </TabsContent>

--- a/packages/react-ui/src/app/features/builder/test-step/test-action-section.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-action-section.tsx
@@ -62,11 +62,11 @@ const TestActionSection = React.memo(
       setIsValid(form.formState.isValid);
     }, [form.formState.isValid]);
 
-    const { data: testOutputData, isLoading: isLoadingTestOutput } =
+    const { data: stepData, isLoading: isLoadingStepData } =
       stepTestOutputHooks.useStepTestOutputFormData(flowVersionId, form);
 
     const sampleDataExists =
-      !isNil(testOutputData?.lastTestDate) || !isNil(errorMessage);
+      !isNil(stepData?.lastTestDate) || !isNil(errorMessage);
 
     const socket = useSocket();
 
@@ -101,7 +101,7 @@ const TestActionSection = React.memo(
       },
     });
 
-    const isTesting = isPending || isLoadingTestOutput;
+    const isTesting = isPending || isLoadingStepData;
 
     const handleTest = () => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -161,10 +161,10 @@ const TestActionSection = React.memo(
         isValid={isValid}
         isSaving={isSaving}
         isTesting={isTesting}
-        outputData={testOutputData?.output}
-        inputData={testOutputData?.input}
+        outputData={stepData?.output}
+        inputData={stepData?.input}
         errorMessage={errorMessage}
-        lastTestDate={testOutputData?.lastTestDate}
+        lastTestDate={stepData?.lastTestDate}
       />
     );
   },

--- a/packages/react-ui/src/app/features/builder/test-step/test-action-section.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-action-section.tsx
@@ -101,7 +101,7 @@ const TestActionSection = React.memo(
       },
     });
 
-    const isTesting = isPending || isLoadingStepData;
+    const isTesting = isPending ?? isLoadingStepData;
 
     const handleTest = () => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/react-ui/src/app/features/builder/test-step/test-action-section.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-action-section.tsx
@@ -88,6 +88,7 @@ const TestActionSection = React.memo(
             stepId: formValues.id,
             flowVersionId,
             output: stepResponse.output,
+            input: stepResponse.input,
             queryClient,
           });
         } else {
@@ -160,7 +161,8 @@ const TestActionSection = React.memo(
         isValid={isValid}
         isSaving={isSaving}
         isTesting={isTesting}
-        data={testOutputData?.output}
+        outputData={testOutputData?.output}
+        inputData={testOutputData?.input}
         errorMessage={errorMessage}
         lastTestDate={testOutputData?.lastTestDate}
       />

--- a/packages/react-ui/src/app/features/builder/test-step/test-sample-data-viewer.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-sample-data-viewer.tsx
@@ -1,4 +1,4 @@
-import { Button, JsonViewer } from '@openops/components/ui';
+import { Button, TestStepDataViewer } from '@openops/components/ui';
 import { t } from 'i18next';
 import React, { useMemo } from 'react';
 
@@ -14,7 +14,8 @@ type TestSampleDataViewerProps = {
   isValid: boolean;
   isSaving: boolean;
   isTesting: boolean;
-  data: unknown;
+  inputData: unknown;
+  outputData: unknown;
   errorMessage: string | undefined;
   lastTestDate: string | undefined;
   children?: React.ReactNode;
@@ -26,14 +27,20 @@ const TestSampleDataViewer = React.memo(
     isValid,
     isSaving,
     isTesting,
-    data,
+    inputData,
+    outputData,
     errorMessage,
     lastTestDate,
     children,
   }: TestSampleDataViewerProps) => {
-    const formattedData = useMemo(
-      () => formatUtils.formatStepInputOrOutput(data),
-      [data],
+    const formattedInputData = useMemo(
+      () => formatUtils.formatStepInputOrOutput(inputData),
+      [inputData],
+    );
+
+    const formattedOutputData = useMemo(
+      () => formatUtils.formatStepInputOrOutput(outputData),
+      [outputData],
     );
 
     const { theme } = useTheme();
@@ -83,11 +90,11 @@ const TestSampleDataViewer = React.memo(
               </Button>
             </TestButtonTooltip>
           </div>
-          <JsonViewer
-            json={errorMessage ?? formattedData}
-            title={t('Output')}
+          <TestStepDataViewer
+            outputJson={errorMessage ?? formattedOutputData}
+            inputJson={formattedInputData}
             theme={theme}
-          ></JsonViewer>
+          />
         </div>
       </>
     );

--- a/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
@@ -86,7 +86,7 @@ const TestTriggerSection = React.memo(
       undefined,
     );
 
-    const { data: testOutputData, isLoading: isLoadingTestOutput } =
+    const { data: stepData, isLoading: isLoadingStepData } =
       stepTestOutputHooks.useStepTestOutputFormData(flowVersionId, form);
 
     const [currentSelectedId, setCurrentSelectedId] = useState<
@@ -174,7 +174,7 @@ const TestTriggerSection = React.memo(
       },
     });
 
-    const isTesting = isPending || isLoadingTestOutput;
+    const isTesting = isPending || isLoadingStepData;
 
     function updateSelectedData(data: TriggerEvent) {
       stepTestOutputCache.setStepData(formValues.id, {
@@ -201,13 +201,13 @@ const TestTriggerSection = React.memo(
       staleTime: 0,
     });
 
-    const currentTestOutput = testOutputData?.output;
-    const currentTestInput = testOutputData?.input;
+    const currentTestOutput = stepData?.output;
+    const currentTestInput = stepData?.input;
 
     const outputDataSelected =
       !isNil(currentTestOutput) || !isNil(errorMessage);
 
-    const isTestedBefore = !isNil(testOutputData?.lastTestDate);
+    const isTestedBefore = !isNil(stepData?.lastTestDate);
 
     useEffect(() => {
       const selectedId = getSelectedId(
@@ -245,7 +245,7 @@ const TestTriggerSection = React.memo(
             outputData={currentTestOutput}
             inputData={currentTestInput}
             errorMessage={errorMessage}
-            lastTestDate={testOutputData?.lastTestDate}
+            lastTestDate={stepData?.lastTestDate}
           >
             {pollResults?.data && (
               <div className="mb-3">

--- a/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
@@ -185,6 +185,7 @@ const TestTriggerSection = React.memo(
         stepId: formValues.id,
         flowVersionId,
         output: data.payload,
+        input: data.input,
         queryClient,
       });
     }
@@ -201,6 +202,8 @@ const TestTriggerSection = React.memo(
     });
 
     const currentTestOutput = testOutputData?.output;
+    const currentTestInput = testOutputData?.input;
+
     const outputDataSelected =
       !isNil(currentTestOutput) || !isNil(errorMessage);
 
@@ -239,7 +242,8 @@ const TestTriggerSection = React.memo(
             isValid={isValid}
             isSaving={isSaving}
             isTesting={isTesting}
-            data={currentTestOutput}
+            outputData={currentTestOutput}
+            inputData={currentTestInput}
             errorMessage={errorMessage}
             lastTestDate={testOutputData?.lastTestDate}
           >

--- a/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
+++ b/packages/react-ui/src/app/features/builder/test-step/test-trigger-section.tsx
@@ -174,7 +174,7 @@ const TestTriggerSection = React.memo(
       },
     });
 
-    const isTesting = isPending || isLoadingStepData;
+    const isTesting = isPending ?? isLoadingStepData;
 
     function updateSelectedData(data: TriggerEvent) {
       stepTestOutputCache.setStepData(formValues.id, {


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-1943.

Not related bug: 
https://linear.app/openops/issue/OPS-2072/when-loading-test-data-for-the-first-time-its-not-saved


![image](https://github.com/user-attachments/assets/91613bd6-7f9b-49fd-a1e1-614f472b331c)
![image](https://github.com/user-attachments/assets/a90a9077-e9b3-4efb-ae49-74c783f4ce1f)
![image](https://github.com/user-attachments/assets/c523efb8-2bfd-4313-97c5-9f61cb1223a8)


Deployed on UX
