### PR TITLE
Extend Github block Oauth2 scope for codespaces access

### DIFF
--- a/packages/blocks/github/src/lib/common/auth.ts
+++ b/packages/blocks/github/src/lib/common/auth.ts
@@ -8,5 +8,5 @@ export const auth = BlockAuth.OAuth2({
   authUrl: 'https://github.com/login/oauth/authorize',
   tokenUrl: 'https://github.com/login/oauth/access_token',
   // Repo is currently required in scope: https://github.com/orgs/discussions/7891
-  scope: ['repo', 'actions:write', 'contents:read'],
+  scope: ['repo', 'actions:write', 'contents:read', 'codespace', 'read:org'],
 });


### PR DESCRIPTION
Adding the 'codespace' and 'read:org' scopes enables:

Full access to the authenticated user's personal Codespaces

Read-only visibility into organization-wide Codespaces (if the user is an org owner)

We currently don't support customizing OAuth scopes via a connection input at creation time. For that reason, I’ve intentionally left out the 'admin:org' scope — it's a privileged permission and not appropriate as a default.