### PR TITLE
Rename FlowRunStatus from stopped to aborted

### DIFF
--- a/packages/react-ui/src/app/features/builder/run-details/run-details-helpers.ts
+++ b/packages/react-ui/src/app/features/builder/run-details/run-details-helpers.ts
@@ -25,7 +25,8 @@ export function getRunMessage(
 
 export function getStatusText(status: FlowRunStatus, timeout: number): string {
   switch (status) {
-    case FlowRunStatus.STOPPED:
+    case FlowRunStatus.ABORTED:
+      return t('Workflow Run was aborted');
     case FlowRunStatus.SUCCEEDED:
       return t('Run Succeeded');
     case FlowRunStatus.FAILED:

--- a/packages/react-ui/src/app/features/builder/run-details/tests/run-details-helpers.test.ts
+++ b/packages/react-ui/src/app/features/builder/run-details/tests/run-details-helpers.test.ts
@@ -33,7 +33,7 @@ describe('getRunMessage', () => {
       ['TIMEOUT', FlowRunStatus.TIMEOUT],
       ['SUCCEEDED', FlowRunStatus.SUCCEEDED],
       ['FAILED', FlowRunStatus.FAILED],
-      ['STOPPED', FlowRunStatus.STOPPED],
+      ['ABORTED', FlowRunStatus.ABORTED],
       ['PAUSED', FlowRunStatus.PAUSED],
     ])('when run has %s status with logsFileId', (_, status) => {
       const run = { status, logsFileId: 'some-log-file-id' } as FlowRun;
@@ -86,7 +86,7 @@ describe('getRunMessage', () => {
 describe('getStatusText', () => {
   describe('should return success messages', () => {
     it.each([
-      ['STOPPED', FlowRunStatus.STOPPED],
+      ['ABORTED', FlowRunStatus.ABORTED],
       ['SUCCEEDED', FlowRunStatus.SUCCEEDED],
     ])('when status is %s', (_, status) => {
       const result = getStatusText(status, 60);

--- a/packages/react-ui/src/app/features/flow-runs/lib/flow-run-utils.ts
+++ b/packages/react-ui/src/app/features/flow-runs/lib/flow-run-utils.ts
@@ -76,7 +76,7 @@ export const flowRunUtils = {
           variant: 'success',
           Icon: Check,
         };
-      case FlowRunStatus.STOPPED:
+      case FlowRunStatus.ABORTED:
         return {
           variant: 'success',
           Icon: Check,

--- a/packages/react-ui/src/app/routes/runs/index.tsx
+++ b/packages/react-ui/src/app/routes/runs/index.tsx
@@ -63,7 +63,7 @@ const FlowRunsPage = () => {
         title: t('Status'),
         accessorKey: 'status',
         options: Object.values(FlowRunStatus)
-          .filter((status) => status !== FlowRunStatus.STOPPED)
+          .filter((status) => status !== FlowRunStatus.ABORTED)
           .map((status) => {
             return {
               label: formatUtils.convertEnumToHumanReadable(status),

--- a/packages/server/api/src/app/workers/engine-controller.ts
+++ b/packages/server/api/src/app/workers/engine-controller.ts
@@ -294,7 +294,7 @@ async function getFlowResponse(
         body: {},
         headers: {},
       };
-    case FlowRunStatus.STOPPED:
+    case FlowRunStatus.ABORTED:
       return {
         status: result.stopResponse?.status ?? StatusCodes.OK,
         body: result.stopResponse?.body,

--- a/packages/server/api/test/unit/engine/engine-controller.test.ts
+++ b/packages/server/api/test/unit/engine/engine-controller.test.ts
@@ -128,14 +128,14 @@ describe('Engine Controller - update-run endpoint', () => {
       });
     });
 
-    it('should handle STOPPED status and convert to SUCCEEDED', async () => {
+    it('should handle ABORTED status and convert to SUCCEEDED', async () => {
       const request = {
         ...baseRequest,
         body: {
           ...baseRequest.body,
           runDetails: {
             ...baseRequest.body.runDetails,
-            status: FlowRunStatus.STOPPED,
+            status: FlowRunStatus.ABORTED,
           },
         },
       };
@@ -489,7 +489,7 @@ describe('Engine Controller - update-run endpoint', () => {
           },
         },
         {
-          status: FlowRunStatus.STOPPED,
+          status: FlowRunStatus.ABORTED,
           stopResponse: {
             status: StatusCodes.ACCEPTED,
             body: { message: 'stopped' },
@@ -502,7 +502,7 @@ describe('Engine Controller - update-run endpoint', () => {
           },
         },
         {
-          status: FlowRunStatus.STOPPED,
+          status: FlowRunStatus.ABORTED,
           stopResponse: null,
           expected: {
             status: StatusCodes.OK,

--- a/packages/shared/src/lib/flow-run/execution/flow-execution.ts
+++ b/packages/shared/src/lib/flow-run/execution/flow-execution.ts
@@ -8,7 +8,7 @@ export enum FlowRunStatus {
   INTERNAL_ERROR = 'INTERNAL_ERROR',
   PAUSED = 'PAUSED',
   RUNNING = 'RUNNING',
-  STOPPED = 'STOPPED',
+  ABORTED = 'ABORTED',
   SUCCEEDED = 'SUCCEEDED',
   TIMEOUT = 'TIMEOUT',
 }
@@ -62,7 +62,7 @@ export const FlowRunResponse = Type.Union([
       Type.Literal(FlowRunStatus.RUNNING),
       Type.Literal(FlowRunStatus.TIMEOUT),
       Type.Literal(FlowRunStatus.INTERNAL_ERROR),
-      Type.Literal(FlowRunStatus.STOPPED),
+      Type.Literal(FlowRunStatus.ABORTED),
     ]),
   }),
 ]);
@@ -71,7 +71,7 @@ export type FlowRunResponse = Static<typeof FlowRunResponse>;
 export const isFlowStateTerminal = (status: FlowRunStatus): boolean => {
   return (
     status === FlowRunStatus.SUCCEEDED ||
-    status === FlowRunStatus.STOPPED ||
+    status === FlowRunStatus.ABORTED ||
     status === FlowRunStatus.TIMEOUT ||
     status === FlowRunStatus.FAILED ||
     status === FlowRunStatus.INTERNAL_ERROR


### PR DESCRIPTION

Part of OPS-2497.

## Additional Notes
- Stopped was not being used
- Stay consistent with the UI that will use 'Aborted'