### PR TITLE
Add toggle to truncate numeric values when inserting in OpenOps Table

### DIFF
--- a/packages/blocks/openops-tables/src/actions/update-record-action.ts
+++ b/packages/blocks/openops-tables/src/actions/update-record-action.ts
@@ -20,13 +20,6 @@ export const updateRecordAction = createAction({
   displayName: 'Add or Update Record',
   props: {
     tableName: openopsTablesDropdownProperty(),
-    roundToFieldPrecision: Property.Checkbox({
-      displayName: 'Round Numeric Values',
-      description:
-        'When ON, numeric inputs are rounded to the number of decimals specified by the destination field in the table. When OFF, inserts fail if inputs have more decimals than the field allows.',
-      required: false,
-      defaultValue: true,
-    }),
     rowPrimaryKey: Property.DynamicProperties({
       displayName: 'Row Primary Key',
       description:
@@ -113,6 +106,13 @@ export const updateRecordAction = createAction({
         });
         return properties;
       },
+    }),
+    roundToFieldPrecision: Property.Checkbox({
+      displayName: 'Round Numeric Values',
+      description:
+        'When ON, numeric inputs are rounded to the number of decimals specified by the destination field in the table. When OFF, inserts fail if inputs have more decimals than the field allows.',
+      required: false,
+      defaultValue: true,
     }),
   },
   async run(context) {

--- a/packages/blocks/openops-tables/src/actions/update-record-action.ts
+++ b/packages/blocks/openops-tables/src/actions/update-record-action.ts
@@ -114,14 +114,14 @@ export const updateRecordAction = createAction({
       description:
         'When ON, numeric inputs are rounded to the number of decimals specified by the destination field in the table. When OFF, inserts fail if inputs have more decimals than the field allows.',
       required: false,
-      defaultValue: true,
+      defaultValue: false,
     }),
   },
   async run(context) {
     const { rowPrimaryKey, fieldsProperties } = context.propsValue;
     const tableName = context.propsValue.tableName as unknown as string;
     const roundToFieldPrecision =
-      (context.propsValue.roundToFieldPrecision as boolean) ?? true;
+      (context.propsValue.roundToFieldPrecision as boolean) ?? false;
 
     const tableCacheKey = `${context.run.id}-table-${tableName}`;
     const tableId = await cacheWrapper.getOrAdd(

--- a/packages/blocks/openops-tables/src/actions/update-record-action.ts
+++ b/packages/blocks/openops-tables/src/actions/update-record-action.ts
@@ -171,28 +171,29 @@ function getPrimaryKey(rowPrimaryKey: any): string | undefined {
 }
 
 function getFieldDecimalPlaces(field: OpenOpsField): number | undefined {
-  const f = field as any;
-  const s = f.number_decimal_places;
+  const fieldObj = field as any;
+  const decimalPlaces = fieldObj.number_decimal_places;
 
-  return typeof s === 'number' ? s : undefined;
+  return typeof decimalPlaces === 'number' ? decimalPlaces : undefined;
 }
 
 function formatDecimalPlaces(
   value: any,
   decimalPlaces: number,
 ): string | number {
-  const n = typeof value === 'number' ? value : Number(value);
-  if (!Number.isFinite(n)) return value;
-  const s = n.toFixed(decimalPlaces);
-  return decimalPlaces === 0 ? Number(s) : s;
+  const numericValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numericValue)) return value;
+  const roundedValue = numericValue.toFixed(decimalPlaces);
+  return decimalPlaces === 0 ? Number(roundedValue) : roundedValue;
 }
 
 function hasMoreDecimalsThan(value: any, decimalPlaces: number): boolean {
-  const n = typeof value === 'number' ? value : Number(value);
-  if (!Number.isFinite(n)) return false;
+  const numericValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numericValue)) return false;
   const factor = Math.pow(10, decimalPlaces);
   return (
-    Math.abs(n - Math.round(n * factor) / factor) > FLOAT_COMPARISON_EPSILON
+    Math.abs(numericValue - Math.round(numericValue * factor) / factor) >
+    FLOAT_COMPARISON_EPSILON
   );
 }
 

--- a/packages/blocks/openops-tables/test/actions/update-record-action.test.ts
+++ b/packages/blocks/openops-tables/test/actions/update-record-action.test.ts
@@ -37,11 +37,16 @@ describe('updateRowAction', () => {
   });
 
   test('should create action with correct properties', () => {
-    expect(Object.keys(updateRecordAction.props).length).toBe(3);
+    expect(Object.keys(updateRecordAction.props).length).toBe(4);
     expect(updateRecordAction.props).toMatchObject({
       tableName: {
         required: true,
         type: 'DROPDOWN',
+      },
+      roundToFieldPrecision: {
+        type: 'CHECKBOX',
+        required: false,
+        defaultValue: true,
       },
       rowPrimaryKey: {
         required: true,

--- a/packages/blocks/openops-tables/test/actions/update-record-action.test.ts
+++ b/packages/blocks/openops-tables/test/actions/update-record-action.test.ts
@@ -326,7 +326,7 @@ describe('updateRowAction', () => {
     context.propsValue.roundToFieldPrecision = false;
 
     await expect(updateRecordAction.run(context)).rejects.toThrow(
-      'Field "amount" allows 2 decimal place(s); received 3.14159. Enable "Round numeric values (to field precision)" or provide a value with at most 2 decimals.',
+      'Field "amount" allows 2 decimal place(s); received 3.14159. Enable "Round Numeric Values" or provide a value with at most 2 decimals.',
     );
   });
 });

--- a/packages/blocks/openops-tables/test/actions/update-record-action.test.ts
+++ b/packages/blocks/openops-tables/test/actions/update-record-action.test.ts
@@ -46,7 +46,7 @@ describe('updateRowAction', () => {
       roundToFieldPrecision: {
         type: 'CHECKBOX',
         required: false,
-        defaultValue: true,
+        defaultValue: false,
       },
       rowPrimaryKey: {
         required: true,


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-2058.

## Additional Notes

<img width="487" height="113" alt="Screenshot 2025-08-14 at 11 33 38 AM" src="https://github.com/user-attachments/assets/44df0e05-c89f-420a-95a5-c33bf3cbc355" />


<!--
Why was it changed?
Any relevant context or links?
Add refactoring notes (if applicable), preferably as comments in the code (if you refactored code, explain what was moved/changed and why).
-->

## Testing Checklist

Check all that apply:

- [ ] I tested the feature thoroughly, including edge cases

- [ ] I verified all affected areas still work as expected

- [x] Automated tests were added/updated if necessary

- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided

