### PR TITLE
Set RiskLevel.HIGH for cli actions

### DIFF
--- a/packages/blocks/aws/src/lib/actions/cli/aws-cli-action.ts
+++ b/packages/blocks/aws/src/lib/actions/cli/aws-cli-action.ts
@@ -7,6 +7,7 @@ import {
   handleCliError,
   tryParseJson,
 } from '@openops/common';
+import { RiskLevel } from '@openops/shared';
 import { runCommand } from './aws-cli';
 
 const BLOCKED_COMMANDS = [
@@ -34,6 +35,7 @@ export const awsCliAction = createAction({
     }),
     dryRun: dryRunCheckBox(),
   },
+  riskLevel: RiskLevel.HIGH,
   async run(context) {
     try {
       const { account, commandToRun, dryRun } = context.propsValue;

--- a/packages/blocks/azure/src/lib/actions/azure-cli-action.ts
+++ b/packages/blocks/azure/src/lib/actions/azure-cli-action.ts
@@ -6,6 +6,7 @@ import {
   handleCliError,
   tryParseJson,
 } from '@openops/common';
+import { RiskLevel } from '@openops/shared';
 import { runCommand } from '../azure-cli';
 import { subDropdown } from '../common-properties';
 
@@ -24,6 +25,7 @@ export const azureCliAction = createAction({
     }),
     dryRun: dryRunCheckBox(),
   },
+  riskLevel: RiskLevel.HIGH,
   async run(context) {
     try {
       const { commandToRun, dryRun } = context.propsValue;

--- a/packages/blocks/google-cloud/src/lib/actions/google-cloud-cli-action.ts
+++ b/packages/blocks/google-cloud/src/lib/actions/google-cloud-cli-action.ts
@@ -6,6 +6,7 @@ import {
   handleCliError,
   tryParseJson,
 } from '@openops/common';
+import { RiskLevel } from '@openops/shared';
 import { projectCliDropdown } from '../common-properties';
 import { runCommand } from '../google-cloud-cli';
 
@@ -27,6 +28,7 @@ export const googleCloudCliAction = createAction({
     }),
     dryRun: dryRunCheckBox(),
   },
+  riskLevel: RiskLevel.HIGH,
   async run(context) {
     try {
       const { commandToRun, dryRun } = context.propsValue;


### PR DESCRIPTION
Part of OPS-1964.

Dismissing the "Risky step" warning for these commonly used steps, it's not in scope of this PR, it's part of this follow-up task: [Ability to dismiss the "Risky step" warning for a step](https://linear.app/openops/issue/OPS-2526/ability-to-dismiss-the-risky-step-warning-for-a-step)