### PR TITLE
Prevent other template filters being reset when user types in the search input

### DIFF
--- a/packages/react-ui/src/app/features/templates/components/select-flow-template-dialog.tsx
+++ b/packages/react-ui/src/app/features/templates/components/select-flow-template-dialog.tsx
@@ -349,7 +349,7 @@ const SelectFlowTemplateDialog = ({
     setSelectedServices([]);
     setSelectedCategories([]);
     resetTemplateDialog();
-  }, [isOpen, resetTemplateDialog, searchText]);
+  }, [isOpen, resetTemplateDialog]);
 
   useEffect(() => {
     resetTemplateDialog();


### PR DESCRIPTION
Part of OPS-1108.

Adjusts templates filtering behavior so that typing in search input when a filter is enabled will further filter (AND) the results.