### PR TITLE
Fix race condition in webhook simulation cleanup

### DIFF
--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -37,6 +37,7 @@ import {
   sendWorkflowExportedEvent,
   sendWorkflowUpdatedEvent,
 } from '../../telemetry/event-models';
+import { webhookSimulationService } from '../../webhooks/webhook-simulation/webhook-simulation-service';
 import {
   flowVersionRepo,
   flowVersionService,
@@ -610,6 +611,11 @@ async function update({
       });
 
       if (lastVersion.state === FlowVersionState.LOCKED) {
+        await webhookSimulationService.delete({
+          flowId: id,
+          projectId,
+        });
+
         const lastVersionWithArtifacts =
           await flowVersionService.getFlowVersionOrThrow({
             flowId: id,


### PR DESCRIPTION
Fixes OPS-2600.

The race condition manifests in this sequence:
- A published flow version exists with webhook simulations
- During import, the system creates a new empty draft version
- The IMPORT_FLOW operation triggers applySingleOperation
- This calls flowVersionSideEffects.preApplyOperation
- preApplyOperation calls deleteWebhookSimulation at the wrong time - when the new flow version is a draft with empty triggers
- This causes the webhook simulation deletion to fail and log an ApplicationError with ErrorCode.TRIGGER_DISABLE
