### PR TITLE
Open a PR to the docs repo when a new release is out

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,4 +149,24 @@ jobs:
           RELEASE_URL: ${{ needs.create-github-release.outputs.download_url }}
         run: |
           gh workflow run "Deploy Docker Compose Release" -R openops-cloud/devops -f release_version=${VERSION} -f release_url=${RELEASE_URL} -r main
+  trigger-docs-update:
+    name: Trigger docs update
+    needs: [get-version, create-github-release]
+    runs-on: ubuntu-latest
+    if: ${{ success() && github.repository == 'openops-cloud/openops' }}
+    steps:
+      - name: Get GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v2.0.6
+        with:
+          app-id: ${{ vars.DEVOPS_GITHUB_APP_ID }}
+          private-key: ${{ secrets.DEVOPS_GITHUB_APP_PEM }}
+          owner: ${{ github.repository_owner }}
 
+      - name: Trigger docs workflow
+        env:
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          gh workflow run update-release-version.yml \
+            --repo openops-cloud/docs \
+            --field version=${{ needs.get-version.outputs.version }}


### PR DESCRIPTION
Part of OPS-2054.

I tested by creating a custom release from this branch `cezudas/OPS-2054` using version name `0.3.1-test-OPS-2054` 
You can see the appropriate `update-release-version` action on the docs repository has been triggered by the release workflow [here](https://github.com/openops-cloud/openops/actions/runs/16151330556).

Related PR on the docs repository [here](https://github.com/openops-cloud/docs/pull/91).