### PR TITLE
Censor more sensitive data in logs

### DIFF
--- a/packages/server/api/src/app/helper/error-handler.ts
+++ b/packages/server/api/src/app/helper/error-handler.ts
@@ -27,6 +27,19 @@ export const errorHandler = async (
       query,
     }))(_request);
 
+    // check if the body in requestSummary has a secret property like password and censor it
+    const secretProperties = ['password', 'secret', 'token', 'key'];
+    if (requestSummary.body && typeof requestSummary.body === 'object') {
+      const censoredBody = { ...requestSummary.body };
+      for (const key of Object.keys(censoredBody)) {
+        if (secretProperties. includes(key.toLowerCase())) {
+          censoredBody[key] = '****';
+        }
+      }
+      requestSummary.body = censoredBody;
+    }
+
+
     logger.error('Error handler caught an exception.', {
       message: error.message,
       stack: error.stack,

--- a/packages/server/shared/src/lib/logger/log-cleaner.ts
+++ b/packages/server/shared/src/lib/logger/log-cleaner.ts
@@ -99,3 +99,19 @@ function stringify(value: any) {
     return `Logger error - could not stringify object. ${error}`;
   }
 }
+
+function isSecretKey(key: string): boolean {
+  const secretKeywords = ["password", "token", "key", "secret", "authorization"];
+  return secretKeywords.some(keyword => key.toLowerCase().includes(keyword));
+}
+
+function censorSecrets(object: Object) {
+  for (const key in Object.keys(object)) {
+    if (typeof object[key] === 'string' && secretKeywords.some(keyword => key.toLowerCase().includes(keyword))) {
+        event[key] = "[CENSORED]";
+    }
+    else if (typeof event[key] === 'object' && event[key] !== null) {
+        censorSecrets(event[key]);
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive information (passwords, tokens, secrets, and keys) are now automatically censored in error logs to prevent accidental exposure of confidential data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->