### PR TITLE
Fix workflow duration

### DIFF
--- a/packages/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/engine/src/lib/handler/context/flow-execution-context.ts
@@ -63,7 +63,7 @@ export class FlowExecutorContext {
     this.tags = copyFrom?.tags ?? [];
     this.steps = copyFrom?.steps ?? {};
     this.pauseId = copyFrom?.pauseId ?? nanoid();
-    this.duration = copyFrom?.duration ?? -1;
+    this.duration = copyFrom?.duration ?? 0;
     this.verdict = copyFrom?.verdict ?? ExecutionVerdict.RUNNING;
     this.verdictResponse = copyFrom?.verdictResponse ?? undefined;
     this.error = copyFrom?.error ?? undefined;
@@ -130,10 +130,11 @@ export class FlowExecutorContext {
     return stepOutput.status === StepOutputStatus.PAUSED;
   }
 
-  public setDuration(duration: number): FlowExecutorContext {
+  public incrementDuration(duration: number): FlowExecutorContext {
+    const newDuration = duration + this.duration;
     return new FlowExecutorContext({
       ...this,
-      duration,
+      duration: newDuration,
     });
   }
 

--- a/packages/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/engine/src/lib/handler/context/flow-execution-context.ts
@@ -130,7 +130,7 @@ export class FlowExecutorContext {
     return stepOutput.status === StepOutputStatus.PAUSED;
   }
 
-  public incrementDuration(duration: number): FlowExecutorContext {
+  public updateDuration(duration: number): FlowExecutorContext {
     const newDuration = duration + this.duration;
     return new FlowExecutorContext({
       ...this,

--- a/packages/engine/src/lib/handler/flow-executor.ts
+++ b/packages/engine/src/lib/handler/flow-executor.ts
@@ -48,16 +48,21 @@ export const flowExecutor = {
     executionState: FlowExecutorContext;
     constants: EngineConstants;
   }): Promise<FlowRunResponse> {
+    const flowStartTime = performance.now();
+
     const output = await flowExecutor.executeFromAction({
       action: trigger.nextAction,
       executionState,
       constants,
     });
 
-    const newContext =
+    let newContext =
       output.verdict === ExecutionVerdict.RUNNING
         ? output.setVerdict(ExecutionVerdict.SUCCEEDED, output.verdictResponse)
         : output;
+
+    const flowEndTime = performance.now();
+    newContext = newContext.incrementDuration(flowEndTime - flowStartTime);
 
     await sendProgress(newContext, constants);
 
@@ -123,7 +128,7 @@ export const flowExecutor = {
 
     const flowEndTime = performance.now();
 
-    return flowExecutionContext.setDuration(flowEndTime - flowStartTime);
+    return flowExecutionContext.incrementDuration(flowEndTime - flowStartTime);
   },
 };
 

--- a/packages/engine/src/lib/handler/flow-executor.ts
+++ b/packages/engine/src/lib/handler/flow-executor.ts
@@ -62,7 +62,7 @@ export const flowExecutor = {
         : output;
 
     const flowEndTime = performance.now();
-    
+
     newContext = newContext.updateDuration(flowEndTime - flowStartTime);
 
     await sendProgress(newContext, constants);

--- a/packages/engine/src/lib/handler/flow-executor.ts
+++ b/packages/engine/src/lib/handler/flow-executor.ts
@@ -62,7 +62,8 @@ export const flowExecutor = {
         : output;
 
     const flowEndTime = performance.now();
-    newContext = newContext.incrementDuration(flowEndTime - flowStartTime);
+    
+    newContext = newContext.updateDuration(flowEndTime - flowStartTime);
 
     await sendProgress(newContext, constants);
 
@@ -128,7 +129,7 @@ export const flowExecutor = {
 
     const flowEndTime = performance.now();
 
-    return flowExecutionContext.incrementDuration(flowEndTime - flowStartTime);
+    return flowExecutionContext.updateDuration(flowEndTime - flowStartTime);
   },
 };
 

--- a/packages/engine/src/lib/operations.ts
+++ b/packages/engine/src/lib/operations.ts
@@ -127,7 +127,10 @@ function getFlowExecutionState(
         }).setOutput(input.triggerPayload),
       );
     case ExecutionType.RESUME: {
-      let flowContext = FlowExecutorContext.empty().increaseTask(input.tasks);
+      let flowContext = FlowExecutorContext.empty()
+        .increaseTask(input.tasks)
+        .updateDuration(input.previousDuration || 0);
+
       for (const [step, output] of Object.entries(input.steps)) {
         flowContext = flowContext.upsertStep(step, output);
       }
@@ -170,6 +173,8 @@ export async function execute(
           flowId: input.flowVersion.flowId,
           flowVersionId: input.flowVersion.id,
         });
+
+        // TODO HERE
 
         const flowExecutorContext = getFlowExecutionState(input);
         const output = await executeFlow(input, flowExecutorContext);

--- a/packages/engine/src/lib/operations.ts
+++ b/packages/engine/src/lib/operations.ts
@@ -174,8 +174,6 @@ export async function execute(
           flowVersionId: input.flowVersion.id,
         });
 
-        // TODO HERE
-
         const flowExecutorContext = getFlowExecutionState(input);
         const output = await executeFlow(input, flowExecutorContext);
         return output;

--- a/packages/server/api/src/app/ai/chat/user-message-handler.ts
+++ b/packages/server/api/src/app/ai/chat/user-message-handler.ts
@@ -153,13 +153,19 @@ async function streamLLMResponse(
           );
         }
       },
-      onAbort: async () => {
+      onAbort: ({ steps }) => {
         sendAiChatAbortedEvent({
           projectId: params.projectId,
           userId: params.userId,
           chatId: params.chatId,
           provider: params.aiConfig.provider,
         });
+        return saveChatHistory(
+          params.chatId,
+          params.userId,
+          params.projectId,
+          steps.flatMap((step) => step.response.messages),
+        );
       },
       abortSignal: params.abortSignal,
     });

--- a/packages/server/worker/src/lib/executors/flow-job-executor.ts
+++ b/packages/server/worker/src/lib/executors/flow-job-executor.ts
@@ -72,6 +72,7 @@ async function prepareInput(
         executionCorrelationId: jobData.executionCorrelationId,
         resumePayload: jobData.payload as ResumePayload,
         progressUpdateType: jobData.progressUpdateType,
+        previousDuration: flowRun.duration,
       };
     }
   }

--- a/packages/shared/src/lib/engine/engine-operation.ts
+++ b/packages/shared/src/lib/engine/engine-operation.ts
@@ -96,6 +96,7 @@ export type BeginExecuteFlowOperation =
 export type ResumeExecuteFlowOperation =
   BaseExecuteFlowOperation<ExecutionType.RESUME> & {
     tasks: number;
+    previousDuration?: number;
     resumePayload: ResumePayload;
   } & ExecutionState;
 


### PR DESCRIPTION
Fixes OPS-2669.

## Additional notes:
- Changed the first value from '-1' to '0'
- We continually add to the previous value. When a workflow has pauses/resumes, the duration will be the sum of all the time the Engine was executing.
