### PR TITLE
Fix handling of empty `attributeName` in EC2 modify instance action

### DIFF
--- a/packages/blocks/aws/src/lib/actions/ec2/ec2-modify-instance-action.ts
+++ b/packages/blocks/aws/src/lib/actions/ec2/ec2-modify-instance-action.ts
@@ -56,7 +56,7 @@ export const ec2ModifyInstanceAction = createAction({
                 attributeName,
               }): Promise<{ [key: string]: any }> => {
                 if (!attributeName) {
-                  return {};
+                  return { attributeValue: {} };
                 }
                 const attributeNameProp = attributeName as unknown as string;
 


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-2365.

https://www.loom.com/share/d8759e0eac214d8a895e931bf2455bd4?sid=40bf5d79-b242-454d-8ecd-7e4b4be1c47f
