### PR TITLE
Implement AssistantUI based step settings chat with inject support

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -22438,9 +22438,9 @@ The following npm packages may be included in this product:
  - @assistant-ui/react-ai-sdk@0.10.15
  - @assistant-ui/react-edge@0.2.13
  - @assistant-ui/react-markdown@0.10.6
- - @assistant-ui/react@0.10.25
+ - @assistant-ui/react@0.10.29
  - assistant-cloud@0.0.3
- - assistant-stream@0.2.18
+ - assistant-stream@0.2.20
 
 These packages each contain the following license:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@ai-sdk/react": "1.2.12",
         "@ai-sdk/togetherai": "0.2.16",
         "@ai-sdk/xai": "1.2.18",
-        "@assistant-ui/react": "0.10.25",
+        "@assistant-ui/react": "0.10.29",
         "@assistant-ui/react-ai-sdk": "0.10.15",
         "@assistant-ui/react-markdown": "0.10.6",
         "@aws-sdk/client-athena": "3.635.0",
@@ -741,9 +741,9 @@
       }
     },
     "node_modules/@assistant-ui/react": {
-      "version": "0.10.25",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.10.25.tgz",
-      "integrity": "sha512-aYWv9+UdAYPOWveS39PN/DfTBOBGpvbrlqOSBBzWxxR6hauqUiRWm/qbIG2uG0+lglQuhbR1X0eJJbi9z7Q0IA==",
+      "version": "0.10.29",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.10.29.tgz",
+      "integrity": "sha512-Z7UwYKhmNVh7EqtOpIs9W4RgKqYPKgoy3imEOrOoZxhtZOfRIXt4s/cx3cyF6dHdBn/5M26uuJMpazHEIsNJ5g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "^1.1.2",
@@ -756,7 +756,7 @@
         "@radix-ui/react-use-escape-keydown": "^1.1.1",
         "@standard-schema/spec": "^1.0.0",
         "assistant-cloud": "0.0.3",
-        "assistant-stream": "^0.2.18",
+        "assistant-stream": "^0.2.20",
         "json-schema": "^0.4.0",
         "nanoid": "5.1.5",
         "react-textarea-autosize": "^8.5.9",
@@ -25844,9 +25844,9 @@
       }
     },
     "node_modules/assistant-stream": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.2.18.tgz",
-      "integrity": "sha512-aNZDOQorUksbGPVKzG9rBKN8O0J4UoGX9y6ChPejuvFLWb8JHse24AnYtr/Lss/+vQHggVQaeUe68wlv5J+WWw==",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.2.20.tgz",
+      "integrity": "sha512-zHvx2X9uLV81prbWedZvMXr/t6AH54QIkckr0cLRVVZZP/kv+af52pr4fTCsigok4L9GRJMIWZRjd1WOsHh0Eg==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.15",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@ai-sdk/react": "1.2.12",
     "@ai-sdk/togetherai": "0.2.16",
     "@ai-sdk/xai": "1.2.18",
-    "@assistant-ui/react": "0.10.25",
+    "@assistant-ui/react": "0.10.29",
     "@assistant-ui/react-ai-sdk": "0.10.15",
     "@assistant-ui/react-markdown": "0.10.6",
     "@aws-sdk/client-athena": "3.635.0",

--- a/packages/react-ui/src/app/features/builder/ai-chat/step-settings-assistant-ui-chat.tsx
+++ b/packages/react-ui/src/app/features/builder/ai-chat/step-settings-assistant-ui-chat.tsx
@@ -1,16 +1,11 @@
 import { useTheme } from '@/app/common/providers/theme-provider';
-import { AssistantRuntimeProvider } from '@assistant-ui/react';
 import {
   AI_CHAT_CONTAINER_SIZES,
   AiCliChatContainerSizeState,
   cn,
-  MarkdownCodeVariations,
   StepSettingsAssistantUiChatContainer,
-  Thread,
-  ThreadExtraContextProvider,
 } from '@openops/components/ui';
 import { FlowVersion } from '@openops/shared';
-import { t } from 'i18next';
 import { useCallback } from 'react';
 import { useAiModelSelector } from '../../ai/lib/ai-model-selector-hook';
 import { useStepSettingsAssistantChat } from '../assistant-ui/hooks/use-step-settings-assistant-chat';
@@ -41,10 +36,8 @@ const StepSettingsAssistantUiChat = ({
     state.applyMidpanelAction,
   ]);
 
-  const { runtime, createNewChat, onInject } = useStepSettingsAssistantChat(
-    flowVersion,
-    selectedStep,
-  );
+  const { runtime, createNewChat, hasMessages, onInject } =
+    useStepSettingsAssistantChat(flowVersion, selectedStep);
 
   const onToggleContainerSizeState = useCallback(
     (size: AiCliChatContainerSizeState) => {
@@ -80,10 +73,17 @@ const StepSettingsAssistantUiChat = ({
       parentWidth={middlePanelSize.width}
       showAiChat={showAiChat}
       onCloseClick={onCloseClick}
-      enableNewChat={true}
+      enableNewChat={hasMessages}
+      handleInject={onInject}
       onNewChatClick={createNewChat}
       containerSize={aiContainerSize}
       toggleContainerSizeState={onToggleContainerSizeState}
+      onModelSelected={onModelSelected}
+      isModelSelectorLoading={isModelSelectorLoading}
+      selectedModel={selectedModel}
+      availableModels={availableModels}
+      theme={theme}
+      runtime={runtime}
       className={cn('right-0 static', {
         'children:transition-none':
           showDataSelector &&
@@ -91,23 +91,7 @@ const StepSettingsAssistantUiChat = ({
           aiContainerSize === AI_CHAT_CONTAINER_SIZES.COLLAPSED &&
           dataSelectorSize === DataSelectorSizeState.DOCKED,
       })}
-    >
-      <AssistantRuntimeProvider runtime={runtime}>
-        <ThreadExtraContextProvider
-          greeting={t('How can I help you?')}
-          handleInject={onInject}
-          codeVariation={MarkdownCodeVariations.WithCopyAndInject}
-        >
-          <Thread
-            theme={theme}
-            availableModels={availableModels}
-            onModelSelected={onModelSelected}
-            isModelSelectorLoading={isModelSelectorLoading}
-            selectedModel={selectedModel}
-          />
-        </ThreadExtraContextProvider>
-      </AssistantRuntimeProvider>
-    </StepSettingsAssistantUiChatContainer>
+    ></StepSettingsAssistantUiChatContainer>
   );
 };
 

--- a/packages/react-ui/src/app/features/builder/ai-chat/step-settings-assistant-ui-chat.tsx
+++ b/packages/react-ui/src/app/features/builder/ai-chat/step-settings-assistant-ui-chat.tsx
@@ -1,0 +1,115 @@
+import { useTheme } from '@/app/common/providers/theme-provider';
+import { AssistantRuntimeProvider } from '@assistant-ui/react';
+import {
+  AI_CHAT_CONTAINER_SIZES,
+  AiCliChatContainerSizeState,
+  cn,
+  MarkdownCodeVariations,
+  StepSettingsAssistantUiChatContainer,
+  Thread,
+  ThreadExtraContextProvider,
+} from '@openops/components/ui';
+import { FlowVersion } from '@openops/shared';
+import { t } from 'i18next';
+import { useCallback } from 'react';
+import { useAiModelSelector } from '../../ai/lib/ai-model-selector-hook';
+import { useStepSettingsAssistantChat } from '../assistant-ui/hooks/use-step-settings-assistant-chat';
+import { useBuilderStateContext } from '../builder-hooks';
+import { DataSelectorSizeState } from '../data-selector/data-selector-size-togglers';
+
+type StepSettingsAssistantUiChatProps = {
+  middlePanelSize: {
+    width: number;
+    height: number;
+  };
+  selectedStep: string;
+  flowVersion: FlowVersion;
+};
+
+const StepSettingsAssistantUiChat = ({
+  middlePanelSize,
+  selectedStep,
+  flowVersion,
+}: StepSettingsAssistantUiChatProps) => {
+  const { theme } = useTheme();
+
+  const [
+    { showDataSelector, dataSelectorSize, aiContainerSize, showAiChat },
+    dispatch,
+  ] = useBuilderStateContext((state) => [
+    state.midpanelState,
+    state.applyMidpanelAction,
+  ]);
+
+  const { runtime, createNewChat, onInject } = useStepSettingsAssistantChat(
+    flowVersion,
+    selectedStep,
+  );
+
+  const onToggleContainerSizeState = useCallback(
+    (size: AiCliChatContainerSizeState) => {
+      switch (size) {
+        case AI_CHAT_CONTAINER_SIZES.DOCKED:
+          dispatch({ type: 'AICHAT_DOCK_CLICK' });
+          return;
+        case AI_CHAT_CONTAINER_SIZES.EXPANDED:
+          dispatch({ type: 'AICHAT_EXPAND_CLICK' });
+          break;
+        case AI_CHAT_CONTAINER_SIZES.COLLAPSED:
+          dispatch({ type: 'AICHAT_MIMIZE_CLICK' });
+          break;
+      }
+    },
+    [dispatch],
+  );
+
+  const onCloseClick = useCallback(() => {
+    dispatch({ type: 'AICHAT_CLOSE_CLICK' });
+  }, [dispatch]);
+
+  const {
+    selectedModel,
+    availableModels,
+    onModelSelected,
+    isLoading: isModelSelectorLoading,
+  } = useAiModelSelector();
+
+  return (
+    <StepSettingsAssistantUiChatContainer
+      parentHeight={middlePanelSize.height}
+      parentWidth={middlePanelSize.width}
+      showAiChat={showAiChat}
+      onCloseClick={onCloseClick}
+      enableNewChat={true}
+      onNewChatClick={createNewChat}
+      containerSize={aiContainerSize}
+      toggleContainerSizeState={onToggleContainerSizeState}
+      className={cn('right-0 static', {
+        'children:transition-none':
+          showDataSelector &&
+          showAiChat &&
+          aiContainerSize === AI_CHAT_CONTAINER_SIZES.COLLAPSED &&
+          dataSelectorSize === DataSelectorSizeState.DOCKED,
+      })}
+    >
+      <AssistantRuntimeProvider runtime={runtime}>
+        <ThreadExtraContextProvider
+          greeting={t('How can I help you?')}
+          handleInject={onInject}
+          codeVariation={MarkdownCodeVariations.WithCopyAndInject}
+        >
+          <Thread
+            theme={theme}
+            availableModels={availableModels}
+            onModelSelected={onModelSelected}
+            isModelSelectorLoading={isModelSelectorLoading}
+            selectedModel={selectedModel}
+          />
+        </ThreadExtraContextProvider>
+      </AssistantRuntimeProvider>
+    </StepSettingsAssistantUiChatContainer>
+  );
+};
+
+StepSettingsAssistantUiChat.displayName = 'StepSettingsAssistantUiChat';
+export { StepSettingsAssistantUiChat };

--- a/packages/react-ui/src/app/features/builder/ai-chat/step-settings-assistant-ui-chat.tsx
+++ b/packages/react-ui/src/app/features/builder/ai-chat/step-settings-assistant-ui-chat.tsx
@@ -67,6 +67,9 @@ const StepSettingsAssistantUiChat = ({
     isLoading: isModelSelectorLoading,
   } = useAiModelSelector();
 
+  const showFullWidth =
+    showDataSelector && dataSelectorSize === DataSelectorSizeState.EXPANDED;
+
   return (
     <StepSettingsAssistantUiChatContainer
       parentHeight={middlePanelSize.height}
@@ -77,6 +80,7 @@ const StepSettingsAssistantUiChat = ({
       handleInject={onInject}
       onNewChatClick={createNewChat}
       containerSize={aiContainerSize}
+      showFullWidth={showFullWidth}
       toggleContainerSizeState={onToggleContainerSizeState}
       onModelSelected={onModelSelected}
       isModelSelectorLoading={isModelSelectorLoading}

--- a/packages/react-ui/src/app/features/builder/assistant-ui/hooks/use-step-settings-assistant-chat.ts
+++ b/packages/react-ui/src/app/features/builder/assistant-ui/hooks/use-step-settings-assistant-chat.ts
@@ -1,0 +1,30 @@
+import { useAssistantChat } from '@/app/features/ai/lib/assistant-ui-chat-hook';
+import { FlowVersion, SourceCode } from '@openops/shared';
+import { useCallback } from 'react';
+import { useBuilderStateContext } from '../../builder-hooks';
+
+export const useStepSettingsAssistantChat = (
+  flowVersion: FlowVersion,
+  selectedStep: string,
+) => {
+  const dispatch = useBuilderStateContext((state) => state.applyMidpanelAction);
+
+  const onInject = useCallback(
+    (code: string | SourceCode) => {
+      dispatch({ type: 'ADD_CODE_TO_INJECT', code });
+    },
+    [dispatch],
+  );
+
+  const assistantChat = useAssistantChat({
+    flowVersion,
+    selectedStep,
+  });
+
+  return {
+    ...assistantChat,
+    onInject,
+    flowVersion,
+    selectedStep,
+  };
+};

--- a/packages/react-ui/src/app/features/builder/interactive-builder.tsx
+++ b/packages/react-ui/src/app/features/builder/interactive-builder.tsx
@@ -1,3 +1,4 @@
+import { flagsHooks } from '@/app/common/hooks/flags-hooks';
 import { FLOW_CANVAS_Y_OFFESET } from '@/app/constants/flow-canvas';
 import { AiAssistantButton } from '@/app/features/ai/ai-assistant-button';
 import { AiAssistantChat } from '@/app/features/ai/ai-assistant-chat';
@@ -12,6 +13,7 @@ import {
 import {
   Action,
   ActionType,
+  FlagId,
   flowHelper,
   FlowVersion,
   isNil,
@@ -20,6 +22,7 @@ import {
 import React, { MutableRefObject, useCallback, useEffect, useRef } from 'react';
 import { useDebounceCallback } from 'usehooks-ts';
 import { StepSettingsAiChat } from './ai-chat/step-settings-ai-chat';
+import { StepSettingsAssistantUiChat } from './ai-chat/step-settings-assistant-ui-chat';
 import { textMentionUtils } from './block-properties/text-input-with-mentions/text-input-utils';
 import { BuilderHeader } from './builder-header/builder-header';
 import { useBuilderStateContext } from './builder-hooks';
@@ -149,6 +152,10 @@ const InteractiveBuilder = ({
     }
   };
 
+  const assistantUiEnabled = flagsHooks.useFlag<boolean>(
+    FlagId.ASSISTANT_UI_ENABLED,
+  ).data;
+
   return (
     <InteractiveContextProvider
       selectedStep={selectedStep}
@@ -179,11 +186,20 @@ const InteractiveBuilder = ({
           className="flex flex-col absolute bottom-0 right-0"
           ref={containerRef}
         >
-          <StepSettingsAiChat
-            middlePanelSize={middlePanelSize}
-            selectedStep={selectedStep}
-            flowVersion={flowVersion}
-          />
+          {selectedStep &&
+            (assistantUiEnabled ? (
+              <StepSettingsAssistantUiChat
+                middlePanelSize={middlePanelSize}
+                selectedStep={selectedStep}
+                flowVersion={flowVersion}
+              />
+            ) : (
+              <StepSettingsAiChat
+                middlePanelSize={middlePanelSize}
+                selectedStep={selectedStep}
+                flowVersion={flowVersion}
+              />
+            ))}
           <DataSelector
             parentHeight={middlePanelSize.height}
             parentWidth={middlePanelSize.width}

--- a/packages/ui-components/src/components/ai-chat-container/index.ts
+++ b/packages/ui-components/src/components/ai-chat-container/index.ts
@@ -5,4 +5,5 @@ export * from './ai-scope-selector';
 export * from './assistant-ui-chat-container';
 export * from './no-ai-enabled-popover';
 export * from './step-settings-ai-chat-container';
+export * from './step-settings-assistant-ui-chat-container';
 export * from './types';

--- a/packages/ui-components/src/components/ai-chat-container/step-settings-assistant-ui-chat-container.tsx
+++ b/packages/ui-components/src/components/ai-chat-container/step-settings-assistant-ui-chat-container.tsx
@@ -1,0 +1,109 @@
+import { t } from 'i18next';
+import { Sparkles } from 'lucide-react';
+import { ReactNode, useRef } from 'react';
+import { cn } from '../../lib/cn';
+import { AiChatSizeTogglers } from './ai-chat-size-togglers';
+import { AI_CHAT_CONTAINER_SIZES, AiCliChatContainerSizeState } from './types';
+
+type StepSettingsAssistantUiChatContainerProps = {
+  parentHeight: number;
+  parentWidth: number;
+  showAiChat: boolean;
+  onCloseClick: () => void;
+  onNewChatClick: () => void;
+  containerSize: AiCliChatContainerSizeState;
+  enableNewChat: boolean;
+  toggleContainerSizeState: (state: AiCliChatContainerSizeState) => void;
+  className?: string;
+  children?: ReactNode;
+};
+
+const StepSettingsAssistantUiChatContainer = ({
+  parentHeight,
+  parentWidth,
+  showAiChat,
+  onCloseClick,
+  onNewChatClick,
+  enableNewChat,
+  containerSize,
+  toggleContainerSizeState,
+  className,
+  children,
+}: StepSettingsAssistantUiChatContainerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  let height: number;
+  if (containerSize === AI_CHAT_CONTAINER_SIZES.COLLAPSED) {
+    height = 0;
+  } else if (containerSize === AI_CHAT_CONTAINER_SIZES.DOCKED) {
+    height = 450;
+  } else if (containerSize === AI_CHAT_CONTAINER_SIZES.EXPANDED) {
+    height = parentHeight - 180;
+  } else {
+    height = parentHeight - 100;
+  }
+
+  const width =
+    containerSize !== AI_CHAT_CONTAINER_SIZES.EXPANDED ? 450 : parentWidth - 40;
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        'absolute bottom-[0px] mr-5 mb-5 z-50 transition-all border border-solid border-outline overflow-x-hidden dark:text-primary bg-background shadow-lg rounded-md',
+        {
+          hidden: !showAiChat,
+        },
+        className,
+      )}
+      style={{
+        height: `${height}px`,
+        width: `${width}px`,
+      }}
+    >
+      <div className="h-full flex flex-col">
+        <div
+          className="text-md dark:text-primary items-center font-bold px-5 py-2 flex gap-2 border-b border-gray-200"
+          role="button"
+          tabIndex={0}
+          onClick={() => {
+            if (containerSize === AI_CHAT_CONTAINER_SIZES.COLLAPSED) {
+              toggleContainerSizeState(AI_CHAT_CONTAINER_SIZES.DOCKED);
+            } else {
+              toggleContainerSizeState(AI_CHAT_CONTAINER_SIZES.COLLAPSED);
+            }
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              if (containerSize === AI_CHAT_CONTAINER_SIZES.COLLAPSED) {
+                toggleContainerSizeState(AI_CHAT_CONTAINER_SIZES.DOCKED);
+              } else {
+                toggleContainerSizeState(AI_CHAT_CONTAINER_SIZES.COLLAPSED);
+              }
+            }
+          }}
+          aria-label={t('Toggle AI Chat')}
+        >
+          <Sparkles />
+          {t('AI Chat')}
+          <div className="flex-grow" />
+          <AiChatSizeTogglers
+            state={containerSize}
+            toggleContainerSizeState={toggleContainerSizeState}
+            onCloseClick={onCloseClick}
+            onNewChatClick={onNewChatClick}
+            enableNewChat={enableNewChat}
+          />
+        </div>
+
+        <div className="overflow-hidden flex-1">
+          <div className="flex flex-col h-full">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+StepSettingsAssistantUiChatContainer.displayName =
+  'StepSettingsAssistantUiChatContainer';
+export { StepSettingsAssistantUiChatContainer };

--- a/packages/ui-components/src/components/ai-chat-container/step-settings-assistant-ui-chat-container.tsx
+++ b/packages/ui-components/src/components/ai-chat-container/step-settings-assistant-ui-chat-container.tsx
@@ -11,7 +11,7 @@ import { AI_CHAT_CONTAINER_SIZES, AiCliChatContainerSizeState } from './types';
 
 const COLLAPSED_HEIGHT = 57;
 const DOCKED_HEIGHT = 450;
-const EXPANDED_HEIGHT = 180;
+const EXPANDED_HEIGHT_OFFSET = 122;
 const FULL_WIDTH_HEIGHT = 100;
 const EXPANDED_WIDTH_OFFSET = 40;
 const REGULAR_WIDTH = 450;
@@ -63,7 +63,7 @@ const StepSettingsAssistantUiChatContainer = ({
   } else if (containerSize === AI_CHAT_CONTAINER_SIZES.DOCKED) {
     height = DOCKED_HEIGHT;
   } else if (containerSize === AI_CHAT_CONTAINER_SIZES.EXPANDED) {
-    height = parentHeight - EXPANDED_HEIGHT;
+    height = parentHeight - EXPANDED_HEIGHT_OFFSET;
   } else {
     height = parentHeight - FULL_WIDTH_HEIGHT;
   }

--- a/packages/ui-components/src/components/ai-chat-container/step-settings-assistant-ui-chat-container.tsx
+++ b/packages/ui-components/src/components/ai-chat-container/step-settings-assistant-ui-chat-container.tsx
@@ -1,8 +1,12 @@
+import { Theme } from '@/lib/theme';
+import { AssistantRuntime } from '@assistant-ui/react';
 import { t } from 'i18next';
-import { Sparkles } from 'lucide-react';
-import { ReactNode, useRef } from 'react';
+import { ExpandIcon, MinimizeIcon } from 'lucide-react';
+import { useRef } from 'react';
 import { cn } from '../../lib/cn';
-import { AiChatSizeTogglers } from './ai-chat-size-togglers';
+import { Button } from '../../ui/button';
+import { AssistantUiChatContainer } from '../assistant-ui/assistant-ui-chat-container';
+import { TooltipWrapper } from '../tooltip-wrapper';
 import { AI_CHAT_CONTAINER_SIZES, AiCliChatContainerSizeState } from './types';
 
 type StepSettingsAssistantUiChatContainerProps = {
@@ -15,7 +19,13 @@ type StepSettingsAssistantUiChatContainerProps = {
   enableNewChat: boolean;
   toggleContainerSizeState: (state: AiCliChatContainerSizeState) => void;
   className?: string;
-  children?: ReactNode;
+  isModelSelectorLoading: boolean;
+  selectedModel?: string;
+  availableModels: string[];
+  onModelSelected: (modelName: string) => void;
+  runtime: AssistantRuntime;
+  theme: Theme;
+  handleInject: (code: string) => void;
 };
 
 const StepSettingsAssistantUiChatContainer = ({
@@ -24,11 +34,17 @@ const StepSettingsAssistantUiChatContainer = ({
   showAiChat,
   onCloseClick,
   onNewChatClick,
-  enableNewChat,
   containerSize,
+  enableNewChat,
   toggleContainerSizeState,
   className,
-  children,
+  isModelSelectorLoading,
+  selectedModel,
+  availableModels,
+  onModelSelected,
+  runtime,
+  theme,
+  handleInject,
 }: StepSettingsAssistantUiChatContainerProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -61,9 +77,21 @@ const StepSettingsAssistantUiChatContainer = ({
         width: `${width}px`,
       }}
     >
-      <div className="h-full flex flex-col">
+      <AssistantUiChatContainer
+        handleInject={handleInject}
+        selectedModel={selectedModel}
+        onModelSelected={onModelSelected}
+        isModelSelectorLoading={isModelSelectorLoading}
+        runtime={runtime}
+        onClose={onCloseClick}
+        onNewChat={onNewChatClick}
+        enableNewChat={enableNewChat}
+        availableModels={availableModels}
+        theme={theme}
+        title={t('AI Chat')}
+      >
         <div
-          className="text-md dark:text-primary items-center font-bold px-5 py-2 flex gap-2 border-b border-gray-200"
+          className="text-md dark:text-primary items-center font-bold flex gap-2"
           role="button"
           tabIndex={0}
           onClick={() => {
@@ -84,22 +112,36 @@ const StepSettingsAssistantUiChatContainer = ({
           }}
           aria-label={t('Toggle AI Chat')}
         >
-          <Sparkles />
-          {t('AI Chat')}
-          <div className="flex-grow" />
-          <AiChatSizeTogglers
-            state={containerSize}
-            toggleContainerSizeState={toggleContainerSizeState}
-            onCloseClick={onCloseClick}
-            onNewChatClick={onNewChatClick}
-            enableNewChat={enableNewChat}
-          />
-        </div>
+          <TooltipWrapper
+            tooltipText={
+              containerSize === AI_CHAT_CONTAINER_SIZES.EXPANDED
+                ? t('Dock')
+                : t('Expand')
+            }
+          >
+            <Button
+              size="icon"
+              className="text-outline"
+              onClick={(e) => {
+                e.stopPropagation();
 
-        <div className="overflow-hidden flex-1">
-          <div className="flex flex-col h-full">{children}</div>
+                if (containerSize === AI_CHAT_CONTAINER_SIZES.EXPANDED) {
+                  toggleContainerSizeState(AI_CHAT_CONTAINER_SIZES.DOCKED);
+                } else {
+                  toggleContainerSizeState(AI_CHAT_CONTAINER_SIZES.EXPANDED);
+                }
+              }}
+              variant="basic"
+            >
+              {containerSize === AI_CHAT_CONTAINER_SIZES.EXPANDED ? (
+                <MinimizeIcon size={16} />
+              ) : (
+                <ExpandIcon size={16} />
+              )}
+            </Button>
+          </TooltipWrapper>
         </div>
-      </div>
+      </AssistantUiChatContainer>
     </div>
   );
 };

--- a/packages/ui-components/src/components/ai-chat-container/step-settings-assistant-ui-chat-container.tsx
+++ b/packages/ui-components/src/components/ai-chat-container/step-settings-assistant-ui-chat-container.tsx
@@ -9,6 +9,13 @@ import { AssistantUiChatContainer } from '../assistant-ui/assistant-ui-chat-cont
 import { TooltipWrapper } from '../tooltip-wrapper';
 import { AI_CHAT_CONTAINER_SIZES, AiCliChatContainerSizeState } from './types';
 
+const COLLAPSED_HEIGHT = 57;
+const DOCKED_HEIGHT = 450;
+const EXPANDED_HEIGHT = 180;
+const FULL_WIDTH_HEIGHT = 100;
+const EXPANDED_WIDTH_OFFSET = 40;
+const REGULAR_WIDTH = 450;
+
 type StepSettingsAssistantUiChatContainerProps = {
   parentHeight: number;
   parentWidth: number;
@@ -26,6 +33,7 @@ type StepSettingsAssistantUiChatContainerProps = {
   runtime: AssistantRuntime;
   theme: Theme;
   handleInject: (code: string) => void;
+  showFullWidth: boolean;
 };
 
 const StepSettingsAssistantUiChatContainer = ({
@@ -45,22 +53,27 @@ const StepSettingsAssistantUiChatContainer = ({
   runtime,
   theme,
   handleInject,
+  showFullWidth,
 }: StepSettingsAssistantUiChatContainerProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   let height: number;
   if (containerSize === AI_CHAT_CONTAINER_SIZES.COLLAPSED) {
-    height = 0;
+    height = COLLAPSED_HEIGHT;
   } else if (containerSize === AI_CHAT_CONTAINER_SIZES.DOCKED) {
-    height = 450;
+    height = DOCKED_HEIGHT;
   } else if (containerSize === AI_CHAT_CONTAINER_SIZES.EXPANDED) {
-    height = parentHeight - 180;
+    height = parentHeight - EXPANDED_HEIGHT;
   } else {
-    height = parentHeight - 100;
+    height = parentHeight - FULL_WIDTH_HEIGHT;
   }
 
-  const width =
-    containerSize !== AI_CHAT_CONTAINER_SIZES.EXPANDED ? 450 : parentWidth - 40;
+  let width: number;
+  if (containerSize === AI_CHAT_CONTAINER_SIZES.EXPANDED || showFullWidth) {
+    width = parentWidth - EXPANDED_WIDTH_OFFSET;
+  } else {
+    width = REGULAR_WIDTH;
+  }
 
   return (
     <div
@@ -91,7 +104,7 @@ const StepSettingsAssistantUiChatContainer = ({
         title={t('AI Chat')}
       >
         <div
-          className="text-md dark:text-primary items-center font-bold flex gap-2"
+          className="text-md dark:text-primary items-center font-bold flex"
           role="button"
           tabIndex={0}
           onClick={() => {


### PR DESCRIPTION
Fixes OPS-2114.
There is a [known styling mismatch](https://linear.app/openops/issue/OPS-2265/misalignment-between-assistant-ui-chat-container-vs-data-selector) between Data Selector and AssistantUiChatContainer. It is not in the scope of this PR.

It can be tested on the test env, [here's](https://github.com/openops-cloud/devops/actions/runs/16619153520) the deployment.