### PR TITLE
Include `user_facing_reasoning` when repairing malformed JSON string by generateObject AI-SDK call

### DIFF
--- a/packages/server/api/src/app/ai/mcp/llm-query-router.ts
+++ b/packages/server/api/src/app/ai/mcp/llm-query-router.ts
@@ -211,7 +211,8 @@ const repairText = (text: string): string | null => {
       query_classification:
         findFirstKeyInObject(parsedText, 'query_classification') || [],
       reasoning: findFirstKeyInObject(parsedText, 'reasoning') || '',
-      user_facing_reasoning: findFirstKeyInObject(parsedText, 'user_facing_reasoning') || '',
+      user_facing_reasoning:
+        findFirstKeyInObject(parsedText, 'user_facing_reasoning') || '',
     });
   } catch (error) {
     return null;

--- a/packages/ui-components/src/components/assistant-ui/thread/reasoning-part.tsx
+++ b/packages/ui-components/src/components/assistant-ui/thread/reasoning-part.tsx
@@ -10,7 +10,7 @@ export const ReasoningPart: FC<ReasoningPartProps> = ({ text }) => {
   if (!text) {
     return null;
   }
-  
+
   return (
     <div className="my-2">
       <ExpandableContent


### PR DESCRIPTION
Fixes OPS-2950.