### PR TITLE
Update @frontegg/js and use ensure cleanup operations after logout are completed

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -17277,7 +17277,7 @@ The following npm packages may be included in this product:
  - @bull-board/api@5.9.1
  - @bull-board/fastify@5.9.1
  - @bull-board/ui@5.9.1
- - @frontegg/js@7.56.0
+ - @frontegg/js@7.79.0
  - @frontegg/redux-store@7.56.0
  - @frontegg/rest-api@7.56.0
  - @frontegg/types@7.56.0

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -17278,9 +17278,9 @@ The following npm packages may be included in this product:
  - @bull-board/fastify@5.9.1
  - @bull-board/ui@5.9.1
  - @frontegg/js@7.79.0
- - @frontegg/redux-store@7.56.0
- - @frontegg/rest-api@7.56.0
- - @frontegg/types@7.56.0
+ - @frontegg/redux-store@7.79.0
+ - @frontegg/rest-api@7.79.0
+ - @frontegg/types@7.79.0
  - @nx/nx-linux-x64-gnu@19.8.8
  - @nx/nx-linux-x64-musl@19.8.8
  - @polka/url@1.0.0-next.25

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@fastify/swagger-ui": "5.2.3",
         "@fastify/type-provider-typebox": "5.1.0",
         "@frontegg/client": "5.3.2",
-        "@frontegg/js": "7.56.0",
+        "@frontegg/js": "7.79.0",
         "@hookform/resolvers": "3.9.0",
         "@microsoft/microsoft-graph-client": "3.0.7",
         "@microsoft/microsoft-graph-types": "2.40.0",
@@ -6964,22 +6964,24 @@
       "integrity": "sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q=="
     },
     "node_modules/@frontegg/js": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@frontegg/js/-/js-7.56.0.tgz",
-      "integrity": "sha512-88DemISbKM4CYd2w75pSykh+S4tAMONXxPSWX3Q+eHy9DBeffPKbyqBYY1278CH+klkFOEUhgd2LX6j93I9+0Q==",
+      "version": "7.79.0",
+      "resolved": "https://registry.npmjs.org/@frontegg/js/-/js-7.79.0.tgz",
+      "integrity": "sha512-NdJgk4iDWvthi6v70KQDuIWMqc8ras9NckNZyYBDtFtx8PlbMyA+rqdpxBsDppf+jy33Toi3Ud8UhWGQhRZjQg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
-        "@frontegg/types": "7.56.0"
+        "@frontegg/types": "7.79.0"
       }
     },
     "node_modules/@frontegg/redux-store": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@frontegg/redux-store/-/redux-store-7.56.0.tgz",
-      "integrity": "sha512-fDRwR4ili6v+HWBzmaI4ccBbid8T+QCY5OvC1szMty9JrgfFkahyhy8RiG/l3WBVP2D4rOOHyPEAZ0SEW0pOEQ==",
+      "version": "7.79.0",
+      "resolved": "https://registry.npmjs.org/@frontegg/redux-store/-/redux-store-7.79.0.tgz",
+      "integrity": "sha512-+qyxLvt/c6BfcFdJNuOye/O0NbVeCT06FXGAVZqcyWcLSb9VGY3kP0SLOu0leXPyizYOP7Am5ThUls3kpYS7IQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@frontegg/entitlements-javascript-commons": "1.1.2",
-        "@frontegg/rest-api": "7.56.0",
+        "@frontegg/rest-api": "7.79.0",
         "fast-deep-equal": "3.1.3",
         "get-value": "^3.0.1",
         "proxy-compare": "^3.0.0",
@@ -6988,21 +6990,23 @@
       }
     },
     "node_modules/@frontegg/rest-api": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@frontegg/rest-api/-/rest-api-7.56.0.tgz",
-      "integrity": "sha512-nxaKKSaGK4asl9dZvDaygQosaRIxlV4lKnRyKKd/xlsQ0C4HP/WT/759eCPzBw+OWoMjjpwX8NuteKRuCSpXiQ==",
+      "version": "7.79.0",
+      "resolved": "https://registry.npmjs.org/@frontegg/rest-api/-/rest-api-7.79.0.tgz",
+      "integrity": "sha512-7QkcP+Alb/G+JpzAinMGmHiCSFulNNZ9yqI9tdxc0aABCHth49VhLHlDzLmRVsFqpKvVyUx7i+uHHTvg2rbl4g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@frontegg/entitlements-javascript-commons": "1.1.2"
       }
     },
     "node_modules/@frontegg/types": {
-      "version": "7.56.0",
-      "resolved": "https://registry.npmjs.org/@frontegg/types/-/types-7.56.0.tgz",
-      "integrity": "sha512-sJk0XdRNwz3N7/3gPK+J/mItIFBNIbDyrUxGNfXvro/TM/OJf/KhzFPBUo8CjKoBg3HX0XDuYvDh+ueRMglxuA==",
+      "version": "7.79.0",
+      "resolved": "https://registry.npmjs.org/@frontegg/types/-/types-7.79.0.tgz",
+      "integrity": "sha512-it6Hqc9yNdGkfJYj5+r94N9bxc9cPy4wWS4FsC5r8BPS/4TqI/uCwrPVOM/V2gKyrjqPQINd7nnTADQ/p4qYsQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
-        "@frontegg/redux-store": "7.56.0",
+        "@frontegg/redux-store": "7.79.0",
         "csstype": "^3.0.9",
         "deepmerge": "^4.2.2"
       }
@@ -32250,6 +32254,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
       "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
+      "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -34904,6 +34909,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
       "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -46946,7 +46952,8 @@
     "node_modules/proxy-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
-      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q=="
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -49546,6 +49553,7 @@
         "https://paypal.me/jonathanschlinkert",
         "https://jonschlinkert.dev/sponsor"
       ],
+      "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4",
         "is-primitive": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@fastify/swagger-ui": "5.2.3",
     "@fastify/type-provider-typebox": "5.1.0",
     "@frontegg/client": "5.3.2",
-    "@frontegg/js": "7.56.0",
+    "@frontegg/js": "7.79.0",
     "@hookform/resolvers": "3.9.0",
     "@microsoft/microsoft-graph-client": "3.0.7",
     "@microsoft/microsoft-graph-types": "2.40.0",

--- a/packages/react-ui/src/app/routes/cloud-connection/cloud-logout-page.tsx
+++ b/packages/react-ui/src/app/routes/cloud-connection/cloud-logout-page.tsx
@@ -1,14 +1,15 @@
 import { flagsHooks } from '@/app/common/hooks/flags-hooks';
+import { FronteggApp } from '@frontegg/js';
 import Cookies from 'js-cookie';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { initializeFrontegg } from './frontegg-setup';
 
-const handleAppReady = (app: any) => {
+const handleAppReady = (app: FronteggApp) => {
   app.ready(() => handleLogout(app));
 };
 
-const handleLogout = (app: any) => {
+const handleLogout = (app: FronteggApp) => {
   app.logout(handleWindowClose);
 };
 

--- a/packages/react-ui/src/app/routes/cloud-connection/cloud-logout-page.tsx
+++ b/packages/react-ui/src/app/routes/cloud-connection/cloud-logout-page.tsx
@@ -4,6 +4,23 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { initializeFrontegg } from './frontegg-setup';
 
+const handleLogout = (app: any) => {
+  app.logout(handleWindowClose);
+};
+
+const handleAppReady = (app: any) => {
+  app.ready(() => handleLogout(app));
+};
+
+const handleWindowClose = () => {
+  if (!window.opener) {
+    return;
+  }
+  setTimeout(() => {
+    window.close();
+  }, 300);
+};
+
 const CloudLogoutPage = () => {
   const navigate = useNavigate();
   const { data: flags, isLoading } = flagsHooks.useFlags();
@@ -28,16 +45,7 @@ const CloudLogoutPage = () => {
     Cookies.remove('cloud-token');
     Cookies.remove('cloud-refresh-token');
 
-    app.ready(() => {
-      app.logout(() => {
-        if (!window.opener) {
-          return;
-        }
-        setTimeout(() => {
-          window.close();
-        }, 300);
-      });
-    });
+    handleAppReady(app);
   }, [flags, isLoading, navigate]);
 
   return null;

--- a/packages/react-ui/src/app/routes/cloud-connection/cloud-logout-page.tsx
+++ b/packages/react-ui/src/app/routes/cloud-connection/cloud-logout-page.tsx
@@ -29,13 +29,13 @@ const CloudLogoutPage = () => {
     Cookies.remove('cloud-refresh-token');
 
     app.ready(() => {
-      app.logout();
-
-      if (window.opener) {
-        setTimeout(() => {
-          window.close();
-        }, 300);
-      }
+      app.logout(() => {
+        if (window.opener) {
+          setTimeout(() => {
+            window.close();
+          }, 300);
+        }
+      });
     });
   }, [flags, isLoading, navigate]);
 

--- a/packages/react-ui/src/app/routes/cloud-connection/cloud-logout-page.tsx
+++ b/packages/react-ui/src/app/routes/cloud-connection/cloud-logout-page.tsx
@@ -4,12 +4,12 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { initializeFrontegg } from './frontegg-setup';
 
-const handleLogout = (app: any) => {
-  app.logout(handleWindowClose);
-};
-
 const handleAppReady = (app: any) => {
   app.ready(() => handleLogout(app));
+};
+
+const handleLogout = (app: any) => {
+  app.logout(handleWindowClose);
 };
 
 const handleWindowClose = () => {

--- a/packages/react-ui/src/app/routes/cloud-connection/cloud-logout-page.tsx
+++ b/packages/react-ui/src/app/routes/cloud-connection/cloud-logout-page.tsx
@@ -30,11 +30,12 @@ const CloudLogoutPage = () => {
 
     app.ready(() => {
       app.logout(() => {
-        if (window.opener) {
-          setTimeout(() => {
-            window.close();
-          }, 300);
+        if (!window.opener) {
+          return;
         }
+        setTimeout(() => {
+          window.close();
+        }, 300);
       });
     });
   }, [flags, isLoading, navigate]);


### PR DESCRIPTION
Fixes OPS-1358.

The bug does not reproduce consistently, and I suspect it's a bug in the client(browser) state.
Yes, there is a redux store under the hood ( see [cloud-connection-page](https://github.com/openops-cloud/openops/blob/cezudas/OPS-1358/packages/react-ui/src/app/routes/cloud-connection/cloud-connection-page.tsx#L51))
```
app.store.subscribe(() => {
  const { auth } = app.store.getState();
  // ... you then use auth.isLoading, auth.isAuthenticated, etc.
});
```

I expect the problem to be solved by [updating @frontegg/js to the latest](https://github.com/openops-cloud/openops/pull/908#discussion_r2182407578), but we need to merge and deploy on `app.openops.com` to actually validate it.