### PR TITLE
Fix SSM Runbook link generation to parse version correctly

### DIFF
--- a/packages/blocks/aws/test/ssm/ssm-generate-runbook-link-action.test.ts
+++ b/packages/blocks/aws/test/ssm/ssm-generate-runbook-link-action.test.ts
@@ -54,7 +54,7 @@ describe('ssmGenerateRunbookLinkAction.run', () => {
     const result = (await ssmGenerateRunbookLinkAction.run(ctx)) as RunResult;
 
     expect(result.link).toBe(
-      'https://ap-south-1.console.aws.amazon.com/systems-manager/automation/execute/My-Runbook?region=ap-south-1&documentVersion=3',
+      'https://ap-south-1.console.aws.amazon.com/systems-manager/automation/execute/My-Runbook?region=ap-south-1#documentVersion=3',
     );
   });
 

--- a/packages/openops/src/lib/aws/ssm/generate-ssm-runbook-execution-link.ts
+++ b/packages/openops/src/lib/aws/ssm/generate-ssm-runbook-execution-link.ts
@@ -32,7 +32,7 @@ export const generateBaseSSMRunbookExecutionLink = (
   return `https://${region}.console.aws.amazon.com/systems-manager/automation/execute/${encodeURIComponent(
     runbookName,
   )}?region=${encodeURIComponent(region)}${
-    version ? `&documentVersion=${encodeURIComponent(version)}` : ''
+    version ? `#documentVersion=${encodeURIComponent(version)}` : ''
   }`;
 };
 

--- a/packages/openops/test/aws/ssm/generate-ssm-runbook-execution-link.test.ts
+++ b/packages/openops/test/aws/ssm/generate-ssm-runbook-execution-link.test.ts
@@ -12,7 +12,7 @@ describe('generateBaseSSMRunbookExecutionLink', () => {
     );
 
     expect(url).toBe(
-      'https://us-east-1.console.aws.amazon.com/systems-manager/automation/execute/AWS-RestartEC2Instance?region=us-east-1&documentVersion=1',
+      'https://us-east-1.console.aws.amazon.com/systems-manager/automation/execute/AWS-RestartEC2Instance?region=us-east-1#documentVersion=1',
     );
   });
 
@@ -36,7 +36,7 @@ describe('generateBaseSSMRunbookExecutionLink', () => {
     );
 
     expect(url).toBe(
-      'https://eu-west-1.console.aws.amazon.com/systems-manager/automation/execute/My%20Runbook%2FName?region=eu-west-1&documentVersion=3%24beta',
+      'https://eu-west-1.console.aws.amazon.com/systems-manager/automation/execute/My%20Runbook%2FName?region=eu-west-1#documentVersion=3%24beta',
     );
   });
 });


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-2931.

This is how aws generated link looks like
<img width="1331" height="140" alt="image" src="https://github.com/user-attachments/assets/456f312e-eb25-4454-8212-a254de59ad65" />

