### PR TITLE
Generate a name for AI chat based on the conversation

### DIFF
--- a/ai-prompts/chat-name.txt
+++ b/ai-prompts/chat-name.txt
@@ -1,0 +1,9 @@
+You are an AI assistant on the OpenOps platform, where users interact about FinOps, cloud providers (AWS, Azure, GCP), OpenOps features, and workflow automation.
+
+Your task:
+Given the following conversation, suggest a short, descriptive name (max five words) that best summarizes the main topic, question, or action discussed in this chat. 
+
+Guidelines:
+- The name should be specific (not generic like "Chat" or "Conversation"), and reflect the user's intent (e.g., "AWS Cost Optimization", "Create Budget Workflow", "OpenOps Integration Help").
+- Limit the name to five words or less.
+- Respond with only the chat name.

--- a/packages/server/api/src/app/ai/chat/ai-chat.service.ts
+++ b/packages/server/api/src/app/ai/chat/ai-chat.service.ts
@@ -59,7 +59,7 @@ export async function generateChatName(
   const { languageModel } = await getLLMConfig(projectId);
   const prompt: CoreMessage[] = [
     {
-      role: 'assistant',
+      role: 'system',
       content: `
       You are an AI assistant on the OpenOps platform, where users interact about FinOps, cloud providers (AWS, Azure, GCP), OpenOps features, and workflow automation.
       Given the following conversation, suggest a short, descriptive name (max five words) that best summarizes the main topic, question, or action discussed in this chat. 

--- a/packages/server/api/src/app/ai/chat/ai-chat.service.ts
+++ b/packages/server/api/src/app/ai/chat/ai-chat.service.ts
@@ -39,18 +39,6 @@ export type MCPChatContext = {
   stepId?: string;
   actionName?: string;
   chatName?: string;
-  userMessageCount?: number;
-};
-
-export const incrementUserMessageCount = async (
-  chatId: string,
-  userId: string,
-  projectId: string,
-): Promise<MCPChatContext> => {
-  const context = (await getChatContext(chatId, userId, projectId)) || {};
-  context.userMessageCount = (context.userMessageCount || 0) + 1;
-  await createChatContext(chatId, userId, projectId, context);
-  return context;
 };
 
 export async function generateChatName(

--- a/packages/server/api/src/app/ai/chat/ai-chat.service.ts
+++ b/packages/server/api/src/app/ai/chat/ai-chat.service.ts
@@ -8,6 +8,7 @@ import {
 import { AiConfig, ApplicationError, ErrorCode } from '@openops/shared';
 import { CoreMessage, LanguageModel, generateText } from 'ai';
 import { aiConfigService } from '../config/ai-config.service';
+import { loadPrompt } from './prompts.service';
 import { MessageWithMergedToolResults } from './types';
 import { mergeToolResultsIntoMessages } from './utils';
 
@@ -57,16 +58,11 @@ export async function generateChatName(
   projectId: string,
 ): Promise<string> {
   const { languageModel } = await getLLMConfig(projectId);
+  const systemPrompt = await loadPrompt('chat-name.txt');
   const prompt: CoreMessage[] = [
     {
       role: 'system',
-      content: `
-      You are an AI assistant on the OpenOps platform, where users interact about FinOps, cloud providers (AWS, Azure, GCP), OpenOps features, and workflow automation.
-      Given the following conversation, suggest a short, descriptive name (max five words) that best summarizes the main topic, question, or action discussed in this chat. 
-      The name should be specific (not generic like "Chat" or "Conversation"), and reflect the user's intent (e.g., "AWS Cost Optimization", "Create Budget Workflow", "OpenOps Integration Help").
-      Limit the name to five words or less.
-      Respond with only the name.
-      `,
+      content: systemPrompt,
     } as const,
     ...messages,
   ];

--- a/packages/server/api/src/app/ai/chat/ai-mcp-chat.controller.ts
+++ b/packages/server/api/src/app/ai/chat/ai-mcp-chat.controller.ts
@@ -199,7 +199,7 @@ export const aiMCPChatController: FastifyPluginAsyncTypebox = async (app) => {
         mcpClients = toolSet.mcpClients;
 
         const filteredTools = await selectRelevantTools({
-          messages,
+          messages: conversationResult.messages,
           tools: toolSet.tools,
           languageModel,
           aiConfig,

--- a/packages/server/api/src/app/ai/chat/ai-mcp-chat.controller.ts
+++ b/packages/server/api/src/app/ai/chat/ai-mcp-chat.controller.ts
@@ -199,7 +199,7 @@ export const aiMCPChatController: FastifyPluginAsyncTypebox = async (app) => {
         mcpClients = toolSet.mcpClients;
 
         const filteredTools = await selectRelevantTools({
-          messages: conversationResult.messages,
+          messages,
           tools: toolSet.tools,
           languageModel,
           aiConfig,

--- a/packages/server/api/src/app/ai/chat/prompts.service.ts
+++ b/packages/server/api/src/app/ai/chat/prompts.service.ts
@@ -90,7 +90,7 @@ export const getBlockSystemPrompt = async (
   }
 };
 
-async function loadPrompt(filename: string): Promise<string> {
+export async function loadPrompt(filename: string): Promise<string> {
   const promptsLocation = system.get<string>(AppSystemProp.AI_PROMPTS_LOCATION);
 
   if (promptsLocation) {

--- a/packages/server/api/test/unit/ai/ai-mcp-chat.controller.test.ts
+++ b/packages/server/api/test/unit/ai/ai-mcp-chat.controller.test.ts
@@ -11,7 +11,7 @@ import {
 import {
   getConversation,
   getLLMConfig,
-  incrementUserMessageCount, // ADD THIS IMPORT
+  incrementUserMessageCount,
 } from '../../../src/app/ai/chat/ai-chat.service';
 import { aiMCPChatController } from '../../../src/app/ai/chat/ai-mcp-chat.controller';
 import {
@@ -83,7 +83,7 @@ jest.mock('../../../src/app/ai/chat/ai-chat.service', () => ({
   createChatContext: jest.fn(),
   getConversation: jest.fn(),
   getLLMConfig: jest.fn(),
-  incrementUserMessageCount: jest.fn(), // ADD THIS MISSING MOCK
+  incrementUserMessageCount: jest.fn(),
   getChatHistoryWithMergedTools: jest.fn(),
 }));
 

--- a/packages/server/api/test/unit/ai/ai-mcp-chat.controller.test.ts
+++ b/packages/server/api/test/unit/ai/ai-mcp-chat.controller.test.ts
@@ -207,7 +207,6 @@ describe('AI MCP Chat Controller - Tool Service Interactions', () => {
         languageModel: mockLanguageModel,
       });
 
-      // ADD THIS MISSING MOCK
       (incrementUserMessageCount as jest.Mock).mockResolvedValue({
         ...mockChatContext,
         userMessageCount: 1,
@@ -371,7 +370,6 @@ describe('AI MCP Chat Controller - Tool Service Interactions', () => {
           mockReply as unknown as FastifyReply,
         );
 
-        // Should result in a 400 error response
         expect(mockReply.code).toHaveBeenCalledWith(400);
         expect(mockReply.send).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -380,7 +378,6 @@ describe('AI MCP Chat Controller - Tool Service Interactions', () => {
           }),
         );
 
-        // Should NOT call selectRelevantTools since validation failed
         expect(selectRelevantTools).not.toHaveBeenCalled();
       });
 
@@ -414,7 +411,6 @@ describe('AI MCP Chat Controller - Tool Service Interactions', () => {
           }),
         );
 
-        // Should NOT call selectRelevantTools since validation failed
         expect(selectRelevantTools).not.toHaveBeenCalled();
       });
 


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-2172.

## Additional Notes
- AI Chat name generates after the 3rd message from the user. 
- Once a chat name is generated, it stays static until the end of conversation. 

- Why I chose 3 user messages and not more? I believe the first couple of messages the user might not send the "actual" questions but just something generic like "Hey, I need your help". Also I thought it is better to not wait for more context, say more than 5 messages from the user, for better UX. 

<!--
Why was it changed?
Any relevant context or links?
Add refactoring notes (if applicable), preferably as comments in the code (if you refactored code, explain what was moved/changed and why).
-->

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [x] Automated tests were added/updated if necessary

- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided

## Visual Changes (if applicable)

If there are UI/UX changes, include at least one of the following:

- Screenshots
- Loom video
- Preview deployment link
