### PR TITLE
Increase AI chat expiration time to 30 days

### DIFF
--- a/packages/server/shared/src/lib/system/system.ts
+++ b/packages/server/shared/src/lib/system/system.ts
@@ -95,7 +95,7 @@ const systemPropDefaultValues: Partial<Record<SystemProp, string>> = {
   [AppSystemProp.REQUEST_BODY_LIMIT]: '10',
   [SharedSystemProp.LANGFUSE_HOST]: 'https://us.cloud.langfuse.com',
   [AppSystemProp.MAX_LLM_CALLS_WITHOUT_INTERACTION]: '100',
-  [AppSystemProp.LLM_CHAT_EXPIRE_TIME_SECONDS]: '86400', // 24 hours
+  [AppSystemProp.LLM_CHAT_EXPIRE_TIME_SECONDS]: '2592000', // 30 days
   [AppSystemProp.TELEMETRY_MODE]: 'COLLECTOR',
   [AppSystemProp.TELEMETRY_COLLECTOR_URL]: 'https://telemetry.openops.com/save',
   [SharedSystemProp.ENABLE_HOST_VALIDATION]: 'true',


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-3159.

