### PR TITLE
Add openopsdev as the app name of the local compose file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,4 @@
+name: openopsdev
 services:
   tables:
     container_name: tables


### PR DESCRIPTION
Fixes CI-42.

To keep your docker volumes before this change, you'll need to rename them.

First shut down running containers if there are any:

```
docker rm -f $(docker ps -aq)
```

Then copy the volumes into their new names:

```
docker volume create --name openopsdev_openops_tables_data
docker run --rm -it -v "openops_openops_tables_data:/from" -v "openopsdev_openops_tables_data:/to" alpine ash -c 'cd /from ; cp -av . /to'
docker volume rm openops_openops_tables_data

docker volume create --name openopsdev_postgres_data
docker run --rm -it -v "openops_postgres_data:/from" -v "openopsdev_postgres_data:/to" alpine ash -c 'cd /from ; cp -av . /to'
docker volume rm openops_postgres_data
```
