### PR TITLE
Fix file uploads

### DIFF
--- a/packages/engine/src/lib/variables/processors/file.ts
+++ b/packages/engine/src/lib/variables/processors/file.ts
@@ -31,7 +31,7 @@ function handleBase64File(propertyValue: string): WorkflowFile | null {
   if (!isBase64(propertyValue, { allowMime: true })) {
     return null;
   }
-  const matches = propertyValue.match(/^data:([A-Za-z-+/]+);base64,(.+)$/); // example match: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQAQMAAAAlPW0iAAAABlBMVEUAAAD///+l2Z/dAAAAM0lEQVR4nGP4/5/h/1+G/58ZDrAz3D/McH8yw83NDDeNGe4Ug9C9zwz3gVLMDA/A6P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC
+  const matches = propertyValue.match(/^data:([A-Za-z.+/-]+);base64,(.+)$/); // example match: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQAQMAAAAlPW0iAAAABlBMVEUAAAD///+l2Z/dAAAAM0lEQVR4nGP4/5/h/1+G/58ZDrAz3D/McH8yw83NDDeNGe4Ug9C9zwz3gVLMDA/A6P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC
   if (!matches || matches?.length !== 3) {
     return null;
   }

--- a/packages/engine/src/lib/variables/props-processor.ts
+++ b/packages/engine/src/lib/variables/props-processor.ts
@@ -7,6 +7,7 @@ import {
   InputPropertyMap,
   PropertyType,
   StaticPropsValue,
+  WorkflowFile,
 } from '@openops/blocks-framework';
 import { tryParseJson } from '@openops/common';
 import { AUTHENTICATION_PROPERTY_NAME, isNil, isObject } from '@openops/shared';
@@ -192,7 +193,7 @@ const validateProperty = (
       });
       break;
     case PropertyType.FILE:
-      schema = z.record(z.any(), z.any(), {
+      schema = z.instanceof(WorkflowFile, {
         error: `Expected a file url or base64 with mimeType, received: ${originalValue}`,
       });
       break;

--- a/packages/engine/test/services/props-processor.test.ts
+++ b/packages/engine/test/services/props-processor.test.ts
@@ -9,7 +9,7 @@ describe('Props Processor', () => {
     };
     const props = {
       base64WithMime: Property.File({
-        displayName: 'Base64',
+        displayName: 'Base64WithMime',
         required: true,
       }),
       base64: Property.File({


### PR DESCRIPTION
This PR fixes the error encountered when using file uploading actions: ["Expected a file url or base64 with mimeType"](https://github.com/openops-cloud/openops/blob/3f3b8285d26d332de896dbc330184130e800bb41/packages/engine/src/lib/variables/props-processor.ts#L196).
The error occurs even for valid file uploads due incorrect regex and schema checks.  The issue was not detected due to a faulty unit test which is also addressed by this PR.


## Additional Notes

* Fixes regex rejecting valid mime types such as `application/vnd.ms-visio.drawing`
* Fixes the Zod schema check for PropertyType.FILE to check for `WorkflowFile` not `record<>`
* Fixes the unit-test that was incorrectly passing due to using the same `displayName` for both test cases which caused the output to contain only 1 error instead of 2.

## Testing Checklist

Check all that apply:

- [x] I tested the feature thoroughly, including edge cases

- [x] I verified all affected areas still work as expected

- [x] Automated tests were added/updated if necessary

- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes OPS-3230.

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file data URL processing to support MIME types with extended character formats.
  * Improved file property validation with stricter type checking for improved reliability.

* **Tests**
  * Updated test naming for improved clarity in file validation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->