### PR TITLE
Add trigger strategy for repeatable jobs

### DIFF
--- a/packages/server/api/src/app/flows/trigger/hooks/enable-trigger-hook.ts
+++ b/packages/server/api/src/app/flows/trigger/hooks/enable-trigger-hook.ts
@@ -137,7 +137,12 @@ export const enableBlockTrigger = async (
 
       const scheduleOptions = engineHelperResponse.result.scheduleOptions;
 
-      await addBlockTriggerToQueue(projectId, flowVersion, scheduleOptions);
+      await addBlockTriggerToQueue(
+        projectId,
+        flowVersion,
+        scheduleOptions,
+        TriggerStrategy.POLLING,
+      );
 
       break;
     }
@@ -150,7 +155,12 @@ export const enableBlockTrigger = async (
         );
       }
 
-      await addBlockTriggerToQueue(projectId, flowVersion, scheduleOptions);
+      await addBlockTriggerToQueue(
+        projectId,
+        flowVersion,
+        scheduleOptions,
+        TriggerStrategy.SCHEDULED,
+      );
 
       break;
     }
@@ -169,6 +179,7 @@ async function addBlockTriggerToQueue(
   projectId: string,
   flowVersion: FlowVersion,
   scheduleOptions: ScheduleOptions,
+  triggerStrategy: TriggerStrategy,
 ): Promise<void> {
   await flowQueue.add({
     executionCorrelationId: flowVersion.id,
@@ -180,6 +191,7 @@ async function addBlockTriggerToQueue(
       flowVersionId: flowVersion.id,
       flowId: flowVersion.flowId,
       triggerType: TriggerType.BLOCK,
+      triggerStrategy,
       jobType: RepeatableJobType.EXECUTE_TRIGGER,
     },
     scheduleOptions,

--- a/packages/server/api/src/app/workers/memory/memory-queue.ts
+++ b/packages/server/api/src/app/workers/memory/memory-queue.ts
@@ -1,4 +1,7 @@
-import { WebhookRenewStrategy } from '@openops/blocks-framework';
+import {
+  TriggerStrategy,
+  WebhookRenewStrategy,
+} from '@openops/blocks-framework';
 import {
   JobType,
   LATEST_JOB_DATA_SCHEMA_VERSION,
@@ -149,6 +152,7 @@ async function renewEnabledRepeating(): Promise<void> {
           flowVersionId: flow.publishedVersionId!,
           flowId: flow.id,
           triggerType: TriggerType.BLOCK,
+          triggerStrategy: TriggerStrategy.SCHEDULED,
           jobType: RepeatableJobType.EXECUTE_TRIGGER,
         },
         scheduleOptions: {

--- a/packages/server/shared/src/lib/job/index.ts
+++ b/packages/server/shared/src/lib/job/index.ts
@@ -79,16 +79,27 @@ export const SavePayloadRequest = Type.Object({
 });
 export type SavePayloadRequest = Static<typeof SavePayloadRequest>;
 
-export const SubmitPayloadsRequest = Type.Object({
+const SubmitPayloadBase = {
   flowVersionId: Type.String(),
   projectId: Type.String(),
   progressUpdateType: Type.Enum(ProgressUpdateType),
   synchronousHandlerId: Type.Optional(Type.String()),
-  executionCorrelationId: Type.String(),
+};
+
+export const SubmitPayloadsRequest = Type.Object({
+  ...SubmitPayloadBase,
   payloads: Type.Array(Type.Unknown()),
 });
 
 export type SubmitPayloadsRequest = Static<typeof SubmitPayloadsRequest>;
+
+export const SubmitPayloadRequest = Type.Object({
+  ...SubmitPayloadBase,
+  executionCorrelationId: Type.String(),
+  payload: Type.Unknown(),
+});
+
+export type SubmitPayloadRequest = Static<typeof SubmitPayloadRequest>;
 
 export const GetRunForWorkerRequest = Type.Object({
   runId: Type.String(),

--- a/packages/server/shared/src/lib/job/job-data.ts
+++ b/packages/server/shared/src/lib/job/job-data.ts
@@ -7,7 +7,7 @@ import {
 } from '@openops/shared';
 import { Static, Type } from '@sinclair/typebox';
 
-export const LATEST_JOB_DATA_SCHEMA_VERSION = 4;
+export const LATEST_JOB_DATA_SCHEMA_VERSION = 5;
 
 export enum RepeatableJobType {
   RENEW_WEBHOOK = 'RENEW_WEBHOOK',

--- a/packages/server/shared/src/lib/job/job-data.ts
+++ b/packages/server/shared/src/lib/job/job-data.ts
@@ -1,3 +1,4 @@
+import { TriggerStrategy } from '@openops/blocks-framework';
 import {
   ExecutionType,
   ProgressUpdateType,
@@ -32,6 +33,7 @@ export const RepeatingJobData = Type.Object({
   flowVersionId: Type.String(),
   flowId: Type.String(),
   triggerType: Type.Enum(TriggerType),
+  triggerStrategy: Type.Enum(TriggerStrategy),
   jobType: Type.Literal(RepeatableJobType.EXECUTE_TRIGGER),
 });
 export type RepeatingJobData = Static<typeof RepeatingJobData>;

--- a/packages/server/worker/src/lib/api/server-api.service.ts
+++ b/packages/server/worker/src/lib/api/server-api.service.ts
@@ -9,6 +9,7 @@ import {
   ResumeRunRequest,
   SavePayloadRequest,
   SendWebhookUpdateRequest,
+  SubmitPayloadRequest,
   SubmitPayloadsRequest,
   UpdateFailureCountRequest,
   UpdateJobRequest,
@@ -66,6 +67,9 @@ export const workerApiService = (workerToken: string) => {
     },
     async startRuns(request: SubmitPayloadsRequest): Promise<FlowRun[]> {
       return client.post<FlowRun[]>('/v1/workers/submit-payloads', request);
+    },
+    async startRun(request: SubmitPayloadRequest): Promise<FlowRun> {
+      return client.post<FlowRun>('/v1/workers/submit-payload', request);
     },
     async sendWebhookUpdate(request: SendWebhookUpdateRequest): Promise<void> {
       await client.post('/v1/workers/send-webhook-update', request);

--- a/packages/server/worker/src/lib/executors/repeating-job-executor.ts
+++ b/packages/server/worker/src/lib/executors/repeating-job-executor.ts
@@ -137,7 +137,7 @@ function shouldUseFlowVersionId(
   triggerStrategy: TriggerStrategy,
   payloads: unknown[],
 ): boolean {
-  return triggerStrategy === TriggerStrategy.SCHEDULED && payloads.length === 0;
+  return triggerStrategy === TriggerStrategy.SCHEDULED && payloads.length === 1;
 }
 
 const consumeRenewWebhookJob = async (

--- a/packages/server/worker/src/lib/executors/repeating-job-executor.ts
+++ b/packages/server/worker/src/lib/executors/repeating-job-executor.ts
@@ -1,3 +1,4 @@
+import { TriggerStrategy } from '@openops/blocks-framework';
 import {
   DelayedJobData,
   logger,
@@ -112,14 +113,32 @@ const consumeBlockTrigger = async (
     },
   );
 
+  if (shouldUseFlowVersionId(data.triggerStrategy, payloads)) {
+    await workerApiService(workerToken).startRun({
+      executionCorrelationId: flowVersion.id,
+      flowVersionId: data.flowVersionId,
+      progressUpdateType: ProgressUpdateType.NONE,
+      projectId: data.projectId,
+      payload: payloads[0],
+    });
+
+    return;
+  }
+
   await workerApiService(workerToken).startRuns({
-    executionCorrelationId: flowVersion.id,
     flowVersionId: data.flowVersionId,
     progressUpdateType: ProgressUpdateType.NONE,
     projectId: data.projectId,
     payloads,
   });
 };
+
+function shouldUseFlowVersionId(
+  triggerStrategy: TriggerStrategy,
+  payloads: unknown[],
+): boolean {
+  return triggerStrategy === TriggerStrategy.SCHEDULED && payloads.length === 0;
+}
 
 const consumeRenewWebhookJob = async (
   data: RenewWebhookJobData,

--- a/packages/server/worker/src/lib/executors/webhook-job-executor.ts
+++ b/packages/server/worker/src/lib/executors/webhook-job-executor.ts
@@ -83,7 +83,6 @@ export const webhookExecutor = {
         ? ProgressUpdateType.WEBHOOK_RESPONSE
         : ProgressUpdateType.NONE,
       synchronousHandlerId: data.synchronousHandlerId ?? undefined,
-      executionCorrelationId: data.executionCorrelationId,
       payloads: filteredPayloads,
     });
     if (isNil(runs) || runs.length === 0 || isNil(runs[0])) {


### PR DESCRIPTION
Fixes OPS-2696.

## Additional notes:
- If the trigger is scheduled, we continue using the flowVersionId as correlationId because we don't want to have runs in parallel. We want the second want to be ignored.
