### PR TITLE
Add system prompt to clarify the scope of session-sql tool

### DIFF
--- a/packages/server/api/src/app/ai/mcp/llm-query-router.ts
+++ b/packages/server/api/src/app/ai/mcp/llm-query-router.ts
@@ -207,7 +207,7 @@ const getSystemPrompt = async (
     `IMPORTANT: Tables tools should always be included in the output if the user asks a question involving those table names: ${openopsTablesNames.join(
       ', ',
     )}. ` +
-    "NOTE: The 'session-sql' tool is ONLY for querying tables created by AWS cost/billing MCP tools and performing temporary analysis. It is NOT for user's database or table related queries. " +
+    "NOTE: The 'session-sql' tool is ONLY for querying tables created by AWS cost/billing MCP tools and performing temporary analysis within the session. It is NOT for user's database or table related queries. " +
     "Classify the user's prompt into one or more of the provided categories. A single prompt can qualify for multiple categories. " +
     'Include ALL relevant categories that apply. ' +
     `${

--- a/packages/server/api/src/app/ai/mcp/llm-query-router.ts
+++ b/packages/server/api/src/app/ai/mcp/llm-query-router.ts
@@ -207,7 +207,7 @@ const getSystemPrompt = async (
     `IMPORTANT: Tables tools should always be included in the output if the user asks a question involving those table names: ${openopsTablesNames.join(
       ', ',
     )}. ` +
-    "NOTE: The 'session-sql' tool is ONLY for querying tables created by AWS cost/billing MCP tools and performing temporary analysis. It is NOT for user's database or table related queries." +
+    "NOTE: The 'session-sql' tool is ONLY for querying tables created by AWS cost/billing MCP tools and performing temporary analysis. It is NOT for user's database or table related queries. " +
     "Classify the user's prompt into one or more of the provided categories. A single prompt can qualify for multiple categories. " +
     'Include ALL relevant categories that apply. ' +
     `${

--- a/packages/server/api/src/app/ai/mcp/llm-query-router.ts
+++ b/packages/server/api/src/app/ai/mcp/llm-query-router.ts
@@ -207,6 +207,7 @@ const getSystemPrompt = async (
     `IMPORTANT: Tables tools should always be included in the output if the user asks a question involving those table names: ${openopsTablesNames.join(
       ', ',
     )}. ` +
+    "NOTE: The 'session-sql' tool is ONLY for querying tables created by AWS cost/billing MCP tools and performing temporary analysis. It is NOT for user's database or table related queries." +
     "Classify the user's prompt into one or more of the provided categories. A single prompt can qualify for multiple categories. " +
     'Include ALL relevant categories that apply. ' +
     `${


### PR DESCRIPTION
Fixes OPS-3138

## Additional Notes

<img width="626" height="230" alt="Screenshot 2025-11-27 at 3 40 36 PM" src="https://github.com/user-attachments/assets/87a6553d-7f84-41a2-bdce-3b91f42d22f4" />

Although it's not happening most of the times, LLM once included `session-sql` tool in the tool selection output even for a simple query like `do you have access to my tables?`

I've checked the description of this tool:
<img width="787" height="331" alt="Screenshot 2025-11-27 at 3 44 48 PM" src="https://github.com/user-attachments/assets/ff95b700-95b8-4098-817f-4ef9403c6f0c" />

The description is kinda generic and may not be clear for LLM to use it correctly in our app. So I've modified the system prompt to clarify the scope of this tool

---

Alternative fix: Do we really need this `session-sql` tool? Can we exclude it from the tools selection?

