### PR TITLE
Add VerdictReason enum to avoid confusion with run status

### DIFF
--- a/packages/engine/src/lib/handler/block-executor.ts
+++ b/packages/engine/src/lib/handler/block-executor.ts
@@ -35,6 +35,7 @@ import { EngineConstants } from './context/engine-constants';
 import {
   ExecutionVerdict,
   FlowExecutorContext,
+  VerdictReason,
 } from './context/flow-execution-context';
 
 type HookResponse = {
@@ -204,7 +205,7 @@ const executeAction: ActionHandler<BlockAction> = async ({
           stepOutput.setOutput(output).setStatus(StepOutputStatus.STOPPED),
         )
         .setVerdict(ExecutionVerdict.SUCCEEDED, {
-          reason: FlowRunStatus.STOPPED,
+          reason: VerdictReason.STOPPED,
           stopResponse: hookResponse.stopResponse.response,
         })
         .increaseTask();
@@ -217,7 +218,7 @@ const executeAction: ActionHandler<BlockAction> = async ({
           stepOutput.setOutput(output).setStatus(StepOutputStatus.PAUSED),
         )
         .setVerdict(ExecutionVerdict.PAUSED, {
-          reason: FlowRunStatus.PAUSED,
+          reason: VerdictReason.PAUSED,
           pauseMetadata: hookResponse.pauseResponse.pauseMetadata,
         });
     }

--- a/packages/engine/src/lib/handler/block-executor.ts
+++ b/packages/engine/src/lib/handler/block-executor.ts
@@ -15,7 +15,6 @@ import {
   AUTHENTICATION_PROPERTY_NAME,
   BlockAction,
   ExecutionType,
-  FlowRunStatus,
   GenericStepOutput,
   isNil,
   StepOutputStatus,

--- a/packages/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/engine/src/lib/handler/context/flow-execution-context.ts
@@ -24,17 +24,23 @@ export enum ExecutionVerdict {
   FAILED = 'FAILED',
 }
 
+export enum VerdictReason {
+  STOPPED = 'STOPPED',
+  PAUSED = 'PAUSED',
+  INTERNAL_ERROR = 'INTERNAL_ERROR',
+}
+
 export type VerdictResponse =
   | {
-      reason: FlowRunStatus.PAUSED;
+      reason: VerdictReason.PAUSED;
       pauseMetadata: PauseMetadata;
     }
   | {
-      reason: FlowRunStatus.STOPPED;
+      reason: VerdictReason.STOPPED;
       stopResponse: StopResponse;
     }
   | {
-      reason: FlowRunStatus.INTERNAL_ERROR;
+      reason: VerdictReason.INTERNAL_ERROR;
     };
 
 export class FlowExecutorContext {
@@ -245,7 +251,7 @@ export class FlowExecutorContext {
     switch (this.verdict) {
       case ExecutionVerdict.FAILED: {
         const verdictResponse = this.verdictResponse;
-        if (verdictResponse?.reason === FlowRunStatus.INTERNAL_ERROR) {
+        if (verdictResponse?.reason === VerdictReason.INTERNAL_ERROR) {
           return {
             ...baseExecutionOutput,
             error: this.error,
@@ -260,7 +266,7 @@ export class FlowExecutorContext {
       }
       case ExecutionVerdict.PAUSED: {
         const verdictResponse = this.verdictResponse;
-        if (verdictResponse?.reason !== FlowRunStatus.PAUSED) {
+        if (verdictResponse?.reason !== VerdictReason.PAUSED) {
           throw new Error(
             'Verdict Response should have pause metadata response',
           );
@@ -279,7 +285,7 @@ export class FlowExecutorContext {
       }
       case ExecutionVerdict.SUCCEEDED: {
         const verdictResponse = this.verdictResponse;
-        if (verdictResponse?.reason === FlowRunStatus.STOPPED) {
+        if (verdictResponse?.reason === VerdictReason.STOPPED) {
           return {
             ...baseExecutionOutput,
             status: FlowRunStatus.SUCCEEDED,

--- a/packages/engine/src/lib/handler/loop-executor.ts
+++ b/packages/engine/src/lib/handler/loop-executor.ts
@@ -2,7 +2,6 @@ import { Store } from '@openops/blocks-framework';
 import {
   Action,
   ActionType,
-  FlowRunStatus,
   isEmpty,
   isNil,
   isString,
@@ -18,6 +17,7 @@ import { EngineConstants } from './context/engine-constants';
 import {
   ExecutionVerdict,
   FlowExecutorContext,
+  VerdictReason,
 } from './context/flow-execution-context';
 import { flowExecutor } from './flow-executor';
 
@@ -223,7 +223,7 @@ async function waitForIterationsToFinishOrPause(
 
     const isPaused =
       verdict === ExecutionVerdict.PAUSED &&
-      verdictResponse?.reason === FlowRunStatus.PAUSED;
+      verdictResponse?.reason === VerdictReason.PAUSED;
 
     if (isPaused) {
       noPausedIterations = false;
@@ -366,7 +366,7 @@ async function generateNextFlowContext(
 
 function pauseLoop(executionState: FlowExecutorContext): FlowExecutorContext {
   return executionState.setVerdict(ExecutionVerdict.PAUSED, {
-    reason: FlowRunStatus.PAUSED,
+    reason: VerdictReason.PAUSED,
     pauseMetadata: {
       executionCorrelationId: executionState.pauseId,
     },

--- a/packages/engine/src/lib/helper/error-handling.ts
+++ b/packages/engine/src/lib/helper/error-handling.ts
@@ -5,6 +5,7 @@ import { EngineConstants } from '../handler/context/engine-constants';
 import {
   ExecutionVerdict,
   FlowExecutorContext,
+  VerdictReason,
   VerdictResponse,
 } from '../handler/context/flow-execution-context';
 import { ExecutionError, ExecutionErrorType } from './execution-errors';
@@ -93,7 +94,7 @@ export const handleExecutionError = (
     message,
     verdictResponse: isEngineError
       ? {
-          reason: FlowRunStatus.INTERNAL_ERROR,
+          reason: VerdictReason.INTERNAL_ERROR,
         }
       : undefined,
   };

--- a/packages/engine/src/lib/helper/error-handling.ts
+++ b/packages/engine/src/lib/helper/error-handling.ts
@@ -1,5 +1,5 @@
 import { SharedSystemProp, system } from '@openops/server-shared';
-import { BlockAction, CodeAction, FlowRunStatus } from '@openops/shared';
+import { BlockAction, CodeAction } from '@openops/shared';
 import { ExecutionMode } from '../core/code/execution-mode';
 import { EngineConstants } from '../handler/context/engine-constants';
 import {

--- a/packages/engine/test/handler/flow-with-response.test.ts
+++ b/packages/engine/test/handler/flow-with-response.test.ts
@@ -1,4 +1,4 @@
-import { ExecutionVerdict, FlowExecutorContext } from '../../src/lib/handler/context/flow-execution-context'
+import { ExecutionVerdict, FlowExecutorContext, VerdictReason } from '../../src/lib/handler/context/flow-execution-context'
 import { flowExecutor } from '../../src/lib/handler/flow-executor'
 import { buildBlockAction, generateMockEngineConstants } from './test-helper'
 import { FlowRunStatus } from '@openops/shared'
@@ -44,7 +44,7 @@ describe('flow with response', () => {
 
         expect(result.verdict).toBe(ExecutionVerdict.SUCCEEDED)
         expect(result.verdictResponse).toEqual({
-            reason: FlowRunStatus.STOPPED,
+            reason: VerdictReason.STOPPED,
             stopResponse: response,
         })
         expect(result.steps.http.output).toEqual(response)

--- a/packages/engine/test/handler/flow-with-response.test.ts
+++ b/packages/engine/test/handler/flow-with-response.test.ts
@@ -1,7 +1,6 @@
 import { ExecutionVerdict, FlowExecutorContext, VerdictReason } from '../../src/lib/handler/context/flow-execution-context'
 import { flowExecutor } from '../../src/lib/handler/flow-executor'
 import { buildBlockAction, generateMockEngineConstants } from './test-helper'
-import { FlowRunStatus } from '@openops/shared'
 
 jest.mock('../../src/lib/services/progress.service', () => ({
     progressService: {

--- a/packages/server/api/src/app/workers/engine-controller.ts
+++ b/packages/server/api/src/app/workers/engine-controller.ts
@@ -130,13 +130,11 @@ export const flowEngineWorker: FastifyPluginAsyncTypebox = async (app) => {
       );
     }
 
-    logger.debug(
-      `Updating run ${runId} to ${getTerminalStatus(runDetails.status)}`,
-    );
+    logger.debug(`Updating run ${runId} to ${runDetails.status}`);
 
     const populatedRun = await flowRunService.updateStatus({
       flowRunId: runId,
-      status: getTerminalStatus(runDetails.status),
+      status: runDetails.status,
       tasks: runDetails.tasks,
       duration: runDetails.duration,
       executionState: getExecutionState(runDetails),
@@ -278,10 +276,6 @@ function getExecutionState(
     steps: flowRunResponse.steps as Record<string, StepOutput>,
   };
 }
-
-const getTerminalStatus = (status: FlowRunStatus): FlowRunStatus => {
-  return status == FlowRunStatus.STOPPED ? FlowRunStatus.SUCCEEDED : status;
-};
 
 async function getFlowResponse(
   result: FlowRunResponse,

--- a/packages/server/api/test/unit/engine/engine-controller.test.ts
+++ b/packages/server/api/test/unit/engine/engine-controller.test.ts
@@ -128,7 +128,7 @@ describe('Engine Controller - update-run endpoint', () => {
       });
     });
 
-    it('should handle STOPPED status and convert to SUCCEEDED', async () => {
+    it('should handle STOPPED status', async () => {
       const request = {
         ...baseRequest,
         body: {
@@ -148,7 +148,7 @@ describe('Engine Controller - update-run endpoint', () => {
 
       expect(flowRunService.updateStatus).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: FlowRunStatus.SUCCEEDED, // STOPPED gets converted to SUCCEEDED
+          status: FlowRunStatus.STOPPED,
         }),
       );
     });


### PR DESCRIPTION

Part of OPS-2497

## Additional Notes
- FlowRunStatus was being used to specify the reason for the final state of the context
- FlowRunStatus was never Stopped even when the reason was Stopped
