### PR TITLE
Add workflow job to add release label to Linear issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         description: Deploy the release to the test environment
         default: true
+      label_linear_issues:
+        type: boolean
+        description: Label Linear issues with the release version
+        default: true
 jobs:
   get-version:
     name: Get release version
@@ -22,13 +26,13 @@ jobs:
     outputs:
       version: ${{ inputs.version || steps.semver.outputs.nextVersion }}
     steps:
-    - name: Get next version
-      if: inputs.version == ''
-      id: semver
-      uses: flatherskevin/semver-action@fc3c4e67353e3c45b8164521ddd17c9e38d6d4d8
-      with:
-        incrementLevel: patch
-        source: tags
+      - name: Get next version
+        if: inputs.version == ''
+        id: semver
+        uses: flatherskevin/semver-action@fc3c4e67353e3c45b8164521ddd17c9e38d6d4d8
+        with:
+          incrementLevel: patch
+          source: tags
   tag-images-for-release:
     needs: get-version
     strategy:
@@ -73,6 +77,26 @@ jobs:
             docker buildx imagetools create $SOURCE_IMAGE --tag $PUBLIC_REPOSITORY:latest
             echo "- ✅ Successfully tagged as \`$PUBLIC_REPOSITORY:latest\`" >> $GITHUB_STEP_SUMMARY
           fi
+  label-linear-issues:
+    name: Label Linear issues for ${{ needs.get-version.outputs.version }}
+    needs: [get-version, tag-images-for-release]
+    if: ${{ inputs.label_linear_issues }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Add release label to Linear issues
+        uses: rayonapp/linear-sync@main
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          linearApiKey: ${{ secrets.LINEAR_API_KEY }}
+          ticketPrefix: OPS
+          baseBranch: main
+          maxPrLength: '200'
+          releaseLabel: v${{ needs.get-version.outputs.version }}
   create-release:
     name: Create a release
     if: github.repository == 'openops-cloud/openops'


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes CI-23.

## Things to Note
- This action can only be run before creating a new release, because it would only find PRs made after the latest release available.
- This job requires a ticket prefix. I checked if we could run the job twice, once for OPS and once for CI. But the second job would always fail because the code tries to recreate a version label in Linear and then it would fail. So this job would only tag OPS related issues. 
- This job runs just before the "Create release" job. There may be instances when a draft release is postponed and then skipped for another draft release. Then there is a chance that PRs after last release to be re-tagged with latest version label. 

<!--
Why was it changed?
Any relevant context or links?
Add refactoring notes (if applicable), preferably as comments in the code (if you refactored code, explain what was moved/changed and why).
-->

## Testing Checklist

Check all that apply:

- [ ] I tested the feature thoroughly, including edge cases

- [ ] Changes are backwards compatible with any existing data, otherwise a migration script is provided

