### PR TITLE
Fix race condition when previously empty step output data is not rendered after clicking Test Step quickly

### DIFF
--- a/packages/react-ui/src/app/features/builder/data-selector/data-selector-cache.ts
+++ b/packages/react-ui/src/app/features/builder/data-selector/data-selector-cache.ts
@@ -79,7 +79,7 @@ export const stepTestOutputCache = new StepTestOutputCache();
 /**
  * Utility to set step test output in both the cache and react-query client.
  */
-export function setStepOutputCache({
+export async function setStepOutputCache({
   stepId,
   flowVersionId,
   output,
@@ -99,8 +99,12 @@ export function setStepOutputCache({
     lastTestDate: dayjs().toISOString(),
     success,
   };
+
   stepTestOutputCache.setStepData(stepId, stepTestOutput);
-  queryClient.setQueryData([QueryKeys.stepTestOutput, flowVersionId, stepId], {
+
+  const queryKey = [QueryKeys.stepTestOutput, flowVersionId, stepId];
+  await queryClient.cancelQueries({ queryKey });
+  queryClient.setQueryData(queryKey, {
     ...stepTestOutput,
     input: formatUtils.formatStepInputOrOutput(input),
   });

--- a/packages/react-ui/src/app/features/builder/data-selector/tests/data-selector-cache.test.ts
+++ b/packages/react-ui/src/app/features/builder/data-selector/tests/data-selector-cache.test.ts
@@ -31,10 +31,12 @@ describe('StepTestOutputCache', () => {
     cache.setStepData('step1', {
       output: { foo: 'bar' },
       lastTestDate: '2024-01-01T00:00:00Z',
+      success: true,
     });
     expect(cache.getStepData('step1')).toEqual({
       output: { foo: 'bar' },
       lastTestDate: '2024-01-01T00:00:00Z',
+      success: true,
     });
   });
 
@@ -42,6 +44,7 @@ describe('StepTestOutputCache', () => {
     cache.setStepData('step1', {
       output: { foo: 'bar' },
       lastTestDate: '2024-01-01T00:00:00Z',
+      success: true,
     });
     cache.setExpanded('step1', true);
     cache.clearStep('step1');
@@ -70,6 +73,7 @@ describe('StepTestOutputCache', () => {
     cache.setStepData('step1', {
       output: { foo: 'bar' },
       lastTestDate: '2024-01-01T00:00:00Z',
+      success: true,
     });
     cache.setExpanded('node1', true);
     cache.clearAll();
@@ -93,33 +97,42 @@ describe('setStepOutputCache', () => {
     jest.clearAllMocks();
   });
 
-  it('should set data in both cache and query client', () => {
+  it('should set data in both cache and query client', async () => {
     const stepId = 'test-step-id';
     const flowVersionId = 'test-flow-version-id';
     const output = { result: 'success' };
     const input = { param: 'value' };
 
-    setStepOutputCache({
+    queryClient.cancelQueries = jest.fn().mockResolvedValue(undefined);
+
+    await setStepOutputCache({
       stepId,
       flowVersionId,
       output,
       input,
       queryClient,
+      success: true,
     });
 
     expect(stepTestOutputCache.getStepData(stepId)).toEqual({
       output: output,
       lastTestDate: '2024-01-01T00:00:00Z',
+      success: true,
     });
 
     expect(formatUtils.formatStepInputOrOutput).toHaveBeenCalledWith(output);
     expect(formatUtils.formatStepInputOrOutput).toHaveBeenCalledWith(input);
+
+    expect(queryClient.cancelQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.stepTestOutput, flowVersionId, stepId],
+    });
 
     expect(queryClient.setQueryData).toHaveBeenCalledWith(
       [QueryKeys.stepTestOutput, flowVersionId, stepId],
       {
         output: output,
         lastTestDate: '2024-01-01T00:00:00Z',
+        success: true,
         input: input,
       },
     );

--- a/packages/react-ui/src/app/features/builder/test-step/step-test-output-hooks.ts
+++ b/packages/react-ui/src/app/features/builder/test-step/step-test-output-hooks.ts
@@ -17,6 +17,7 @@ export const stepTestOutputHooks = {
         const stepTestOutput = await flowsApi.getStepTestOutput(
           flowVersionId,
           stepId,
+          { signal },
         );
 
         if (!signal?.aborted) {

--- a/packages/react-ui/src/app/features/builder/test-step/step-test-output-hooks.ts
+++ b/packages/react-ui/src/app/features/builder/test-step/step-test-output-hooks.ts
@@ -13,13 +13,15 @@ export const stepTestOutputHooks = {
   useStepTestOutput(flowVersionId: string, stepId: string) {
     return useQuery({
       queryKey: [QueryKeys.stepTestOutput, flowVersionId, stepId],
-      queryFn: async () => {
+      queryFn: async ({ signal }) => {
         const stepTestOutput = await flowsApi.getStepTestOutput(
           flowVersionId,
           stepId,
         );
 
-        stepTestOutputCache.setStepData(stepId, stepTestOutput);
+        if (!signal?.aborted) {
+          stepTestOutputCache.setStepData(stepId, stepTestOutput);
+        }
 
         return stepTestOutput;
       },

--- a/packages/react-ui/src/app/features/flows/lib/flows-api.ts
+++ b/packages/react-ui/src/app/features/flows/lib/flows-api.ts
@@ -131,10 +131,16 @@ export const flowsApi = {
       queryParams,
     );
   },
-  getStepTestOutput(flowVersionId: string, stepId: string) {
+  getStepTestOutput(
+    flowVersionId: string,
+    stepId: string,
+    config?: AxiosRequestConfig,
+  ) {
     return api
       .get<Record<string, StepOutputWithData>>(
         `/v1/flow-versions/${flowVersionId}/test-output?stepIds=${stepId}`,
+        undefined,
+        config,
       )
       .then((response) => response[stepId] ?? {});
   },


### PR DESCRIPTION
Fixes OPS-2327.

Before and after demo: https://www.loom.com/share/605947d6957d40b79cc0bfeabe6d0263