### PR TITLE
Simplify the config validation prompt to speed up gpt-5 response times

### DIFF
--- a/packages/openops/src/lib/ai/providers.ts
+++ b/packages/openops/src/lib/ai/providers.ts
@@ -102,7 +102,7 @@ export const validateAiProviderConfig = async (
 
     await generateText({
       model: languageModel,
-      prompt: 'Is the connection valid?',
+      prompt: 'Hi',
       ...config.modelSettings,
     });
   } catch (error) {


### PR DESCRIPTION
Fixes OPS-2343.

It seems to make a massive difference for all GPT-5-based models, with the simpler prompt `POST /api/v1/ai/config` consistently taking under 5 seconds.