### PR TITLE
Fix "Inject code" not visible in the AI code assistant

### DIFF
--- a/packages/ui-components/src/components/assistant-ui/generate-code-tool/generate-code-tool.tsx
+++ b/packages/ui-components/src/components/assistant-ui/generate-code-tool/generate-code-tool.tsx
@@ -57,6 +57,7 @@ const GenerateCodeTool = ({ result, status, theme }: GenerateCodeToolProps) => {
         readonly={true}
         showLineNumbers={false}
         className="border border-solid rounded"
+        nativeEditorClassName="min-h-10"
         theme={theme}
         showTabs={true}
         language={getLanguageExtensionForCode('language-typescript')}

--- a/packages/ui-components/src/components/code-editor/code-editor.tsx
+++ b/packages/ui-components/src/components/code-editor/code-editor.tsx
@@ -22,6 +22,7 @@ type CodeEditorProps = {
   onChange?: (value: string | SourceCode) => void;
   className?: string;
   containerClassName?: string;
+  nativeEditorClassName?: string;
   theme: Theme;
   placeholder?: string;
   showLineNumbers?: boolean;
@@ -43,6 +44,7 @@ const CodeEditor = React.forwardRef<CodeEditorRef, CodeEditorProps>(
       onChange,
       className,
       containerClassName,
+      nativeEditorClassName,
       theme,
       placeholder,
       showLineNumbers = true,
@@ -256,7 +258,7 @@ const CodeEditor = React.forwardRef<CodeEditorRef, CodeEditorProps>(
             })}
           >
             <Editor
-              className="min-h-[250px]"
+              className={cn('min-h-[250px]', nativeEditorClassName)}
               value={formatValue(currentValue)}
               language={currentLanguage}
               theme={editorTheme}


### PR DESCRIPTION
Fixes OPS-2686, a regression from [0.5.1]( https://github.com/openops-cloud/openops/commit/dc9b4d89e421bcd14a4963f932bc661b4ad34318#diff-ae40b566f4aa99a3a54d173869c7970724faae543401a6262c572a0046bdd273L259).