### PR TITLE
Prevent Date objects from being converted to empty objects during PostgreSQL sanitization

### DIFF
--- a/packages/shared/src/lib/common/utils/object-utils.ts
+++ b/packages/shared/src/lib/common/utils/object-utils.ts
@@ -59,8 +59,6 @@ export function applyFunctionToValuesSync<T>(
     return obj.map((item) =>
       applyFunctionToValuesSync(item, apply),
     ) as unknown as T;
-  } else if (obj instanceof Date) {
-    return obj as T;
   } else if (isObject(obj)) {
     return Object.fromEntries(
       Object.entries(obj).map(([key, value]) => [


### PR DESCRIPTION
Fixes OPS-2838.

Object.entries(dateObject) → returns [] (Date objects have no enumerable properties)
Object.fromEntries([]) → returns {}