### PR TITLE
Remove redundant quotes from inserted text in builder JSON wrapper

### DIFF
--- a/packages/react-ui/src/app/features/builder/block-properties/builder-json-wrapper.tsx
+++ b/packages/react-ui/src/app/features/builder/block-properties/builder-json-wrapper.tsx
@@ -36,7 +36,7 @@ const BuilderJsonEditorWrapper = ({
                   endLineNumber: position.lineNumber,
                   endColumn: position.column,
                 },
-                text: `"{{${propertyPath}}}"`,
+                text: `{{${propertyPath}}}`,
               },
             ]);
           }


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-2401.

After plain inserting we will see the linter error, but it's fine as most of the cases it will be inserted into existing string 

<img width="1924" height="994" alt="image" src="https://github.com/user-attachments/assets/6eac9296-0212-4d6d-8286-6515dbf07a39" />
  


https://www.loom.com/share/4df838aada4b475d8b639da673ac0ae6?sid=177a8085-00f2-42fd-8414-da4f1796b1f2