### PR TITLE
Add `TooltipWrapper` to display operation details for condition selectors

### DIFF
--- a/packages/react-ui/src/app/features/builder/step-settings/branch-settings/branch-single-condition.tsx
+++ b/packages/react-ui/src/app/features/builder/step-settings/branch-settings/branch-single-condition.tsx
@@ -5,6 +5,7 @@ import {
   FormMessage,
   Label,
   Switch,
+  TooltipWrapper,
   cn,
 } from '@openops/components/ui';
 import {
@@ -107,16 +108,20 @@ const BranchSingleCondition = ({
           name={`settings.conditions.${groupIndex}.${conditionIndex}.operator`}
           control={form.control}
           render={({ field }) => (
-            <FormItem>
-              <SearchableSelect
-                disabled={readonly}
-                value={field.value}
-                options={operationOptions}
-                placeholder={''}
-                onChange={field.onChange}
-              />
-              <FormMessage />
-            </FormItem>
+            <TooltipWrapper
+              tooltipText={field.value && textToBranchOperation[field.value]}
+            >
+              <FormItem>
+                <SearchableSelect
+                  disabled={readonly}
+                  value={field.value}
+                  options={operationOptions}
+                  placeholder={''}
+                  onChange={field.onChange}
+                />
+                <FormMessage />
+              </FormItem>
+            </TooltipWrapper>
           )}
         />
         {!isSingleValueCondition && (

--- a/packages/react-ui/src/app/features/builder/step-settings/split-settings/single-condition.tsx
+++ b/packages/react-ui/src/app/features/builder/step-settings/split-settings/single-condition.tsx
@@ -1,4 +1,10 @@
-import { cn, FormField, FormItem, FormMessage } from '@openops/components/ui';
+import {
+  cn,
+  FormField,
+  FormItem,
+  FormMessage,
+  TooltipWrapper,
+} from '@openops/components/ui';
 import { t } from 'i18next';
 import { useFormContext } from 'react-hook-form';
 
@@ -73,16 +79,20 @@ const SingleCondition = ({
           name={`${groupName}.${conditionIndex}.${0}.operator`}
           control={form.control}
           render={({ field }) => (
-            <FormItem>
-              <SearchableSelect
-                disabled={readonly}
-                value={field.value}
-                options={operationOptions}
-                placeholder={''}
-                onChange={(e) => field.onChange(e)}
-              />
-              <FormMessage />
-            </FormItem>
+            <TooltipWrapper
+              tooltipText={field.value && textToBranchOperation[field.value]}
+            >
+              <FormItem>
+                <SearchableSelect
+                  disabled={readonly}
+                  value={field.value}
+                  options={operationOptions}
+                  placeholder={''}
+                  onChange={(e) => field.onChange(e)}
+                />
+                <FormMessage />
+              </FormItem>
+            </TooltipWrapper>
           )}
         />
         {!isSingleValueCondition && (


### PR DESCRIPTION
Fixes OPS-2698

<img width="380" height="167" alt="image" src="https://github.com/user-attachments/assets/69cd929e-bed4-4a1a-b4e2-dd05bcdcd4ef" />
