### PR TITLE
Use flow id from builder state context to decouple from route definition

### DIFF
--- a/packages/react-ui/src/app/features/builder/hooks/use-flow-updates.ts
+++ b/packages/react-ui/src/app/features/builder/hooks/use-flow-updates.ts
@@ -9,12 +9,10 @@ import {
   WorkflowStepTestedPayload,
   WorkflowStepUpdatedPayload,
 } from '@openops/shared';
-import { useParams } from 'react-router-dom';
 import { useBuilderStateContext } from '../builder-hooks';
 import { stepTestOutputCache } from '../data-selector/data-selector-cache';
 
-export const useFlowUpdates = () => {
-  const { flowId } = useParams();
+export const useFlowUpdates = (flowId: string) => {
   const socket = useSocket();
   const queryClient = useQueryClient();
   const refreshSettings = useBuilderStateContext(

--- a/packages/react-ui/src/app/features/builder/index.tsx
+++ b/packages/react-ui/src/app/features/builder/index.tsx
@@ -218,7 +218,7 @@ const BuilderPage = ({ children }: { children?: ReactNode }) => {
     refetchBlock,
   });
 
-  useFlowUpdates();
+  useFlowUpdates(flowVersion.flowId);
 
   useEffect(() => {
     const viewOnlyParam = searchParams.get(SEARCH_PARAMS.viewOnly) === 'true';


### PR DESCRIPTION
Fixes OPS-2771, more about it [here](https://linear.app/openops/issue/OPS-2771/add-page-llm-live-update-in-templates-page#comment-6d730d3b).