### PR TITLE
Enable AssistantUI via flag on OSS and localdev environments

### DIFF
--- a/packages/server/shared/src/lib/system/system.ts
+++ b/packages/server/shared/src/lib/system/system.ts
@@ -94,7 +94,7 @@ const systemPropDefaultValues: Partial<Record<SystemProp, string>> = {
   [AppSystemProp.SAMPLE_DATA_SIZE_LIMIT_KB]: '100',
   [AppSystemProp.REQUEST_BODY_LIMIT]: '10',
   [SharedSystemProp.LANGFUSE_HOST]: 'https://us.cloud.langfuse.com',
-  [AppSystemProp.ASSISTANT_UI_ENABLED]: 'false',
+  [AppSystemProp.ASSISTANT_UI_ENABLED]: 'true',
   [AppSystemProp.MAX_LLM_CALLS_WITHOUT_INTERACTION]: '10',
 };
 


### PR DESCRIPTION
Fixes OPS-2305.

PR will not be merged before [OPS-2259](https://linear.app/openops/issue/OPS-2259/add-custom-tool-display-for-code-tool) and dependent tasks are completed.