### PR TITLE
Fix Searchable select text overlap

### DIFF
--- a/packages/react-ui/src/app/common/components/searchable-select.tsx
+++ b/packages/react-ui/src/app/common/components/searchable-select.tsx
@@ -148,12 +148,9 @@ export const SearchableSelect = <T extends React.Key>({
             data-testid="searchableSelectTrigger"
           >
             <span
-              className={cn(
-                'w-full text-start truncate select-none overflow-hidden',
-                {
-                  'mr-8': showRefresh,
-                },
-              )}
+              className={cn('w-full text-start truncate select-none', {
+                'mr-8': showRefresh,
+              })}
             >
               {selectedIndex > -1 && options[selectedIndex]
                 ? options[selectedIndex].label


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-2905.

<img width="375" height="354" alt="image" src="https://github.com/user-attachments/assets/9cb5cbf8-4102-4b00-b504-b6f9428e26ab" />


