### PR TITLE
Add request schemas for project endpoints

### DIFF
--- a/packages/server/api/src/app/project/project-controller.ts
+++ b/packages/server/api/src/app/project/project-controller.ts
@@ -1,5 +1,13 @@
-import { FastifyPluginCallbackTypebox } from '@fastify/type-provider-typebox';
-import { ApplicationError, ErrorCode } from '@openops/shared';
+import {
+  FastifyPluginCallbackTypebox,
+  Type,
+} from '@fastify/type-provider-typebox';
+import {
+  ApplicationError,
+  ErrorCode,
+  Project,
+  SeekPage,
+} from '@openops/shared';
 import { paginationHelper } from '../helper/pagination/pagination-utils';
 import { projectService } from './project-service';
 
@@ -8,23 +16,45 @@ export const userProjectController: FastifyPluginCallbackTypebox = (
   _opts,
   done,
 ) => {
-  fastify.get('/:id', async (request, response) => {
-    try {
-      return await projectService.getOneOrThrow(request.principal.projectId);
-    } catch (err) {
-      if (err instanceof ApplicationError) {
-        err.error.code = ErrorCode.ENTITY_NOT_FOUND;
-        return response.code(401).send();
+  fastify.get(
+    '/:id',
+    GetUserProjectRequestOptions,
+    async (request, response) => {
+      try {
+        return await projectService.getOneOrThrow(request.principal.projectId);
+      } catch (err) {
+        if (err instanceof ApplicationError) {
+          err.error.code = ErrorCode.ENTITY_NOT_FOUND;
+          return response.code(401).send();
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 
-  fastify.get('/', async (request) => {
+  fastify.get('/', ListUserProjectsRequestOptions, async (request) => {
     return paginationHelper.createPage(
       [await projectService.getOneOrThrow(request.principal.projectId)],
       null,
     );
   });
   done();
+};
+
+const ProjectWithoutToken = Type.Omit(Project, ['tablesDatabaseToken']);
+
+const GetUserProjectRequestOptions = {
+  schema: {
+    response: {
+      200: ProjectWithoutToken,
+    },
+  },
+};
+
+const ListUserProjectsRequestOptions = {
+  schema: {
+    response: {
+      200: SeekPage(ProjectWithoutToken),
+    },
+  },
 };


### PR DESCRIPTION
<!--
Ensure the title clearly reflects what was changed.
Provide a clear and concise description of the changes made. The PR should only contain the changes related to the issue, and no other unrelated changes.
-->

Fixes OPS-3115.

Simply added schemas to remove the token from the response 

