### PR TITLE
Block some AWS cli commands to prevent faulty configuration state

### DIFF
--- a/packages/blocks/aws/src/lib/actions/cli/aws-cli-action.ts
+++ b/packages/blocks/aws/src/lib/actions/cli/aws-cli-action.ts
@@ -40,8 +40,8 @@ export const awsCliAction = createAction({
 
       if (isCommandBlocked(commandToRun)) {
         throw new Error(
-          `Command blocked: '${commandToRun}' can corrupt the managed authentication system. ` +
-            `Local AWS configuration changes are not permitted to prevent faulty states that require container restarts.`,
+          'This AWS CLI command is blocked to prevent faulty configuration state. ' +
+            "Blocked commands include: 'aws configure', 'aws sso', and 'aws eks update-kubeconfig'.",
         );
       }
 

--- a/packages/blocks/aws/src/lib/actions/cli/aws-cli-action.ts
+++ b/packages/blocks/aws/src/lib/actions/cli/aws-cli-action.ts
@@ -10,9 +10,9 @@ import {
 import { runCommand } from './aws-cli';
 
 const BLOCKED_COMMANDS = [
-  /^aws\s+configure(\s|$)/i,
-  /^aws\s+sso(\s|$)/i,
-  /^aws\s+eks\s+update-kubeconfig(\s|$)/i,
+  /^(aws\s+)?configure(\s|$)/i,
+  /^(aws\s+)?sso(\s|$)/i,
+  /^(aws\s+)?eks\s+update-kubeconfig(\s|$)/i,
 ];
 
 function isCommandBlocked(command: string): boolean {

--- a/packages/blocks/aws/test/cli/aws-cli-action.test.ts
+++ b/packages/blocks/aws/test/cli/aws-cli-action.test.ts
@@ -113,4 +113,155 @@ describe('awsCliAction single account', () => {
 
     expect(awsCliMock.runCommand).not.toHaveBeenCalled();
   });
+
+  describe('blocked commands', () => {
+    test('should call handleCliError for blocked aws configure command', async () => {
+      const context = {
+        ...jest.requireActual('@openops/blocks-framework'),
+        auth: auth,
+        propsValue: {
+          commandToRun: 'aws configure',
+          account: { accounts: 'account' },
+        },
+      };
+
+      await awsCliAction.run(context);
+
+      expect(openOpsMock.handleCliError).toHaveBeenCalledTimes(1);
+      expect(openOpsMock.handleCliError).toHaveBeenCalledWith({
+        provider: 'AWS',
+        command: 'aws configure',
+        error: expect.objectContaining({
+          message:
+            'This AWS CLI command is blocked to prevent faulty configuration state. ' +
+            "Blocked commands include: 'aws configure', 'aws sso', and 'aws eks update-kubeconfig'.",
+        }),
+      });
+      expect(awsCliMock.runCommand).not.toHaveBeenCalled();
+      expect(openOpsMock.getCredentialsForAccount).not.toHaveBeenCalled();
+    });
+
+    test('should call handleCliError for blocked aws configure command with arguments', async () => {
+      const context = {
+        ...jest.requireActual('@openops/blocks-framework'),
+        auth: auth,
+        propsValue: {
+          commandToRun: 'aws configure set region us-east-1',
+          account: { accounts: 'account' },
+        },
+      };
+
+      await awsCliAction.run(context);
+
+      expect(openOpsMock.handleCliError).toHaveBeenCalledTimes(1);
+      expect(openOpsMock.handleCliError).toHaveBeenCalledWith({
+        provider: 'AWS',
+        command: 'aws configure set region us-east-1',
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            'This AWS CLI command is blocked to prevent faulty configuration state.',
+          ),
+        }),
+      });
+      expect(awsCliMock.runCommand).not.toHaveBeenCalled();
+    });
+
+    test('should call handleCliError for blocked aws sso command', async () => {
+      const context = {
+        ...jest.requireActual('@openops/blocks-framework'),
+        auth: auth,
+        propsValue: {
+          commandToRun: 'aws sso login',
+          account: { accounts: 'account' },
+        },
+      };
+
+      await awsCliAction.run(context);
+
+      expect(openOpsMock.handleCliError).toHaveBeenCalledTimes(1);
+      expect(openOpsMock.handleCliError).toHaveBeenCalledWith({
+        provider: 'AWS',
+        command: 'aws sso login',
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            'This AWS CLI command is blocked to prevent faulty configuration state.',
+          ),
+        }),
+      });
+      expect(awsCliMock.runCommand).not.toHaveBeenCalled();
+    });
+
+    test('should call handleCliError for blocked aws eks update-kubeconfig command', async () => {
+      const context = {
+        ...jest.requireActual('@openops/blocks-framework'),
+        auth: auth,
+        propsValue: {
+          commandToRun: 'aws eks update-kubeconfig --name my-cluster',
+          account: { accounts: 'account' },
+        },
+      };
+
+      await awsCliAction.run(context);
+
+      expect(openOpsMock.handleCliError).toHaveBeenCalledTimes(1);
+      expect(openOpsMock.handleCliError).toHaveBeenCalledWith({
+        provider: 'AWS',
+        command: 'aws eks update-kubeconfig --name my-cluster',
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            'This AWS CLI command is blocked to prevent faulty configuration state.',
+          ),
+        }),
+      });
+      expect(awsCliMock.runCommand).not.toHaveBeenCalled();
+    });
+
+    test('should handle commands with extra whitespace', async () => {
+      const context = {
+        ...jest.requireActual('@openops/blocks-framework'),
+        auth: auth,
+        propsValue: {
+          commandToRun: '  aws    configure    set    region   us-east-1  ',
+          account: { accounts: 'account' },
+        },
+      };
+
+      await awsCliAction.run(context);
+
+      expect(openOpsMock.handleCliError).toHaveBeenCalledTimes(1);
+      expect(openOpsMock.handleCliError).toHaveBeenCalledWith({
+        provider: 'AWS',
+        command: '  aws    configure    set    region   us-east-1  ',
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            'This AWS CLI command is blocked to prevent faulty configuration state.',
+          ),
+        }),
+      });
+      expect(awsCliMock.runCommand).not.toHaveBeenCalled();
+    });
+
+    test('should allow commands that contain blocked words but are not blocked patterns', async () => {
+      awsCliMock.runCommand.mockResolvedValue('success');
+
+      const context = {
+        ...jest.requireActual('@openops/blocks-framework'),
+        auth: auth,
+        propsValue: {
+          commandToRun: 'aws iam get-user --user-name configure-user',
+          account: { accounts: 'account' },
+        },
+      };
+
+      const result = await awsCliAction.run(context);
+
+      expect(result).toEqual('success');
+      expect(awsCliMock.runCommand).toHaveBeenCalledWith(
+        'aws iam get-user --user-name configure-user',
+        auth.defaultRegion,
+        auth,
+      );
+      expect(openOpsMock.handleCliError).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/blocks/aws/test/cli/aws-cli-action.test.ts
+++ b/packages/blocks/aws/test/cli/aws-cli-action.test.ts
@@ -263,5 +263,30 @@ describe('awsCliAction single account', () => {
       );
       expect(openOpsMock.handleCliError).not.toHaveBeenCalled();
     });
+
+    test('should block commands without aws prefix and with blocked patterns', async () => {
+      const context = {
+        ...jest.requireActual('@openops/blocks-framework'),
+        auth: auth,
+        propsValue: {
+          commandToRun: 'sso login',
+          account: { accounts: 'account' },
+        },
+      };
+
+      await awsCliAction.run(context);
+
+      expect(openOpsMock.handleCliError).toHaveBeenCalledTimes(1);
+      expect(openOpsMock.handleCliError).toHaveBeenCalledWith({
+        provider: 'AWS',
+        command: 'sso login',
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            'This AWS CLI command is blocked to prevent faulty configuration state.',
+          ),
+        }),
+      });
+      expect(awsCliMock.runCommand).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-2147.

## Additional Notes

- Blocked command
<img width="1496" height="737" alt="Screenshot 2025-08-11 at 4 00 52 PM" src="https://github.com/user-attachments/assets/cdfa10af-4eee-45c4-93f8-3da6e63ecd10" />

- Blocked command without aws prefix
<img width="1496" height="737" alt="Screenshot 2025-08-11 at 6 14 00 PM" src="https://github.com/user-attachments/assets/84646ed6-6ada-413a-8ec6-12700742eba4" />



<!--
Why was it changed?
Any relevant context or links?
Add refactoring notes (if applicable), preferably as comments in the code (if you refactored code, explain what was moved/changed and why).
-->

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [ ] I verified all affected areas still work as expected

- [ ] Automated tests were added/updated if necessary

- [ ] Changes are backwards compatible with any existing data, otherwise a migration script is provided

## Visual Changes (if applicable)

If there are UI/UX changes, include at least one of the following:

- Screenshots
- Loom video
- Preview deployment link
