### PR TITLE
Fix linear block displaying duplicate labels by filtering with selected team

### DIFF
--- a/packages/blocks/linear/src/lib/common/props.ts
+++ b/packages/blocks/linear/src/lib/common/props.ts
@@ -104,10 +104,17 @@ export const props = {
       required,
       refreshers: ['auth', 'team_id'],
       options: async ({ auth, team_id }) => {
-        if (!auth || !team_id) {
+        if (!auth) {
           return {
             disabled: true,
-            placeholder: 'connect your account first and select team',
+            placeholder: 'Connect your account first',
+            options: [],
+          };
+        }
+        if (!team_id) {
+          return {
+            disabled: true,
+            placeholder: 'Select a team to load labels',
             options: [],
           };
         }

--- a/packages/blocks/linear/src/lib/common/props.ts
+++ b/packages/blocks/linear/src/lib/common/props.ts
@@ -2,6 +2,8 @@ import { LinearDocument } from '@linear/sdk';
 import { Property } from '@openops/blocks-framework';
 import { makeClient } from './client';
 
+const LABELS_PAGE_SIZE = 100;
+
 type PaginatedResponse<T> = {
   nodes: T[] | Promise<T[]>;
   pageInfo: {
@@ -129,7 +131,7 @@ export const props = {
               },
             },
             orderBy: LinearDocument.PaginationOrderBy.UpdatedAt,
-            first: 100,
+            first: LABELS_PAGE_SIZE,
             after: cursor,
           }),
         );

--- a/packages/blocks/linear/src/lib/common/props.ts
+++ b/packages/blocks/linear/src/lib/common/props.ts
@@ -102,18 +102,25 @@ export const props = {
       description: 'Labels for the Issue',
       displayName: 'Labels',
       required,
-      refreshers: ['auth'],
-      options: async ({ auth }) => {
-        if (!auth) {
+      refreshers: ['auth', 'team_id'],
+      options: async ({ auth, team_id }) => {
+        if (!auth || !team_id) {
           return {
             disabled: true,
-            placeholder: 'connect your account first',
+            placeholder: 'connect your account first and select team',
             options: [],
           };
         }
         const client = makeClient(auth as string);
         const allLabels = await fetchAllPaginatedItems((cursor) =>
           client.listIssueLabels({
+            filter: {
+              team: {
+                id: {
+                  eq: team_id as string,
+                },
+              },
+            },
             orderBy: LinearDocument.PaginationOrderBy.UpdatedAt,
             first: 100,
             after: cursor,


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-2129.

## Additional Notes
1. Previously all labels are displayed irrespective of the selected team.
2. Now labels are filtered with the selected team which resulted in removing duplicates. 

<!--
Why was it changed?
Any relevant context or links?
Add refactoring notes (if applicable), preferably as comments in the code (if you refactored code, explain what was moved/changed and why).
-->

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [x] Automated tests were added/updated if necessary

- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided

## Visual Changes (if applicable)

If there are UI/UX changes, include at least one of the following:

- Screenshots
<img width="1104" height="729" alt="Screenshot 2025-07-11 at 12 04 38 PM" src="https://github.com/user-attachments/assets/1d9155e3-d9ae-4d93-a9a2-9cf276f938e4" />

- Loom video
- Preview deployment link
