### PR TITLE
Remove wrong property description in GitHub block

### DIFF
--- a/packages/blocks/github/src/lib/common/branch-property.ts
+++ b/packages/blocks/github/src/lib/common/branch-property.ts
@@ -8,7 +8,6 @@ import { listBranches } from './github-api';
 export function getBranchProperty(): DropdownProperty<string, true> {
   return Property.Dropdown({
     displayName: 'Branch',
-    description: 'The branch to run the workflow on',
     required: true,
     refreshers: ['repository'],
     options: async ({ repository, auth }) => {


### PR DESCRIPTION
Fixes OPS-2977
<img width="476" height="454" alt="image" src="https://github.com/user-attachments/assets/4ead9aaa-400f-4751-9c2e-c9571e86ab14" />
