### PR TITLE
Prompt for isWriteAction when creating a new action

### DIFF
--- a/packages/cli/src/lib/commands/create-action.ts
+++ b/packages/cli/src/lib/commands/create-action.ts
@@ -22,8 +22,8 @@ export const ${camelCase} = createAction({
   name: '${camelCase}',
   displayName: '${displayName}',
   description: '${description}',
-  props: {},
   isWriteAction: ${isWriteAction},
+  props: {},
   async run() {
     // Action logic here
   },


### PR DESCRIPTION

Fixes OPS-2799.

## Additional Notes

`isWriteAction` is a required property in `CreateActionParams` and we don't have it in the create-action command. Therefore this command created a broken file.

Now we ask user if the action is a write action and it creates the file with correct props.

Fix:

<img width="1108" height="312" alt="Screenshot 2025-10-15 at 2 39 46 PM" src="https://github.com/user-attachments/assets/8547f2cf-d2f4-4f85-af56-0cc2b96c59ac" />

<img width="821" height="352" alt="Screenshot 2025-10-15 at 2 40 19 PM" src="https://github.com/user-attachments/assets/ffdd69cb-cb4b-4fc0-ae99-3beed1243909" />

