### PR TITLE
Fix system prompt punctuation and spacing at end of default tables enumeration

### DIFF
--- a/packages/server/api/src/app/ai/mcp/llm-query-router.ts
+++ b/packages/server/api/src/app/ai/mcp/llm-query-router.ts
@@ -117,7 +117,7 @@ const getSystemPrompt = (
     `Default tables in the system: "Business units", "Tag-Owner mapping", "Idle EBS Volumes to delete", "Auto EC2 instances shutdown", "Resource BU tag assignment", "Opportunities", "Aggregated Costs", "Known cost types by application", "Auto instances shutdown" ` +
     `IMPORTANT: Tables tools should always be included in the output if the user asks a question involving those table names: ${openopsTablesNames.join(
       ', ',
-    )}` +
+    )}. ` +
     "Additionally, classify the user's query into one or more of the provided categories. A single query can qualify for multiple categories. " +
     'Include ALL relevant categories that apply to the query. ' +
     `${uiContext ? `${buildUIContextSection(uiContext)}\n` : ''}


### PR DESCRIPTION
Part of OPS-2601.
Part of the system prompt with the punctuation problem:

> IMPORTANT: Tables tools should always be included in the output if the user asks a question involving those table names: User Distinct Ids, Github users, Business units, Tag-Owner mapping, Idle EBS Volumes to delete, Auto EC2 instances shutdown, Resource BU tag assignment, Opportunities, Aggregated Costs, Known cost types by application, Users, Sent reminders, Auto instances _shutdown_**Additionally**, classify the user's query into one or more of the provided 