### PR TITLE
Add a note about api key permissions for linear event triggers

### DIFF
--- a/packages/blocks/linear/src/index.ts
+++ b/packages/blocks/linear/src/index.ts
@@ -13,9 +13,11 @@ import { linearUpdatedIssue } from './lib/triggers/updated-issue';
 const markdown = `
 To obtain your API key, follow these steps:
 
-1. Go to settings by clicking your profile-pic (top-left)
+1. Go to settings by clicking your profile-pic (top-left).
 2. Click on the Security & access section in the left pane.
-3. In Personal API keys section, click on the New API key to create a key.`;
+3. In Personal API keys section, click on the New API key to create a key.
+
+⚠️ For a Linear event **Trigger**, you need an API key with admin permissions.`;
 
 export const linearAuth = BlockAuth.SecretAuth({
   authProviderKey: 'Linear',


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-2295.

## Additional Notes

For Linear event triggers, users need an API key with admin permissions. The same is confirmed with Linear's team on their Slack channel.

![Uploading Screenshot 2025-08-13 at 12.07.32 PM.png…]()


## Visual Changes (if applicable)

If there are UI/UX changes, include at least one of the following:

- Screenshots
- Loom video
- Preview deployment link
