### PR TITLE
Fix react minified issue on token expiry

### DIFF
--- a/packages/react-ui/src/app/common/guards/allow-logged-in-user-only-guard.tsx
+++ b/packages/react-ui/src/app/common/guards/allow-logged-in-user-only-guard.tsx
@@ -46,15 +46,26 @@ export const AllowOnlyLoggedInUserOnlyGuard = ({
   const expired = !token || isJwtExpired(token);
 
   useEffect(() => {
-    if (!isLoggedIn || expired) {
-      navigationUtil.save(location.pathname + location.search);
-      (async () => {
+    let isMounted = true;
+    async function doLogout() {
+      try {
         await authenticationSession.logOut({
           userInitiated: false,
           navigate,
         });
-      })();
+      } catch (e) {
+        if (isMounted) {
+          console.error('Logout failed:', e);
+        }
+      }
     }
+    if (!isLoggedIn || expired) {
+      navigationUtil.save(location.pathname + location.search);
+      doLogout();
+    }
+    return () => {
+      isMounted = false;
+    };
   }, [isLoggedIn, expired, location.pathname, location.search, navigate]);
 
   if (!isLoggedIn || expired) {


### PR DESCRIPTION
Fixes OPS-2428.

### Additional Notes

The bug was caused by calling the asynchronous ```authenticationSession.logOut``` function directly during the render phase. 

So, we move it to useEffect hook and it fixes the issue. 
