### PR TITLE
Fix /open calls and empty AI step setting chat when selecting a trigger

### DIFF
--- a/packages/react-ui/src/app/features/builder/builder-hooks.ts
+++ b/packages/react-ui/src/app/features/builder/builder-hooks.ts
@@ -124,6 +124,14 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
         selectStepByName: (stepName: string, openRightSideBar = true) => {
           set(
             (state) => {
+              const triggerMidpanelState = {
+                showDataSelector: state.midpanelState.showDataSelector,
+                dataSelectorSize: state.midpanelState.dataSelectorSize,
+                aiContainerSize: state.midpanelState.aiContainerSize,
+                showAiChat: false,
+                aiChatProperty: undefined,
+              };
+
               if (
                 stepName === 'trigger' &&
                 state.flowVersion.trigger.type === TriggerType.EMPTY
@@ -132,6 +140,7 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
                   selectedStep: stepName,
                   rightSidebar: RightSideBarType.NONE,
                   leftSidebar: getLeftSidebarOnSelectStep(state),
+                  midpanelState: triggerMidpanelState,
                 };
               } else if (
                 stepName === 'trigger' &&
@@ -141,6 +150,7 @@ export const createBuilderStore = (initialState: BuilderInitialState) =>
                   selectedStep: stepName,
                   rightSidebar: RightSideBarType.BLOCK_SETTINGS,
                   leftSidebar: getLeftSidebarOnSelectStep(state),
+                  midpanelState: triggerMidpanelState,
                 };
               }
 


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-2102

## Additional Notes
- we did an /open call every time we select a step (even though the step does not supportAI)
- when we had step settings chat opened, selecting a trigger would lead to a loading chat state


## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [ ] Automated tests were added/updated if necessary

- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided

## Visual Changes (if applicable)
https://www.loom.com/share/e31ef92c2a20400b919f218025fa6db2
