### PR TITLE
Remove admin login from tables service

### DIFF
--- a/packages/server/api/src/app/authentication/new-user/organization-assignment.ts
+++ b/packages/server/api/src/app/authentication/new-user/organization-assignment.ts
@@ -1,6 +1,7 @@
 import { AppSystemProp, system } from '@openops/server-shared';
 import { ApplicationError, ErrorCode, isNil, User } from '@openops/shared';
 import { openopsTables } from '../../openops-tables';
+import { authenticateAdminUserInOpenOpsTables } from '../../openops-tables/auth-admin-tables';
 import { organizationService } from '../../organization/organization.service';
 import { projectService } from '../../project/project-service';
 import { userService } from '../../user/user-service';
@@ -52,8 +53,7 @@ async function addUserToDefaultWorkspace(values: {
   email: string;
   workspaceId: number;
 }): Promise<void> {
-  const { token: defaultToken } =
-    await openopsTables.authenticateAdminUserInOpenOpsTables();
+  const { token: defaultToken } = await authenticateAdminUserInOpenOpsTables();
 
   await openopsTables.addUserToWorkspace(defaultToken, {
     ...values,

--- a/packages/server/api/src/app/database/seeds/create-open-ops-tables-mcp-endpoint.ts
+++ b/packages/server/api/src/app/database/seeds/create-open-ops-tables-mcp-endpoint.ts
@@ -1,9 +1,10 @@
 import { logger } from '@openops/server-shared';
 import { openopsTables } from '../../openops-tables';
+import { authenticateAdminUserInOpenOpsTables } from '../../openops-tables/auth-admin-tables';
 import { OPENOPS_DEFAULT_WORKSPACE_NAME } from '../../openops-tables/default-workspace-database';
 
 export const createOpenOpsTablesMcpEndpoint = async () => {
-  const { token } = await openopsTables.authenticateAdminUserInOpenOpsTables();
+  const { token } = await authenticateAdminUserInOpenOpsTables();
   const mcpEndpoints = await openopsTables.getMcpEndpointList(token);
   const workspace = await openopsTables.getWorkspaceByName(
     token,

--- a/packages/server/api/src/app/database/seeds/openops-delete-old-opportunities-table.ts
+++ b/packages/server/api/src/app/database/seeds/openops-delete-old-opportunities-table.ts
@@ -7,7 +7,7 @@ import {
 } from '@openops/common';
 import { logger } from '@openops/server-shared';
 import { FlagEntity } from '../../flags/flag.entity';
-import { openopsTables } from '../../openops-tables';
+import { authenticateAdminUserInOpenOpsTables } from '../../openops-tables/auth-admin-tables';
 import { SEED_OPENOPS_TABLE_NAME } from '../../openops-tables/template-tables/create-opportunities-table';
 import { databaseConnection } from '../database-connection';
 import { getDefaultProjectTablesDatabaseToken } from '../get-default-user-db-token';
@@ -53,8 +53,7 @@ export const deleteOldOpportunitiesTable = async (): Promise<void> => {
   }
 
   try {
-    const { token } =
-      await openopsTables.authenticateAdminUserInOpenOpsTables();
+    const { token } = await authenticateAdminUserInOpenOpsTables();
 
     const table = await getTableByName(
       SEED_OPENOPS_TABLE_NAME,

--- a/packages/server/api/src/app/database/seeds/openops-tables-rename-database.ts
+++ b/packages/server/api/src/app/database/seeds/openops-tables-rename-database.ts
@@ -7,6 +7,7 @@ import {
 import { logger } from '@openops/server-shared';
 import { FlagEntity } from '../../flags/flag.entity';
 import { openopsTables } from '../../openops-tables';
+import { authenticateAdminUserInOpenOpsTables } from '../../openops-tables/auth-admin-tables';
 import { databaseConnection } from '../database-connection';
 
 const OPENOPS_TABLES_DATABASE_RENAMED_FLAG = 'TABLES_DB_RENAMED';
@@ -37,7 +38,7 @@ export const updateOpenopsTablesDatabase = async (): Promise<void> => {
     return;
   }
 
-  const { token } = await openopsTables.authenticateAdminUserInOpenOpsTables();
+  const { token } = await authenticateAdminUserInOpenOpsTables();
 
   try {
     const tablesDatabaseId = await getDefaultDatabaseId(

--- a/packages/server/api/src/app/database/seeds/seed-admin.ts
+++ b/packages/server/api/src/app/database/seeds/seed-admin.ts
@@ -2,6 +2,7 @@ import { AppSystemProp, logger, system } from '@openops/server-shared';
 import { OrganizationRole, Provider, User } from '@openops/shared';
 import { authenticationService } from '../../authentication/basic/authentication-service';
 import { openopsTables } from '../../openops-tables';
+import { authenticateAdminUserInOpenOpsTables } from '../../openops-tables/auth-admin-tables';
 import { organizationService } from '../../organization/organization.service';
 import { projectService } from '../../project/project-service';
 import { userService } from '../../user/user-service';
@@ -80,7 +81,7 @@ async function ensureOpenOpsTablesWorkspaceAndDatabaseExist(): Promise<{
   workspaceId: number;
   databaseId: number;
 }> {
-  const { token } = await openopsTables.authenticateAdminUserInOpenOpsTables();
+  const { token } = await authenticateAdminUserInOpenOpsTables();
 
   const { workspaceId, databaseId, databaseToken } =
     await openopsTables.createDefaultWorkspaceAndDatabase(token);

--- a/packages/server/api/src/app/openops-tables/template-tables/seed-tables-for-templates.ts
+++ b/packages/server/api/src/app/openops-tables/template-tables/seed-tables-for-templates.ts
@@ -1,6 +1,7 @@
 import { AppSystemProp, logger, system } from '@openops/server-shared';
 import { projectService } from '../../project/project-service';
 import { userService } from '../../user/user-service';
+import { authenticateAdminUserInOpenOpsTables } from '../auth-admin-tables';
 import { openopsTables } from '../index';
 import { createAggregatedCostsTable } from './create-aggregated-costs-table';
 import { createAutoInstancesShutdownTable } from './create-auto-instances-shutdown-table';
@@ -33,8 +34,7 @@ const getProjectTablesDatabaseId = async (): Promise<number> => {
 
 export const seedTemplateTablesService = {
   async createBaseTemplateTables() {
-    const { token } =
-      await openopsTables.authenticateAdminUserInOpenOpsTables();
+    const { token } = await authenticateAdminUserInOpenOpsTables();
     const databaseId = await getProjectTablesDatabaseId();
 
     const buTable = await createBusinessUnitsTable(databaseId, token);
@@ -50,8 +50,7 @@ export const seedTemplateTablesService = {
   },
 
   async createOpportunityTemplateTable() {
-    const { token } =
-      await openopsTables.authenticateAdminUserInOpenOpsTables();
+    const { token } = await authenticateAdminUserInOpenOpsTables();
     const databaseId = await getProjectTablesDatabaseId();
 
     await createOpportunitiesTable(token, databaseId);
@@ -60,16 +59,14 @@ export const seedTemplateTablesService = {
   },
 
   async createAggregatedCostsTable() {
-    const { token } =
-      await openopsTables.authenticateAdminUserInOpenOpsTables();
+    const { token } = await authenticateAdminUserInOpenOpsTables();
     const databaseId = await getProjectTablesDatabaseId();
 
     await createAggregatedCostsTable(databaseId, token);
   },
 
   async createKnownCostTypesByApplicationTable() {
-    const { token } =
-      await openopsTables.authenticateAdminUserInOpenOpsTables();
+    const { token } = await authenticateAdminUserInOpenOpsTables();
     const databaseId = await getProjectTablesDatabaseId();
 
     await createKnownCostTypesByApplicationTable(token, databaseId);
@@ -78,8 +75,7 @@ export const seedTemplateTablesService = {
   },
 
   async createAutoInstancesShutdownTable(): Promise<void> {
-    const { token } =
-      await openopsTables.authenticateAdminUserInOpenOpsTables();
+    const { token } = await authenticateAdminUserInOpenOpsTables();
     const databaseId = await getProjectTablesDatabaseId();
 
     await createAutoInstancesShutdownTable(token, databaseId);


### PR DESCRIPTION
Part of OPS-3123.

- We use the Tables service in migrations, so if I add the administrator login there, we'll have a problem with circular dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal authentication module structure across multiple components to improve code maintainability and separation of concerns. Authentication functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->