### PR TITLE
Sort Benchmark providers based on selectability

### DIFF
--- a/packages/react-ui/src/app/features/benchmark/components/initial-benchmark-step.tsx
+++ b/packages/react-ui/src/app/features/benchmark/components/initial-benchmark-step.tsx
@@ -8,6 +8,7 @@ import {
 } from '@openops/components/ui';
 import { t } from 'i18next';
 
+import { sortBySelectability } from '@/app/lib/provider-sorting';
 import { CLOUD_PROVIDERS, CloudProvider } from '../cloud-providers';
 import { ComingSoonLabel } from './coming-soon-label';
 import { NotConnectedContent } from './not-connected-content';
@@ -58,6 +59,10 @@ export const InitialBenchmarkStep = ({
   onConnect,
   connectedProviders,
 }: InitialBenchmarkStepProps) => {
+  const sortedProviders = sortBySelectability(CLOUD_PROVIDERS, {
+    isSelectable: (provider) => provider.enabled,
+    isConnected: (provider) => connectedProviders?.[provider.value] === true,
+  });
   return (
     <>
       <StepTitle>{t("Let's create your Benchmark Report!")}</StepTitle>
@@ -78,7 +83,7 @@ export const InitialBenchmarkStep = ({
           onValueChange={onProviderChange}
         >
           <>
-            {CLOUD_PROVIDERS.map((provider) => (
+            {sortedProviders.map((provider) => (
               <SelectOption
                 key={provider.value}
                 value={provider.value}

--- a/packages/react-ui/src/app/lib/provider-sorting.ts
+++ b/packages/react-ui/src/app/lib/provider-sorting.ts
@@ -1,0 +1,29 @@
+type SortBySelectabilityOptions<T> = {
+  isSelectable: (item: T) => boolean;
+  isConnected: (item: T) => boolean;
+};
+
+export function sortBySelectability<T>(
+  items: readonly T[],
+  { isSelectable, isConnected }: SortBySelectabilityOptions<T>,
+): T[] {
+  return items
+    .map((item, index) => ({
+      item,
+      index,
+      selectable: isSelectable(item),
+      connected: isConnected(item),
+    }))
+    .sort((a, b) => {
+      if (a.selectable !== b.selectable) {
+        return a.selectable ? -1 : 1;
+      }
+
+      if (a.selectable && a.connected !== b.connected) {
+        return a.connected ? -1 : 1;
+      }
+
+      return a.index - b.index;
+    })
+    .map(({ item }) => item);
+}

--- a/packages/react-ui/src/app/lib/tests/provider-sorting.test.ts
+++ b/packages/react-ui/src/app/lib/tests/provider-sorting.test.ts
@@ -1,0 +1,36 @@
+import { sortBySelectability } from '../provider-sorting';
+
+describe('sortBySelectability', () => {
+  it('keeps original order when all items are equal', () => {
+    const items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+    const sorted = sortBySelectability(items, {
+      isSelectable: () => false,
+      isConnected: () => false,
+    });
+
+    expect(sorted.map((i) => i.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('prioritizes selectable items first, then connected items among selectable', () => {
+    const items = [{ id: 'aws' }, { id: 'azure' }, { id: 'gcp' }];
+
+    const sorted = sortBySelectability(items, {
+      isSelectable: (i) => i.id !== 'gcp',
+      isConnected: (i) => i.id === 'azure',
+    });
+
+    expect(sorted.map((i) => i.id)).toEqual(['azure', 'aws', 'gcp']);
+  });
+
+  it('does not elevate connected items if they are not selectable', () => {
+    const items = [{ id: 'aws' }, { id: 'azure' }, { id: 'gcp' }];
+
+    const sorted = sortBySelectability(items, {
+      isSelectable: (i) => i.id === 'aws',
+      isConnected: (i) => i.id === 'gcp',
+    });
+
+    expect(sorted.map((i) => i.id)).toEqual(['aws', 'azure', 'gcp']);
+  });
+});


### PR DESCRIPTION
Part of OPS-4221

## Additional Notes

### Items will be sorted in this order:
- First priority is given to providers that are enabled and connections are available.
- Second priority is to providers that are enabled but no connections are saved yet.
- Then everything else

Once this is merged, I will re-use the helper function for templates selection step in Campaigns.

Before this fix:
<img width="493" height="400" alt="Screenshot 2026-04-28 at 2 34 15 PM" src="https://github.com/user-attachments/assets/97cb0ebf-dfc7-447a-9bcb-af2a89557f72" />

After:
<img width="493" height="400" alt="Screenshot 2026-04-28 at 2 33 54 PM" src="https://github.com/user-attachments/assets/58ab4ad7-4fae-4b76-94f7-81a8c55bc807" />

