### PR TITLE
Revert "Add shared tool approval timeout constant (#1259)"

### DIFF
--- a/packages/shared/src/lib/ai/tool-approval/constants.ts
+++ b/packages/shared/src/lib/ai/tool-approval/constants.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_APPROVAL_TIMEOUT = 1 * 60 * 1000;

--- a/packages/shared/src/lib/ai/tool-approval/index.ts
+++ b/packages/shared/src/lib/ai/tool-approval/index.ts
@@ -1,2 +1,7 @@
-export * from './constants';
-export * from './types';
+export type ToolStepContext = {
+  stepName: string;
+  actionDescription?: string;
+  actionName?: string;
+};
+
+export type ToolApprovalType = 'DefaultToolApproval' | 'RiskyStepToolApproval';

--- a/packages/shared/src/lib/ai/tool-approval/types.ts
+++ b/packages/shared/src/lib/ai/tool-approval/types.ts
@@ -1,7 +1,0 @@
-export type ToolStepContext = {
-  stepName: string;
-  actionDescription?: string;
-  actionName?: string;
-};
-
-export type ToolApprovalType = 'DefaultToolApproval' | 'RiskyStepToolApproval';


### PR DESCRIPTION
This reverts commit bcccfffa17314d533235cc6191670f2d50c1a2af.

Part of OPS-2469.