### PR TITLE
Add workflow to automatically mark and close stale PRs and issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,46 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '30 18 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-pr-stale: 60
+          days-before-pr-close: 5
+
+          days-before-issue-stale: 60
+          days-before-issue-close: 5
+
+          stale-issue-label: 'stale'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            activity in the last 60 days. It will be closed in 5 days if no further activity occurs. Please
+            feel free to leave a comment if you believe the issue is still relevant.
+            Thank you for your contributions!
+
+          stale-pr-label: 'stale'
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            activity in the last 60 days. It will be closed in 5 days if no further activity occurs. Please
+            feel free to give a status update by leaving a comment. Thank you for your contributions!
+
+          close-issue-message: >
+            This issue has been automatically closed because it has not had any further
+            activity in the last 5 days. Thank you for your contributions!
+          close-pr-message: >
+            This pull request has been automatically closed because it has not had any further
+            activity in the last 5 days. Thank you for your contributions!
+
+          debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
       - id: stale
         uses: actions/stale@v10
         with:
-          debug-only: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] == 'true' || 'false' }}
+          debug-only: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] == 'true') || 'false' }}
 
           days-before-issue-stale: 60
           days-before-issue-close: 5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,12 +1,17 @@
-name: 'Close stale issues and PRs'
+name: Close stale issues and PRs
 
 on:
   schedule:
-    - cron: '30 18 * * 1'
+    - cron: '30 16 * * 1'
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run in dry-run mode (no issues or PRs will be labelled or closed)'
+        required: true
+        default: false
+        type: boolean
 
 permissions:
-  actions: write
   issues: write
   pull-requests: write
   contents: read
@@ -15,26 +20,30 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - id: stale
+        uses: actions/stale@v10
         with:
-          days-before-pr-stale: 60
-          days-before-pr-close: 5
+          debug-only: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] == 'true' || 'false' }}
 
           days-before-issue-stale: 60
           days-before-issue-close: 5
 
+          days-before-pr-stale: 30
+          days-before-pr-close: 5
+
           stale-issue-label: 'stale'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
-            activity in the last 60 days. It will be closed in 5 days if no further activity occurs. Please
-            feel free to leave a comment if you believe the issue is still relevant.
+            activity in the last 60 days. It will be closed in 5 days if no further activity occurs. 
+            Please feel free to leave a comment if you believe the issue is still relevant.
             Thank you for your contributions!
 
           stale-pr-label: 'stale'
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had
-            activity in the last 60 days. It will be closed in 5 days if no further activity occurs. Please
-            feel free to give a status update by leaving a comment. Thank you for your contributions!
+            activity in the last 30 days. It will be closed in 5 days if no further activity occurs. 
+            Please feel free to give a status update by leaving a comment. 
+            Thank you for your contributions!
 
           close-issue-message: >
             This issue has been automatically closed because it has not had any further
@@ -43,4 +52,9 @@ jobs:
             This pull request has been automatically closed because it has not had any further
             activity in the last 5 days. Thank you for your contributions!
 
-          debug-only: true
+          operations-per-run: 50
+
+      - name: Show outputs
+        run: |
+          echo "Staled: ${{ steps.stale.outputs.staled-issues-prs }}"
+          echo "Closed: ${{ steps.stale.outputs.closed-issues-prs }}"


### PR DESCRIPTION
Part of CI-70.

## Additional Notes

- Runs every Monday at 16:30 UTC
- PRs are considered stale after 30 days of inactivity
- Issues are considered stale after 60 days of inactivity
- After a PR/issue is staled, it is closed after a grace period of 5 days
- If an issue or a PR is updated after it is staled, it will not be closed and the counter resets
- Although the default operations (30) is enough, I increased it to 50 just to be future proof

If everything looks good and after test run, I will work on making changes to send a message to Slack channel.

