### PR TITLE
Prevent flow navigation on clicking workflow status toggle

### DIFF
--- a/packages/react-ui/src/app/features/home/flows-table/flows-table.tsx
+++ b/packages/react-ui/src/app/features/home/flows-table/flows-table.tsx
@@ -53,6 +53,7 @@ const HomeFlowsTable = ({
           columnVisibility={columnVisibility}
           loading={loading}
           stickyHeader
+          nonInteractiveColumns={['actions', 'status']}
           border={false}
           getRowHref={(row) => `/flows/${row.id}`}
           onRowClick={(row, e) => {

--- a/packages/react-ui/src/app/features/home/flows-table/flows-table.tsx
+++ b/packages/react-ui/src/app/features/home/flows-table/flows-table.tsx
@@ -53,7 +53,7 @@ const HomeFlowsTable = ({
           columnVisibility={columnVisibility}
           loading={loading}
           stickyHeader
-          nonInteractiveColumns={['actions', 'status']}
+          navigationExcludedColumns={['actions', 'status']}
           border={false}
           getRowHref={(row) => `/flows/${row.id}`}
           onRowClick={(row, e) => {

--- a/packages/react-ui/src/app/features/home/runs-table/runs-table.tsx
+++ b/packages/react-ui/src/app/features/home/runs-table/runs-table.tsx
@@ -30,7 +30,7 @@ const HomeRunsTable = ({ data, loading }: Props) => {
         loading={loading}
         stickyHeader
         border={false}
-        nonInteractiveColumns={['actions']}
+        navigationExcludedColumns={['actions']}
         emptyStateComponent={<EmptyTableState />}
         getRowHref={(row) => `/runs/${row.id}`}
         onRowClick={(row, e) => {

--- a/packages/react-ui/src/app/features/home/runs-table/runs-table.tsx
+++ b/packages/react-ui/src/app/features/home/runs-table/runs-table.tsx
@@ -30,6 +30,7 @@ const HomeRunsTable = ({ data, loading }: Props) => {
         loading={loading}
         stickyHeader
         border={false}
+        nonInteractiveColumns={['actions']}
         emptyStateComponent={<EmptyTableState />}
         getRowHref={(row) => `/runs/${row.id}`}
         onRowClick={(row, e) => {

--- a/packages/react-ui/src/app/routes/flows/index.tsx
+++ b/packages/react-ui/src/app/routes/flows/index.tsx
@@ -70,7 +70,7 @@ const FlowsPage = () => {
             fetchData={fetchData}
             filters={FLOWS_TABLE_FILTERS}
             columnVisibility={columnVisibility}
-            nonInteractiveColumns={['status', 'actions']}
+            navigationExcludedColumns={['status', 'actions']}
             refresh={tableRefresh}
             getRowHref={(row) =>
               `/flows/${row.id}?${qs.stringify({

--- a/packages/react-ui/src/app/routes/flows/index.tsx
+++ b/packages/react-ui/src/app/routes/flows/index.tsx
@@ -70,6 +70,7 @@ const FlowsPage = () => {
             fetchData={fetchData}
             filters={FLOWS_TABLE_FILTERS}
             columnVisibility={columnVisibility}
+            nonInteractiveColumns={['status', 'actions']}
             refresh={tableRefresh}
             getRowHref={(row) =>
               `/flows/${row.id}?${qs.stringify({

--- a/packages/react-ui/src/app/routes/runs/index.tsx
+++ b/packages/react-ui/src/app/routes/runs/index.tsx
@@ -110,7 +110,7 @@ const FlowRunsPage = () => {
         <DataTable
           columns={columns}
           fetchData={fetchData}
-          nonInteractiveColumns={['actions']}
+          navigationExcludedColumns={['actions']}
           filters={filters}
           refresh={refresh}
           getRowHref={(row) => `/runs/${row.id}`}

--- a/packages/react-ui/src/app/routes/runs/index.tsx
+++ b/packages/react-ui/src/app/routes/runs/index.tsx
@@ -110,6 +110,7 @@ const FlowRunsPage = () => {
         <DataTable
           columns={columns}
           fetchData={fetchData}
+          nonInteractiveColumns={['actions']}
           filters={filters}
           refresh={refresh}
           getRowHref={(row) => `/runs/${row.id}`}

--- a/packages/ui-components/src/ui/data-table.tsx
+++ b/packages/ui-components/src/ui/data-table.tsx
@@ -37,8 +37,6 @@ import {
 } from './table';
 import { INTERNAL_ERROR_TOAST, toast } from './use-toast';
 
-const INTERACTIVE_COLUMN_KEYS = new Set(['actions', 'status']);
-
 export type DataWithId = {
   id?: string;
 };
@@ -103,6 +101,7 @@ interface DataTableProps<
   border?: boolean;
   emptyStateComponent?: React.ReactNode;
   getRowHref?: (row: RowDataWithActions<TData>) => string | undefined;
+  nonInteractiveColumns?: string[];
 }
 
 export function DataTable<
@@ -125,6 +124,7 @@ export function DataTable<
   border = true,
   emptyStateComponent,
   getRowHref,
+  nonInteractiveColumns,
 }: DataTableProps<TData, TValue, Keys, F>) {
   const columns = columnsInitial.concat([
     {
@@ -367,7 +367,7 @@ export function DataTable<
                     {row.getVisibleCells().map((cell) => (
                       <TableCell key={cell.id}>
                         {rowHref &&
-                        !INTERACTIVE_COLUMN_KEYS.has(cell.column.id) ? (
+                        !nonInteractiveColumns?.includes(cell.column.id) ? (
                           <Link
                             to={rowHref}
                             onClick={(e) => e.stopPropagation()}

--- a/packages/ui-components/src/ui/data-table.tsx
+++ b/packages/ui-components/src/ui/data-table.tsx
@@ -37,6 +37,8 @@ import {
 } from './table';
 import { INTERNAL_ERROR_TOAST, toast } from './use-toast';
 
+const INTERACTIVE_COLUMN_KEYS = ['actions', 'status'];
+
 export type DataWithId = {
   id?: string;
 };
@@ -364,7 +366,8 @@ export function DataTable<
                   >
                     {row.getVisibleCells().map((cell) => (
                       <TableCell key={cell.id}>
-                        {rowHref && cell.column.id !== 'actions' ? (
+                        {rowHref &&
+                        !INTERACTIVE_COLUMN_KEYS.includes(cell.column.id) ? (
                           <Link
                             to={rowHref}
                             onClick={(e) => e.stopPropagation()}

--- a/packages/ui-components/src/ui/data-table.tsx
+++ b/packages/ui-components/src/ui/data-table.tsx
@@ -101,7 +101,7 @@ interface DataTableProps<
   border?: boolean;
   emptyStateComponent?: React.ReactNode;
   getRowHref?: (row: RowDataWithActions<TData>) => string | undefined;
-  nonInteractiveColumns?: string[];
+  navigationExcludedColumns?: string[];
 }
 
 export function DataTable<
@@ -124,7 +124,7 @@ export function DataTable<
   border = true,
   emptyStateComponent,
   getRowHref,
-  nonInteractiveColumns,
+  navigationExcludedColumns,
 }: DataTableProps<TData, TValue, Keys, F>) {
   const columns = columnsInitial.concat([
     {
@@ -367,7 +367,7 @@ export function DataTable<
                     {row.getVisibleCells().map((cell) => (
                       <TableCell key={cell.id}>
                         {rowHref &&
-                        !nonInteractiveColumns?.includes(cell.column.id) ? (
+                        !navigationExcludedColumns?.includes(cell.column.id) ? (
                           <Link
                             to={rowHref}
                             onClick={(e) => e.stopPropagation()}

--- a/packages/ui-components/src/ui/data-table.tsx
+++ b/packages/ui-components/src/ui/data-table.tsx
@@ -37,7 +37,7 @@ import {
 } from './table';
 import { INTERNAL_ERROR_TOAST, toast } from './use-toast';
 
-const INTERACTIVE_COLUMN_KEYS = ['actions', 'status'];
+const INTERACTIVE_COLUMN_KEYS = new Set(['actions', 'status']);
 
 export type DataWithId = {
   id?: string;
@@ -367,7 +367,7 @@ export function DataTable<
                     {row.getVisibleCells().map((cell) => (
                       <TableCell key={cell.id}>
                         {rowHref &&
-                        !INTERACTIVE_COLUMN_KEYS.includes(cell.column.id) ? (
+                        !INTERACTIVE_COLUMN_KEYS.has(cell.column.id) ? (
                           <Link
                             to={rowHref}
                             onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
Fixes OPS-2662.

## Additional Notes

This could be a regression of https://github.com/openops-cloud/openops/pull/1242

Since we are wrapping each cell in a row with *Link*, adding event handler directly to the tooltip is not working all the time. So we now do not wrap the *Flow status toggle* with Link. This prevents the flow navigation on clicking the status toggle. 

I've added a new prop to DataTable component to control interactive columns that should not be wrapped with *Link*