### PR TITLE
Use the internal API for webhook sync URLs when the request matches the app’s public URL host

### DIFF
--- a/packages/blocks/http/src/lib/common/webhook-url-validator.ts
+++ b/packages/blocks/http/src/lib/common/webhook-url-validator.ts
@@ -47,36 +47,33 @@ export async function validateAndRewritePublicWebhookUrl(
     return userUrl;
   }
 
-  try {
+  const publicUrl = await networkUtls.getPublicUrl();
+  const internalApiUrl = networkUtls.getInternalApiUrl();
+
+  const publicUrlObj = new URL(publicUrl);
+  const internalUrlObj = new URL(internalApiUrl);
+  const userUrlObj = new URL(userUrl);
+
+  if (userUrlObj.host !== publicUrlObj.host) {
     await validateHost(userUrl);
     return userUrl;
-  } catch (originalError) {
-    const publicUrl = await networkUtls.getPublicUrl();
-    const internalApiUrl = networkUtls.getInternalApiUrl();
-
-    const publicUrlObj = new URL(publicUrl);
-    const internalUrlObj = new URL(internalApiUrl);
-    const userUrlObj = new URL(userUrl);
-
-    if (userUrlObj.host !== publicUrlObj.host) {
-      throw originalError;
-    }
-
-    const publicBasePath = normalizeBasePath(publicUrlObj.pathname);
-    const internalBasePath = normalizeBasePath(internalUrlObj.pathname);
-
-    const webhookPath = extractWebhookPath(
-      userUrlObj.pathname,
-      publicBasePath,
-      internalBasePath,
-    );
-
-    if (!webhookPath) {
-      throw originalError;
-    }
-
-    const rewrittenPath = normalizePath(`${internalBasePath}${webhookPath}`);
-
-    return `${internalUrlObj.origin}${rewrittenPath}${userUrlObj.search}${userUrlObj.hash}`;
   }
+
+  const publicBasePath = normalizeBasePath(publicUrlObj.pathname);
+  const internalBasePath = normalizeBasePath(internalUrlObj.pathname);
+
+  const webhookPath = extractWebhookPath(
+    userUrlObj.pathname,
+    publicBasePath,
+    internalBasePath,
+  );
+
+  if (!webhookPath) {
+    await validateHost(userUrl);
+    return userUrl;
+  }
+
+  const rewrittenPath = normalizePath(`${internalBasePath}${webhookPath}`);
+
+  return `${internalUrlObj.origin}${rewrittenPath}${userUrlObj.search}${userUrlObj.hash}`;
 }

--- a/packages/blocks/http/test/webhook-url-validator.test.ts
+++ b/packages/blocks/http/test/webhook-url-validator.test.ts
@@ -21,10 +21,18 @@ describe('webhook-url-validator', () => {
 
   it('should return the original URL if validateHost passes', async () => {
     (validateHost as jest.Mock).mockResolvedValue(undefined);
+    (networkUtls.getPublicUrl as jest.Mock).mockResolvedValue(
+      'https://app.openops.com/api',
+    );
+    (networkUtls.getInternalApiUrl as jest.Mock).mockReturnValue(
+      'http://127.0.0.1:3000/',
+    );
     const userUrl = 'https://example.com/webhook';
     const result = await validateAndRewritePublicWebhookUrl(userUrl);
     expect(result).toBe(userUrl);
     expect(validateHost).toHaveBeenCalledWith(userUrl);
+    expect(networkUtls.getPublicUrl).toHaveBeenCalledTimes(1);
+    expect(networkUtls.getInternalApiUrl).toHaveBeenCalledTimes(1);
   });
 
   test.each([
@@ -100,9 +108,7 @@ describe('webhook-url-validator', () => {
       userUrl: string,
       expectedUrl: string,
     ) => {
-      const originalError = new Error('Host must not be an internal address');
-
-      (validateHost as jest.Mock).mockRejectedValue(originalError);
+      (validateHost as jest.Mock).mockResolvedValue(undefined);
       (networkUtls.getPublicUrl as jest.Mock).mockResolvedValue(publicUrl);
       (networkUtls.getInternalApiUrl as jest.Mock).mockReturnValue(
         internalApiUrl,
@@ -112,7 +118,7 @@ describe('webhook-url-validator', () => {
         expectedUrl,
       );
 
-      expect(validateHost).toHaveBeenCalledWith(userUrl);
+      expect(validateHost).not.toHaveBeenCalled();
       expect(networkUtls.getPublicUrl).toHaveBeenCalledTimes(1);
       expect(networkUtls.getInternalApiUrl).toHaveBeenCalledTimes(1);
     },


### PR DESCRIPTION


Fixes OPS-4109.

## Additional Notes




