### PR TITLE
Add Hyperglance block

### DIFF
--- a/packages/blocks/hyperglance/.eslintrc.json
+++ b/packages/blocks/hyperglance/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/blocks/hyperglance/README.md
+++ b/packages/blocks/hyperglance/README.md
@@ -1,0 +1,11 @@
+# blocks-hyperglance
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build blocks-hyperglance` to build the library.
+
+## Running unit tests
+
+Run `nx test blocks-hyperglance` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/blocks/hyperglance/jest.config.ts
+++ b/packages/blocks/hyperglance/jest.config.ts
@@ -1,0 +1,11 @@
+export default {
+  displayName: 'blocks-hyperglance',
+  preset: '../../../jest.preset.js',
+  setupFiles: ['../../../jest.env.js'],
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/packages/blocks/hyperglance',
+};

--- a/packages/blocks/hyperglance/package.json
+++ b/packages/blocks/hyperglance/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "hyperglance",
+  "version": "0.0.1"
+}

--- a/packages/blocks/hyperglance/project.json
+++ b/packages/blocks/hyperglance/project.json
@@ -1,0 +1,33 @@
+{
+  "name": "blocks-hyperglance",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/blocks/hyperglance/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/blocks/hyperglance",
+        "tsConfig": "packages/blocks/hyperglance/tsconfig.lib.json",
+        "packageJson": "packages/blocks/hyperglance/package.json",
+        "main": "packages/blocks/hyperglance/src/index.ts",
+        "assets": ["packages/blocks/hyperglance/*.md"],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "packages/blocks/hyperglance/jest.config.ts"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    }
+  }
+}

--- a/packages/blocks/hyperglance/src/index.ts
+++ b/packages/blocks/hyperglance/src/index.ts
@@ -1,0 +1,41 @@
+import { createCustomApiCallAction } from '@openops/blocks-common';
+import { createBlock, Property } from '@openops/blocks-framework';
+import { BlockCategory } from '@openops/shared';
+import { HGAuth, hyperglanceAuth } from './lib/auth';
+import {  getRecommendations} from './lib/actions/getRecommendations';
+import { exportTopologyForGroup } from './lib/actions/exportTopologyForGroup';
+import { searchTopology } from './lib/actions/searchTopology';
+import { getCollectorRecords } from './lib/actions/getCollectorRecords';
+import { getCollectorRecordStatus } from './lib/actions/getCollectorRecordStatus';
+import { getCollectorRecordStatistics } from './lib/actions/getCollectorRecordStatistics';
+
+export const hyperglance = createBlock({
+  displayName: 'Hyperglance',
+  auth: hyperglanceAuth,
+  minimumSupportedRelease: '0.20.0',
+  logoUrl: 'https://static.openops.com/blocks/hyperglance.svg',
+  authors: [],
+  categories: [BlockCategory.FINOPS],
+  actions: [
+    exportTopologyForGroup,
+    getCollectorRecordStatistics,
+    getCollectorRecordStatus,
+    getRecommendations,
+    searchTopology,
+    getCollectorRecords,
+    createCustomApiCallAction({
+      baseUrl: (auth) => {
+        return `${(auth as HGAuth).instanceUrl}/hgapi/`;
+      },
+      auth: hyperglanceAuth,
+      additionalProps: {
+        documentation: Property.MarkDown({
+          value:
+            'For more information, visit the [Hyperglance API documentation](https://support.hyperglance.com/knowledge/getting-started-with-the-hyperglance-api).',
+        }),
+      },
+      name:'customHgApiCall'
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/blocks/hyperglance/src/lib/actions/exportTopologyForGroup.ts
+++ b/packages/blocks/hyperglance/src/lib/actions/exportTopologyForGroup.ts
@@ -1,0 +1,26 @@
+import { createAction } from '@openops/blocks-framework';
+import { hyperglanceAuth } from '../auth';
+import { exportTopology, getAccountProp, getExportTypeProp, getIDProp, getIncludeDependenciesProp, getShowCostProp } from '../hgapi/topology';
+import { getDatasourceProp } from '../hgapi/common';
+
+export const exportTopologyForGroup = createAction({
+  auth: hyperglanceAuth,
+  name: 'exportTopologyForGroup',
+  displayName: 'Export Diagram',
+  description: 'Export a diagram group to PNG or Visio (VSDX)',
+  props: {
+    datasource: getDatasourceProp(),
+    account:getAccountProp(),
+    id:getIDProp(),
+    includeDependencies:getIncludeDependenciesProp(),
+    showCost:getShowCostProp(),
+    exportType : getExportTypeProp()
+  },
+  isWriteAction: false,
+  async run(context) {
+    const {auth, propsValue} = context;
+   
+    return await exportTopology(auth, propsValue);
+  },
+});
+

--- a/packages/blocks/hyperglance/src/lib/actions/getCollectorRecordStatistics.ts
+++ b/packages/blocks/hyperglance/src/lib/actions/getCollectorRecordStatistics.ts
@@ -1,0 +1,20 @@
+import { createAction } from '@openops/blocks-framework';
+import { hyperglanceAuth } from '../auth';
+import { getDatasourceProp } from '../hgapi/common';
+import { getAliasDropdownProp, getRecordStatistics } from '../hgapi/collectorRecords';
+
+export const getCollectorRecordStatistics = createAction({
+  auth: hyperglanceAuth,
+  name: 'getCollectorRecordStatistics',
+  displayName: 'Get Credential Statistics',
+  description: 'Returns Collection Statistics for the credential',
+  props: {
+    datasource: getDatasourceProp({description:'Get credential of this cloud provider'}),
+    alias: getAliasDropdownProp()
+  },
+  isWriteAction: false,
+  async run(context) {
+    const {datasource="", alias} = context.propsValue;
+    return await getRecordStatistics(context.auth, datasource, alias);
+  },
+});

--- a/packages/blocks/hyperglance/src/lib/actions/getCollectorRecordStatus.ts
+++ b/packages/blocks/hyperglance/src/lib/actions/getCollectorRecordStatus.ts
@@ -1,0 +1,20 @@
+import { createAction } from '@openops/blocks-framework';
+import { hyperglanceAuth } from '../auth';
+import { getDatasourceProp } from '../hgapi/common';
+import { getAliasDropdownProp, getRecordStatus } from '../hgapi/collectorRecords';
+
+export const getCollectorRecordStatus = createAction({
+  auth: hyperglanceAuth,
+  name: 'getCollectorRecordStatus',
+  displayName: 'Get Credential Status',
+  description: 'Returns Collector Record Status',
+  props: {
+    datasource: getDatasourceProp({description:'Get credential of this cloud provider'}),
+    alias: getAliasDropdownProp()
+  },
+  isWriteAction: false,
+  async run(context) {
+    const {datasource="", alias} = context.propsValue;
+    return await getRecordStatus(context.auth, datasource, alias);
+  },
+});

--- a/packages/blocks/hyperglance/src/lib/actions/getCollectorRecords.ts
+++ b/packages/blocks/hyperglance/src/lib/actions/getCollectorRecords.ts
@@ -1,0 +1,18 @@
+import { createAction } from '@openops/blocks-framework';
+import { hyperglanceAuth } from '../auth';
+import { getDatasourceProp } from '../hgapi/common';
+import { listRecords } from '../hgapi/collectorRecords';
+
+export const getCollectorRecords = createAction({
+  auth: hyperglanceAuth,
+  name: 'getCollectorRecords',
+  displayName: 'List Credentials',
+  description: 'List All Hyperglance Credentials',
+  props: {
+    datasource: getDatasourceProp({description:'List credentials of this cloud provider'})
+  },
+  isWriteAction: false,
+  async run(context) {
+    return await listRecords(context.auth, context.propsValue.datasource??"");
+  },
+});

--- a/packages/blocks/hyperglance/src/lib/actions/getRecommendations.ts
+++ b/packages/blocks/hyperglance/src/lib/actions/getRecommendations.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@openops/blocks-framework';
+import { hyperglanceAuth } from '../auth';
+import { fetchRecommendations, getRecommendationsProp } from '../hgapi/recommendations';
+import { getDatasourceProp, getResourceTypeProp } from '../hgapi/common';
+
+export const getRecommendations = createAction({
+  auth: hyperglanceAuth,
+  name: 'getRecommendations',
+  displayName: 'Get Recommendations',
+  description: 'Get Recommendations',
+  props: {
+    datasource: getDatasourceProp({description:'Fetch recommendations in regards to this cloud provider'}),
+    type: getResourceTypeProp({required: true, description:'Fetch recommendations in regards to this type of resource'}),
+    recommendations :getRecommendationsProp()
+  },
+  isWriteAction: false,
+  async run(context ) {
+    const {auth, propsValue} = context;
+    const { datasource="", type="" } = propsValue;
+    return await fetchRecommendations(auth, {resourceType:{datasource,type}, recommendation : propsValue.recommendations});
+  }
+});

--- a/packages/blocks/hyperglance/src/lib/actions/searchTopology.ts
+++ b/packages/blocks/hyperglance/src/lib/actions/searchTopology.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@openops/blocks-framework';
+import { hyperglanceAuth } from '../auth';
+import { getAccountProp, getTagKeyProp, getTagValueProp, search, SearchPropsType } from '../hgapi/search';
+import { getDatasourceProp, getResourceTypeProp } from '../hgapi/common';
+
+export const searchTopology = createAction({
+  auth: hyperglanceAuth,
+  name: 'searchTopology',
+  displayName: 'Get Resource List',
+  description: 'Returns a list of all entities which match the applied filter criteria',
+  props: {
+    datasource: getDatasourceProp({ required : false, description:'Get resources in regards to this cloud provider'}),
+    type: getResourceTypeProp({required: true, description:'Get resources in regards to this type of resource'}),
+    account:getAccountProp(),
+    tagKey: getTagKeyProp(),
+    tagValue: getTagValueProp()
+  },
+  isWriteAction: false,
+  async run(context) {
+    return await search(context.auth, context.propsValue as SearchPropsType);
+  },
+});

--- a/packages/blocks/hyperglance/src/lib/auth.ts
+++ b/packages/blocks/hyperglance/src/lib/auth.ts
@@ -1,0 +1,39 @@
+import { BlockAuth, Property } from '@openops/blocks-framework';
+import { makeGetRequest } from './callRestApi';
+
+export const hyperglanceAuth = BlockAuth.CustomAuth({
+  authProviderKey: 'hyperglance',
+  authProviderDisplayName: 'Hyperglance',
+  authProviderLogoUrl: 'https://static.openops.com/blocks/hyperglance.svg',
+  description: `Configure your Hyperglance connection. For more information, visit the [Hyperglance API documentation](https://support.hyperglance.com/knowledge/getting-started-with-the-hyperglance-api).`,
+  required: true,
+  props: {
+    instanceUrl: Property.ShortText({
+      displayName: 'Instance URL',
+      description: 'The instance URL for Hyperglance',
+      required: true,
+    }),
+     authToken: Property.SecretText({
+      displayName: 'Auth Token',
+      description: 'The API auth token. E.g BASIC fhdhdhdbfbdb= ',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+      try {
+        await makeGetRequest(auth.instanceUrl+"/hgapi/", auth.authToken);
+        return { valid: true };
+      } catch (error: any) {
+        const errorMessage = error?.response?.data?.message || error?.response?.statusText || error?.message || 'Unknown error';
+        return {
+          valid: false,
+          error: errorMessage,
+       };
+      }
+  },
+});
+
+export type HGAuth = {
+  instanceUrl: string;
+  authToken: string;
+};

--- a/packages/blocks/hyperglance/src/lib/callRestApi.ts
+++ b/packages/blocks/hyperglance/src/lib/callRestApi.ts
@@ -1,0 +1,54 @@
+import { httpClient, HttpMethod } from '@openops/blocks-common';
+
+export async function makeGetRequest<T = unknown>(
+  url: string,
+  authToken: string,
+  queryParams?: Record<string, string>,
+): Promise<T> {
+  const response = await httpClient.sendRequest({
+    method: HttpMethod.GET,
+    url: url,
+    headers: {
+      Authorization: `${authToken}`,
+      'Content-Type': 'application/json',
+      'Accept': '*/*'
+    },
+    queryParams,
+  });
+  return response.body;
+}
+
+export async function makePostRequest<T = unknown>(
+    url: string,
+    authToken: string,
+    payload: any
+): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method: HttpMethod.POST,
+    url: url,
+    headers: {
+      Authorization: `${authToken}`,
+      'Content-Type': 'application/json',
+      'Accept': '*/*'
+    },
+    body: payload,
+  });
+  return response.body;
+}
+
+//This will be used in future - delete credentials for example
+export async function makeDeleteRequest<T = unknown>(
+  url: string,
+  authToken: string
+): Promise<T> {
+  const response = await httpClient.sendRequest({
+    method: HttpMethod.DELETE,
+    url: url,
+    headers: {
+      Authorization: `${authToken}`,
+      'Content-Type': 'application/json',
+      'Accept': '*/*'
+    }
+  });
+  return response.body;
+}

--- a/packages/blocks/hyperglance/src/lib/hgapi/collectorRecords.ts
+++ b/packages/blocks/hyperglance/src/lib/hgapi/collectorRecords.ts
@@ -1,0 +1,68 @@
+import { HGAuth } from "../auth";
+import { makeDeleteRequest, makeGetRequest, makePostRequest } from "../callRestApi";
+import { Property } from '@openops/blocks-framework';
+
+export function getAliasDropdownProp() {
+    return (
+        Property.Dropdown({
+            displayName: 'Account name',
+            required: true,
+            refreshers:  ['auth', 'datasource'],
+            options: async ({ auth, datasource }) => {
+                if (!auth || !datasource) {
+                    return {
+                        options: [],
+                    };
+                }
+                const hgAuth = auth as HGAuth;
+                const data = await listRecords(hgAuth, datasource as string); 
+                return {
+                    options: data.map((d) => ({
+                        label: d['accountAlias'],
+                        value: d['accountAlias'],
+                    }))
+                }
+            },
+        })
+    );
+}
+
+export function getAliasPlainTextProp() {
+    return Property.ShortText({
+        displayName: 'Account name',
+        required: true
+    })
+}
+
+export function getAccountGroupsProp() {
+    return (Property.Array({
+      displayName: 'Account Groups',
+      description: 'Array of account groups',
+      required: false,
+    }));
+}
+
+export async function listRecords(auth : HGAuth, datasource:string) : Promise<Record<string, any>[]>{
+    const url = auth.instanceUrl+"/hgapi/integrations/"+datasource;
+    return await makeGetRequest(url, auth.authToken);
+}
+
+export async function getRecordStatus(auth : HGAuth, datasource:string, alias:string) {
+    const url = auth.instanceUrl+"/hgapi/integrations/"+datasource+"/"+alias+"/status";
+    return await makeGetRequest(url, auth.authToken);
+}
+
+export async function getRecordStatistics(auth : HGAuth, datasource:string, alias:string) {
+    const url = auth.instanceUrl+"/hgapi/integrations/"+datasource+"/"+alias+"/statistics";
+    return await makeGetRequest(url, auth.authToken);
+}
+
+export async function deleteRecord(auth : HGAuth, datasource:string, alias:string) {
+    const url = auth.instanceUrl+"/hgapi/integrations/"+datasource+"/"+alias;
+    return await makeDeleteRequest(url, auth.authToken);
+}
+
+export async function addRecord(auth : HGAuth, datasource:string, body : Record<string, any>) {
+    const url = auth.instanceUrl+"/hgapi/integrations/"+datasource;
+    return await makePostRequest(url, auth.authToken, body);
+}

--- a/packages/blocks/hyperglance/src/lib/hgapi/common.ts
+++ b/packages/blocks/hyperglance/src/lib/hgapi/common.ts
@@ -1,0 +1,53 @@
+import { Property } from '@openops/blocks-framework';
+import { HGAuth } from "../auth";
+import { makeGetRequest } from "../callRestApi";
+
+type PropType = {required?:boolean, description?:string};
+
+export function getResourceTypeProp (prop?: PropType) {
+    return Property.Dropdown({
+        displayName: 'Resource Type',
+        description: prop?.description?? 'Fetch data in regards to this type of resource',
+        required: prop?.required ?? false,
+        refreshers:  ['auth', 'datasource'],
+        options: async ({ auth, datasource }) => {
+            if (!auth) {
+                return {
+                    options: [],
+                };
+            }
+
+            const hgAuth = auth as HGAuth;
+            type dataType = {
+                datasource: string;
+                entityTypes: string[];
+            };
+            const data: dataType[] = await makeGetRequest(hgAuth.instanceUrl+"/hgapi/entity-types", hgAuth.authToken);
+            const types = data.find((d) => d.datasource === datasource)?.entityTypes ?? [];
+            return {
+                options: types.map((t) => ({
+                    label: t,
+                    value: t,
+                }))
+            }
+        },
+    })
+}
+
+export function getDatasourceProp (prop?: PropType) {
+    return (
+      Property.StaticDropdown({
+        displayName: 'Cloud Provider',
+        description: prop?.description?? 'Fetch data in regards to this cloud provider',
+        required: prop?.required ?? true,
+        options: {
+          options: [
+            { label: 'AWS', value: 'Amazon' },
+            { label: 'Azure', value: 'Azure' },
+            { label: 'GCP', value: 'GCP' },
+            { label: 'Kubernetes', value: 'Kubernetes' }
+          ],
+        },
+      })
+    );
+}

--- a/packages/blocks/hyperglance/src/lib/hgapi/recommendations.ts
+++ b/packages/blocks/hyperglance/src/lib/hgapi/recommendations.ts
@@ -1,0 +1,47 @@
+import { Property } from "@openops/blocks-framework";
+import { HGAuth } from "../auth";
+import { makePostRequest } from "../callRestApi";
+
+export enum RECOMMENDATIONS {
+  COMMITMENT = "Commitment Recommendations",
+  COST_WASTAGE = "Cost Wastage Findings",
+  RIGHT_SIZING = "Right Sizing Recommendations",
+  SNC = "Security And Compliance Findings"
+}
+export function getRecommendationsProp () {
+    return (
+      Property.StaticDropdown({
+        displayName: 'Recommendations Type',
+        description: 'Fetch recommendations in regards to this type',
+        required: true,
+        options: {
+          options: [
+            { label: RECOMMENDATIONS.COMMITMENT, value: RECOMMENDATIONS.COMMITMENT},
+            { label: RECOMMENDATIONS.COST_WASTAGE, value: RECOMMENDATIONS.COST_WASTAGE },
+            { label: RECOMMENDATIONS.RIGHT_SIZING, value: RECOMMENDATIONS.RIGHT_SIZING },
+            { label: RECOMMENDATIONS.SNC, value: RECOMMENDATIONS.SNC },
+          ],
+        },
+      })
+    );
+}
+
+type dataType = {
+      resourceType ?: {
+        datasource: string;
+        type: string;
+      },
+      recommendation: RECOMMENDATIONS
+    };
+
+
+    export async function fetchRecommendations(auth : HGAuth, data:dataType) {
+        const body = {
+            showCommitmentRecommendations : data.recommendation === RECOMMENDATIONS.COMMITMENT, 
+            showCostWastageFindings : data.recommendation === RECOMMENDATIONS.COST_WASTAGE, 
+            showRightSizingRecommendations : data.recommendation === RECOMMENDATIONS.RIGHT_SIZING, 
+            showSecurityAndComplianceFindings: data.recommendation === RECOMMENDATIONS.SNC,
+            resourceType : data.resourceType?.type
+        };
+        return await makePostRequest(auth.instanceUrl+"/hgapi/recommendations/list", auth.authToken, body);
+    }

--- a/packages/blocks/hyperglance/src/lib/hgapi/search.ts
+++ b/packages/blocks/hyperglance/src/lib/hgapi/search.ts
@@ -1,0 +1,60 @@
+import { HGAuth } from "../auth";
+import { Property } from '@openops/blocks-framework';
+import { makeGetRequest } from "../callRestApi";
+export function getAccountProp () {
+    return (
+        Property.ShortText({
+            displayName: 'Filter by Account name',
+            required: false
+        })
+    );
+}
+
+export function getTagKeyProp () {
+    return (
+        Property.ShortText({
+            displayName: 'Filter by Tag Key',
+            required: false
+        })
+    );
+}
+
+export function getTagValueProp () {
+    return (
+        Property.ShortText({
+            displayName: 'Filter by Tag Value',
+            required: false
+        })
+    );
+}
+
+export type SearchPropsType = {
+    datasource?:string;
+    type?:string;
+    account?:string;
+    tagKey?:string;
+    tagValue?:string;
+}
+
+
+export async function search(auth : HGAuth, data:SearchPropsType) {
+    const queryParams: Record<string, string> = {};
+    if(data.datasource){
+        queryParams['datasource'] = data.datasource;
+    }
+    if(data.type){
+        queryParams['type'] = data.type;
+    }
+    if(data.account){
+        queryParams['account'] = data.account;
+    }
+    if(data.tagKey){
+        queryParams['tag_key'] = data.tagKey;
+    }
+    if(data.tagValue){
+        queryParams['tag_value'] = data.tagValue;
+    }
+    
+    const url = auth.instanceUrl+"/hgapi/inventory";
+    return await makeGetRequest(url, auth.authToken, queryParams);
+}

--- a/packages/blocks/hyperglance/src/lib/hgapi/topology.ts
+++ b/packages/blocks/hyperglance/src/lib/hgapi/topology.ts
@@ -1,0 +1,85 @@
+import { HGAuth } from "../auth";
+import { Property } from '@openops/blocks-framework';
+import { makePostRequest } from "../callRestApi";
+
+export function getExportTypeProp () {
+    return (
+      Property.StaticDropdown({
+        displayName: 'Export Type',
+        description: 'Select PNG or Visio export type',
+        required: true,
+        options: {
+          options: [
+            { label: ExportType.PNG, value: ExportType.PNG},
+            { label: ExportType.VISIO, value: ExportType.VISIO },
+          ],
+        },
+      })
+    );
+}
+
+export function getAccountProp () {
+    return (
+        Property.ShortText({
+            displayName: 'Account name',
+            required: false
+            })
+    );
+}
+
+export function getIDProp () {
+    return (
+        Property.ShortText({
+            displayName: 'ID',
+            required: false
+            })
+    );
+}
+
+export function getShowCostProp () {
+    return (
+        Property.Checkbox({
+            displayName: 'Show Cost',
+            required: true,
+            defaultValue:true
+            })
+    );
+}
+
+export function getIncludeDependenciesProp () {
+    return (
+        Property.Checkbox({
+            displayName: 'Include dependencies',
+            required: true,
+            defaultValue:true
+            })
+    );
+}
+
+type TagType = {
+  key:string;
+  value:string;
+}
+
+export enum ExportType {
+  PNG = "PNG",
+  VISIO = "Visio"
+}
+
+type dataType = {
+    datasource?:string;
+    account?:string;
+    id?:string;
+    tagViewIds?:string[];
+    tags?:TagType[];
+    includeDependencies:boolean;
+    showCost:boolean;
+    exportType : ExportType;
+}
+
+
+    export async function exportTopology(auth : HGAuth, data:dataType) {
+        const {exportType, ...body} = data;
+        const url = exportType === ExportType.PNG ? auth.instanceUrl+"/hgapi/export-png" : auth.instanceUrl+"/hgapi/export-vsdx";
+        return await makePostRequest(url, auth.authToken, body);
+    }

--- a/packages/blocks/hyperglance/test/index.test.ts
+++ b/packages/blocks/hyperglance/test/index.test.ts
@@ -1,0 +1,47 @@
+import { hyperglance } from '../src/index';
+
+describe('block declaration tests', () => {
+  test('should return block with correct authentication', () => {
+    expect(hyperglance.auth).toMatchObject({
+      type: 'CUSTOM_AUTH',
+      required: true,
+      authProviderKey: 'hyperglance',
+      authProviderDisplayName: 'Hyperglance',
+      authProviderLogoUrl: 'https://static.openops.com/blocks/hyperglance.svg',
+    });
+  });
+
+  test('should return block with correct number of actions', () => {
+    expect(Object.keys(hyperglance.actions()).length).toBe(7);
+    expect(hyperglance.actions()).toMatchObject({
+      exportTopologyForGroup: {
+        name: 'exportTopologyForGroup',
+        requireAuth: true,
+      },
+      getCollectorRecordStatistics: {
+        name: 'getCollectorRecordStatistics',
+        requireAuth: true,
+      },
+      getCollectorRecordStatus: {
+        name: 'getCollectorRecordStatus',
+        requireAuth: true,
+      },
+      getRecommendations: {
+        name: 'getRecommendations',
+        requireAuth: true,
+      },
+      searchTopology: {
+        name: 'searchTopology',
+        requireAuth: true,
+      },
+      getCollectorRecords: {
+        name: 'getCollectorRecords',
+        requireAuth: true,
+      },
+      customHgApiCall: {
+        name: 'customHgApiCall',
+        requireAuth: true,
+      }
+    });
+  });
+});

--- a/packages/blocks/hyperglance/tsconfig.json
+++ b/packages/blocks/hyperglance/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/blocks/hyperglance/tsconfig.lib.json
+++ b/packages/blocks/hyperglance/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/blocks/hyperglance/tsconfig.spec.json
+++ b/packages/blocks/hyperglance/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -359,6 +359,7 @@
       "@openops/shared": ["packages/shared/src/index.ts"],
       "@openops/ui-kit": ["packages/ui-kit/src/index.ts"],
       "Aminos": ["packages/blocks/Aminos/src/index.ts"],
+      "hyperglance": ["packages/blocks/hyperglance/src/index.ts"],
       "server-worker": ["packages/server/worker/src/index.ts"]
     },
     "resolveJsonModule": true


### PR DESCRIPTION
Fixes OPS-3000

This PR adds the initial version of the Hyperglance block.

## Additional Notes
<img width="675" height="464" alt="image" src="https://github.com/user-attachments/assets/af965262-d7c1-4023-98d0-aaca66186825" />

Actions added in this PR:
* Export Diagram
* Get Recommendations
* Get Resource List
* Get Credential Statistics
* Get Credential Status
* List Credentials
* Custom API Call

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [x] Automated tests were added/updated if necessary

- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided