### PR TITLE
Revert JSON editor height by restoring mih-h class in code editor

### DIFF
--- a/packages/ui-components/src/components/code-editor/code-editor.tsx
+++ b/packages/ui-components/src/components/code-editor/code-editor.tsx
@@ -267,7 +267,7 @@ const CodeEditor = React.forwardRef<CodeEditorRef, CodeEditorProps>(
             })}
           >
             <Editor
-              className={cn('min-h-[250px]', nativeEditorClassName)}
+              className={cn('min-h-10', nativeEditorClassName)}
               value={formatValue(currentValue)}
               language={currentLanguage}
               theme={editorTheme}


### PR DESCRIPTION
Fixes OPS-2726.

## Additional Notes
- Regression from the changes made while implementing new step settings UI
https://github.com/openops-cloud/openops/pull/1193/files#diff-ae40b566f4aa99a3a54d173869c7970724faae543401a6262c572a0046bdd273L259

<img width="846" height="572" alt="Screenshot 2025-09-29 at 3 00 18 PM" src="https://github.com/user-attachments/assets/8abd7fc2-d13d-472f-b9af-7d68c754567b" />

