### PR TITLE
Refetch test run using polling while run status is FlowRunStatus.SCHEDULED

### DIFF
--- a/packages/react-ui/src/app/features/builder/hooks/use-run-progress.ts
+++ b/packages/react-ui/src/app/features/builder/hooks/use-run-progress.ts
@@ -3,7 +3,10 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { useSocket } from '@/app/common/providers/socket-provider';
 import { flowRunsApi } from '@/app/features/flow-runs/lib/flow-runs-api';
+import { api } from '@/app/lib/api';
 import {
+  ApplicationErrorParams,
+  ErrorCode,
   FlowRun,
   FlowRunStatus,
   FlowVersion,
@@ -105,6 +108,17 @@ export const useRunProgress = ({
               setRun(updatedRun, flowVersion);
 
               if (!shouldPollForUpdates(updatedRun.status)) {
+                clearPollingInterval();
+              }
+            }
+          },
+          onError: (err) => {
+            if (api.isError(err)) {
+              const apError = err.response?.data as ApplicationErrorParams;
+              if (
+                apError.code === ErrorCode.FLOW_RUN_NOT_FOUND ||
+                apError.code === ErrorCode.FLOW_RUN_ENDED
+              ) {
                 clearPollingInterval();
               }
             }


### PR DESCRIPTION
Fixes OPS-2842.

When a run is first created in SCHEDULED status, we poll every 1 second to catch the rapid initial transition to RUNNING, then immediately stop polling and rely on websocket events to handle all subsequent status updates efficiently.