### PR TITLE
Fix error object parsing for invalid connection

### DIFF
--- a/packages/react-ui/src/app/features/connections/components/create-edit-connection-dialog-content.tsx
+++ b/packages/react-ui/src/app/features/connections/components/create-edit-connection-dialog-content.tsx
@@ -184,6 +184,10 @@ const CreateEditConnectionDialogContent = ({
               msg:
                 typeof apError.params.error === 'string'
                   ? apError.params.error
+                  : apError.params.error &&
+                    typeof apError.params.error === 'object' &&
+                    'message' in apError.params.error
+                  ? apError.params.error.message
                   : JSON.stringify(apError.params.error),
             }),
           );

--- a/packages/react-ui/src/app/features/connections/components/create-edit-connection-dialog-content.tsx
+++ b/packages/react-ui/src/app/features/connections/components/create-edit-connection-dialog-content.tsx
@@ -181,7 +181,10 @@ const CreateEditConnectionDialogContent = ({
         } else if (apError.code === ErrorCode.INVALID_APP_CONNECTION) {
           setErrorMessage(
             t('Connection failed with error {msg}', {
-              msg: apError.params.error,
+              msg:
+                typeof apError.params.error === 'string'
+                  ? apError.params.error
+                  : JSON.stringify(apError.params.error),
             }),
           );
         }

--- a/packages/react-ui/src/app/features/connections/components/create-edit-connection-dialog-content.tsx
+++ b/packages/react-ui/src/app/features/connections/components/create-edit-connection-dialog-content.tsx
@@ -49,6 +49,7 @@ import { appConnectionsHooks } from '../lib/app-connections-hooks';
 import {
   buildConnectionSchema,
   createDefaultValues,
+  formatErrorObjectToString,
 } from '../lib/connections-utils';
 import { BasicAuthConnectionSettings } from './basic-secret-connection-settings';
 import { CustomAuthConnectionSettings } from './custom-auth-connection-settings';
@@ -181,14 +182,7 @@ const CreateEditConnectionDialogContent = ({
         } else if (apError.code === ErrorCode.INVALID_APP_CONNECTION) {
           setErrorMessage(
             t('Connection failed with error {msg}', {
-              msg:
-                typeof apError.params.error === 'string'
-                  ? apError.params.error
-                  : apError.params.error &&
-                    typeof apError.params.error === 'object' &&
-                    'message' in apError.params.error
-                  ? apError.params.error.message
-                  : JSON.stringify(apError.params.error),
+              msg: formatErrorObjectToString(apError.params.error),
             }),
           );
         }

--- a/packages/react-ui/src/app/features/connections/lib/connections-utils.ts
+++ b/packages/react-ui/src/app/features/connections/lib/connections-utils.ts
@@ -199,3 +199,18 @@ export const aggregateBlocksByProvider = (
     }, {} as Record<string, BlockMetadataModelSummary>) ?? {},
   );
 };
+
+export function formatErrorObjectToString(error: unknown): string {
+  if (error === undefined || error === null) {
+    return 'Unknown error';
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object' && 'message' in error) {
+    return typeof error.message === 'string'
+      ? error.message
+      : JSON.stringify(error);
+  }
+  return JSON.stringify(error);
+}

--- a/packages/react-ui/src/app/features/connections/lib/tests/connections-utils.test.ts
+++ b/packages/react-ui/src/app/features/connections/lib/tests/connections-utils.test.ts
@@ -1,5 +1,9 @@
 import { BlockMetadataModelSummary } from '@openops/blocks-framework';
-import { aggregateBlocksByProvider, filterBlocks } from '../connections-utils';
+import {
+  aggregateBlocksByProvider,
+  filterBlocks,
+  formatErrorObjectToString,
+} from '../connections-utils';
 
 describe('filterBlocks', () => {
   const blocks: BlockMetadataModelSummary[] = [
@@ -130,5 +134,38 @@ describe('aggregateBlocksByProvider', () => {
     expect(
       result[0].auth && (result[0].auth as any).authProviderKey,
     ).toBeNull();
+  });
+});
+
+describe('formatErrorObjectToString', () => {
+  it('returns the string if error is a string', () => {
+    expect(formatErrorObjectToString('Simple error')).toBe('Simple error');
+  });
+
+  it('returns the message if error is an object with a string message', () => {
+    expect(formatErrorObjectToString({ message: 'Object error message' })).toBe(
+      'Object error message',
+    );
+  });
+
+  it('returns JSON string if error is an object with a non-string message', () => {
+    expect(formatErrorObjectToString({ message: 123 })).toBe('{"message":123}');
+    expect(formatErrorObjectToString({ message: null })).toBe(
+      '{"message":null}',
+    );
+    expect(formatErrorObjectToString({ message: undefined })).toBe('{}');
+  });
+
+  it('returns JSON string if error is an object without message', () => {
+    expect(formatErrorObjectToString({ code: 401 })).toBe('{"code":401}');
+  });
+
+  it('returns JSON string if error is an array', () => {
+    expect(formatErrorObjectToString([1, 2, 3])).toBe('[1,2,3]');
+  });
+
+  it('returns "Unknown error" if error is undefined or null', () => {
+    expect(formatErrorObjectToString(undefined as any)).toBe('Unknown error');
+    expect(formatErrorObjectToString(null as any)).toBe('Unknown error');
   });
 });

--- a/packages/shared/src/lib/common/application-error.ts
+++ b/packages/shared/src/lib/common/application-error.ts
@@ -368,7 +368,7 @@ export type EngineOperationFailureParams = BaseErrorParams<
 export type InvalidAppConnectionParams = BaseErrorParams<
   ErrorCode.INVALID_APP_CONNECTION,
   {
-    error: string;
+    error: string | { message?: string };
   }
 >;
 

--- a/packages/shared/src/lib/common/application-error.ts
+++ b/packages/shared/src/lib/common/application-error.ts
@@ -368,7 +368,7 @@ export type EngineOperationFailureParams = BaseErrorParams<
 export type InvalidAppConnectionParams = BaseErrorParams<
   ErrorCode.INVALID_APP_CONNECTION,
   {
-    error: string | { message?: string };
+    error: string;
   }
 >;
 


### PR DESCRIPTION
Fixes OPS-2742.

## Additional Notes

We have a few blocks which could send the error message as an object instead of a string. Example blocks include Jira, SMTP, Ternary. So this PR converts the error object to string if it is not already a string (in the frontend). 
