### PR TITLE
Add descriptions to object definitions in test-run-settings

### DIFF
--- a/packages/shared/src/lib/flow-run/test-run-settings.ts
+++ b/packages/shared/src/lib/flow-run/test-run-settings.ts
@@ -16,7 +16,7 @@ export const TestRunLimit = Type.Object(
     }),
     limit: Type.Number({
       description:
-        'Maximum number of write operations allowed for this action in a single test run.',
+        'Maximum number of times this action will be executed in a single test run.',
     }),
   },
   {


### PR DESCRIPTION
Fixes OPS-2873