### PR TITLE
Fix the alignment of top edges of sample and quick link cards

### DIFF
--- a/packages/react-ui/src/app/features/home/components/home-get-started.tsx
+++ b/packages/react-ui/src/app/features/home/components/home-get-started.tsx
@@ -36,8 +36,8 @@ const HomeGetStarted = ({
     >
       <div className="p-6 flex flex-col gap-4 bg-secondary font-bold">
         <h2 className="text-[24px]">{t('Get started')}</h2>
-        <div className="flex items-center justify-between gap-4 flex-wrap @[1160px]:flex-nowrap">
-          <div className="w-full @[1160px]:w-[50%] flex flex-col gap-[10px]">
+        <div className="flex items-start justify-between gap-4 flex-wrap @[1160px]:flex-nowrap">
+          <div className="w-full @[1160px]:w-[50%] flex flex-col gap-[8px]">
             <h3>{t('Start with our Sample template')}</h3>
             <div className="flex gap-2">
               {displayedTemplates.map((template, index) => (
@@ -49,7 +49,7 @@ const HomeGetStarted = ({
               ))}
             </div>
           </div>
-          <div className="w-full flex flex-col gap-[10px]">
+          <div className="w-full flex flex-col gap-[8px]">
             <h3>{t('Quick links')}</h3>
             <div className="w-full grid grid-cols-2 gap-2 @[900px]:grid-cols-4 font-normal">
               <KnowledgeBaseCard


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->
Align top edges of sample and quick link cards by standardising gap to 8px in the samples and quick links containers.

Fixes OPS-1322.

## Additional Notes

<!--
Why was it changed?
Any relevant context or links?
Add refactoring notes (if applicable), preferably as comments in the code (if you refactored code, explain what was moved/changed and why).
-->

## Testing Checklist

Check all that apply:

- [ ] I tested the feature thoroughly, including edge cases

- [ ] I verified all affected areas still work as expected

- [ ] Automated tests were added/updated if necessary

- [ ] Changes are backwards compatible with any existing data, otherwise a migration script is provided

## Visual Changes (if applicable)

If there are UI/UX changes, include at least one of the following:

- Screenshots
- Loom video
- Preview deployment link
