### PR TITLE
Set frontend url in jest env for engine tests

### DIFF
--- a/jest.env.js
+++ b/jest.env.js
@@ -1,2 +1,3 @@
 process.env.OPS_QUEUE_MODE = 'MEMORY';
 process.env.OPS_ENGINE_URL = 'http://localhost:3005';
+process.env.OPS_FRONTEND_URL = 'http://localhost:4200';


### PR DESCRIPTION

Fixes OPS-4199.

## Additional Notes

For the changes made to [validateAndRewritePublicWebhookUrl,](https://github.com/openops-cloud/openops/pull/2247) we load the configured public and internal base URLs first. Some engine tests failed because the validator now always requires OPS_FRONTEND_URL. 



