### PR TITLE
Fix Stop execution block to not change the verdict to SUCCEEDED

### DIFF
--- a/packages/engine/src/lib/handler/block-executor.ts
+++ b/packages/engine/src/lib/handler/block-executor.ts
@@ -203,7 +203,7 @@ const executeAction: ActionHandler<BlockAction> = async ({
           action.name,
           stepOutput.setOutput(output).setStatus(StepOutputStatus.STOPPED),
         )
-        .setVerdict(ExecutionVerdict.SUCCEEDED, {
+        .setVerdict(ExecutionVerdict.RUNNING, {
           reason: VerdictReason.STOPPED,
           stopResponse: hookResponse.stopResponse.response,
         })

--- a/packages/engine/src/lib/handler/flow-executor.ts
+++ b/packages/engine/src/lib/handler/flow-executor.ts
@@ -18,6 +18,7 @@ import { EngineConstants } from './context/engine-constants';
 import {
   ExecutionVerdict,
   FlowExecutorContext,
+  VerdictReason,
 } from './context/flow-execution-context';
 import { loopExecutor } from './loop-executor';
 import { splitExecutor } from './split-executor';
@@ -107,7 +108,10 @@ export const flowExecutor = {
 
       await sendProgress(flowExecutionContext, constants);
 
-      if (flowExecutionContext.verdict !== ExecutionVerdict.RUNNING) {
+      if (
+        flowExecutionContext.verdict !== ExecutionVerdict.RUNNING ||
+        flowExecutionContext.verdictResponse?.reason === VerdictReason.STOPPED
+      ) {
         break;
       }
 

--- a/packages/engine/test/handler/flow-with-response.test.ts
+++ b/packages/engine/test/handler/flow-with-response.test.ts
@@ -41,7 +41,7 @@ describe('flow with response', () => {
             }), executionState: FlowExecutorContext.empty(), constants: generateMockEngineConstants(),
         })
 
-        expect(result.verdict).toBe(ExecutionVerdict.SUCCEEDED)
+        expect(result.verdict).toBe(ExecutionVerdict.RUNNING)
         expect(result.verdictResponse).toEqual({
             reason: VerdictReason.STOPPED,
             stopResponse: response,


### PR DESCRIPTION
Fixes OPS-2632.

## Additional notes:
- The Stop execution step was marking the run as finished even though it was included inside a loop.
- Now we are marking the execution as finished only when we are returning from the engine to the server.