### PR TITLE
Add 429 retry behaviour to engine's error handler

### DIFF
--- a/packages/blocks/azure/test/azure-retry-delay.test.ts
+++ b/packages/blocks/azure/test/azure-retry-delay.test.ts
@@ -1,0 +1,62 @@
+import { getAzureRetryDelayMs } from '@openops/blocks-common';
+
+describe('getAzureRetryDelayMs', () => {
+  test('should use Azure Cost Management retry headers', () => {
+    expect(
+      getAzureRetryDelayMs({
+        'x-ms-ratelimit-microsoft.costmanagement-entity-retry-after': '1',
+      }),
+    ).toBe(1000);
+  });
+
+  test('should use Azure Retail Prices retry headers', () => {
+    expect(
+      getAzureRetryDelayMs({
+        'x-ms-ratelimit-retailprices-retry-after': '60',
+      }),
+    ).toBe(60000);
+  });
+
+  test('should use the longest matching Azure retry header value', () => {
+    expect(
+      getAzureRetryDelayMs({
+        'x-ms-ratelimit-microsoft.costmanagement-entity-retry-after': '3',
+        'x-ms-ratelimit-microsoft.costmanagement-clienttype-retry-after': '1',
+        'x-ms-ratelimit-retailprices-retry-after': '2',
+      }),
+    ).toBe(3000);
+  });
+
+  test('should ignore non-matching headers', () => {
+    expect(
+      getAzureRetryDelayMs({
+        'retry-after': '10',
+      }),
+    ).toBeUndefined();
+  });
+
+  test('should ignore invalid matching header values', () => {
+    expect(
+      getAzureRetryDelayMs({
+        'x-ms-ratelimit-retailprices-retry-after': 'abc',
+      }),
+    ).toBeUndefined();
+  });
+
+  test('should ignore zero and negative retry values', () => {
+    expect(
+      getAzureRetryDelayMs({
+        'x-ms-ratelimit-retailprices-retry-after': '0',
+        'x-ms-ratelimit-microsoft.costmanagement-entity-retry-after': '-1',
+      }),
+    ).toBeUndefined();
+  });
+
+  test('should cap matching retry values at ten minutes', () => {
+    expect(
+      getAzureRetryDelayMs({
+        'x-ms-ratelimit-retailprices-retry-after': '1200',
+      }),
+    ).toBe(600000);
+  });
+});

--- a/packages/blocks/common/src/lib/http/core/azure-retry-delay.ts
+++ b/packages/blocks/common/src/lib/http/core/azure-retry-delay.ts
@@ -1,0 +1,67 @@
+import { HttpHeaders } from './http-headers';
+
+const MAX_RETRY_DELAY_MS = 10 * 60 * 1000;
+const COST_MANAGEMENT_RETRY_AFTER_HEADER_PATTERN =
+  /^x-ms-ratelimit-microsoft\.costmanagement.*-retry-after$/i;
+
+const AZURE_RETRY_AFTER_HEADERS = new Set([
+  'x-ms-ratelimit-microsoft.consumption-retry-after',
+  'x-ms-ratelimit-retailprices-retry-after',
+]);
+
+export function getAzureRetryDelayMs(
+  headers: HttpHeaders | undefined,
+): number | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  const retryValues: string[] = [];
+
+  for (const [headerName, headerValue] of Object.entries(headers)) {
+    if (
+      AZURE_RETRY_AFTER_HEADERS.has(headerName.toLowerCase()) ||
+      COST_MANAGEMENT_RETRY_AFTER_HEADER_PATTERN.test(headerName)
+    ) {
+      retryValues.push(...normalizeHeaderValues(headerValue));
+    }
+  }
+
+  if (retryValues.length === 0) {
+    return undefined;
+  }
+
+  const retryDelaysMs = retryValues
+    .map((value) => parseRetryDelayMs(value))
+    .filter((value): value is number => value !== undefined);
+
+  if (retryDelaysMs.length === 0) {
+    return undefined;
+  }
+
+  return Math.max(...retryDelaysMs);
+}
+
+function normalizeHeaderValues(
+  headerValue: string | string[] | undefined,
+): string[] {
+  if (!headerValue) {
+    return [];
+  }
+
+  return Array.isArray(headerValue) ? headerValue : [headerValue];
+}
+
+function parseRetryDelayMs(headerValue: string): number | undefined {
+  const trimmedValue = headerValue.trim();
+  if (trimmedValue.length === 0) {
+    return undefined;
+  }
+
+  const retryAfterSeconds = Number(trimmedValue);
+  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds <= 0) {
+    return undefined;
+  }
+
+  return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY_MS);
+}

--- a/packages/blocks/common/src/lib/http/core/http-error.ts
+++ b/packages/blocks/common/src/lib/http/core/http-error.ts
@@ -1,4 +1,6 @@
 import { AxiosError } from 'axios';
+import { getAzureRetryDelayMs } from './azure-retry-delay';
+import { HttpHeaders } from './http-headers';
 
 export class HttpError extends Error {
   constructor(
@@ -33,8 +35,17 @@ export class HttpError extends Error {
   get response() {
     return {
       status: this._err?.response?.status || 500,
+      headers: (this._err?.response?.headers as HttpHeaders | undefined) ?? {},
       body: this._err?.response?.data,
     };
+  }
+
+  get retryAfterMs(): number | undefined {
+    if (this.response.status !== 429) {
+      return undefined;
+    }
+
+    return getAzureRetryDelayMs(this.response.headers);
   }
 
   get request() {

--- a/packages/blocks/common/src/lib/http/index.ts
+++ b/packages/blocks/common/src/lib/http/index.ts
@@ -1,4 +1,5 @@
 export * from './axios/axios-http-client';
+export * from './core/azure-retry-delay';
 export * from './core/base-http-client';
 export * from './core/delegating-authentication-converter';
 export * from './core/http-client';

--- a/packages/engine/src/lib/handler/block-executor.ts
+++ b/packages/engine/src/lib/handler/block-executor.ts
@@ -288,9 +288,8 @@ const executeAction: ActionHandler<BlockAction> = async ({
 
     const failedStepOutput = stepOutput
       .setStatus(stepStatus)
-      .setErrorMessage(handledError.message);
-
-    failedStepOutput.retryMetadata = retryMetadata;
+      .setErrorMessage(handledError.message)
+      .setRetryMetadata(retryMetadata);
 
     return executionState
       .upsertStep(action.name, failedStepOutput)

--- a/packages/engine/src/lib/handler/block-executor.ts
+++ b/packages/engine/src/lib/handler/block-executor.ts
@@ -28,6 +28,7 @@ import {
 import { blockLoader } from '../helper/block-loader';
 import {
   continueIfFailureHandler,
+  getBlockRetryMetadata,
   handleExecutionError,
   runWithExponentialBackoff,
 } from '../helper/error-handling';
@@ -277,6 +278,7 @@ const executeAction: ActionHandler<BlockAction> = async ({
       .setVerdict(ExecutionVerdict.RUNNING, undefined);
   } catch (e) {
     const handledError = handleExecutionError(e);
+    const retryMetadata = getBlockRetryMetadata(action, e);
 
     const stepStatus =
       handledError.verdictResponse?.reason ===
@@ -287,6 +289,8 @@ const executeAction: ActionHandler<BlockAction> = async ({
     const failedStepOutput = stepOutput
       .setStatus(stepStatus)
       .setErrorMessage(handledError.message);
+
+    failedStepOutput.retryMetadata = retryMetadata;
 
     return executionState
       .upsertStep(action.name, failedStepOutput)

--- a/packages/engine/src/lib/helper/error-handling.ts
+++ b/packages/engine/src/lib/helper/error-handling.ts
@@ -1,5 +1,6 @@
 import { SharedSystemProp, system } from '@openops/server-shared';
-import { BlockAction, CodeAction } from '@openops/shared';
+import type { StepRetryMetadata } from '@openops/shared';
+import { ActionType, BlockAction, CodeAction } from '@openops/shared';
 import { ExecutionMode } from '../core/code/execution-mode';
 import { wasExecutionLimitReached } from '../execution-limit-reached';
 import { EngineConstants } from '../handler/context/engine-constants';
@@ -18,6 +19,10 @@ import {
 const executionMode = system.get<ExecutionMode>(
   SharedSystemProp.EXECUTION_MODE,
 );
+const DEFAULT_AZURE_429_RETRY_DELAY_MS = 60000;
+const AZURE_BLOCK_NAME = '@openops/block-azure';
+const CUSTOM_AZURE_API_ACTION_NAME = 'custom_azure_api_call';
+const AZURE_429_RETRY_TYPE = 'AZURE_429';
 
 export async function runWithExponentialBackoff<
   T extends CodeAction | BlockAction,
@@ -42,9 +47,12 @@ export async function runWithExponentialBackoff<
     retryEnabled &&
     !constants.testSingleStepMode
   ) {
-    const backoffTime =
-      Math.pow(constants.retryConstants.retryExponential, attemptCount) *
-      constants.retryConstants.retryInterval;
+    const backoffTime = getRetryDelayMs(
+      resultExecutionState,
+      action,
+      constants,
+      attemptCount,
+    );
     await new Promise((resolve) => setTimeout(resolve, backoffTime));
     return runWithExponentialBackoff(
       executionState,
@@ -139,6 +147,73 @@ const executionFailedWithRetryableError = (
   return flowExecutorContext.verdict === ExecutionVerdict.FAILED;
 };
 
+export function getBlockRetryMetadata(
+  action: BlockAction,
+  error: unknown,
+): StepRetryMetadata | undefined {
+  if (!isAzureCustomApiAction(action) || !isHttpErrorLike(error)) {
+    return undefined;
+  }
+
+  if (error.response.status !== 429) {
+    return undefined;
+  }
+
+  return {
+    type: AZURE_429_RETRY_TYPE,
+    retryAfterMs:
+      typeof error.retryAfterMs === 'number' ? error.retryAfterMs : undefined,
+  };
+}
+
+function getRetryDelayMs<T extends CodeAction | BlockAction>(
+  executionState: FlowExecutorContext,
+  action: T,
+  constants: EngineConstants,
+  attemptCount: number,
+): number {
+  const retryMetadata = getRetryMetadata(executionState, action);
+  if (retryMetadata?.type === AZURE_429_RETRY_TYPE) {
+    return retryMetadata.retryAfterMs ?? DEFAULT_AZURE_429_RETRY_DELAY_MS;
+  }
+
+  return (
+    Math.pow(constants.retryConstants.retryExponential, attemptCount) *
+    constants.retryConstants.retryInterval
+  );
+}
+
+function getRetryMetadata<T extends CodeAction | BlockAction>(
+  executionState: FlowExecutorContext,
+  action: T,
+): StepRetryMetadata | undefined {
+  if (action.type !== ActionType.BLOCK) {
+    return undefined;
+  }
+
+  return executionState.getStepOutput(action.name)?.retryMetadata;
+}
+
+function isAzureCustomApiAction(action: BlockAction): boolean {
+  return (
+    action.settings.blockName === AZURE_BLOCK_NAME &&
+    action.settings.actionName === CUSTOM_AZURE_API_ACTION_NAME
+  );
+}
+
+function isHttpErrorLike(error: unknown): error is HttpErrorLike {
+  if (!isObject(error) || !('response' in error)) {
+    return false;
+  }
+
+  const response = error.response;
+  return isObject(response) && typeof response.status === 'number';
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 type Request<T extends CodeAction | BlockAction> = {
   action: T;
   executionState: FlowExecutorContext;
@@ -148,6 +223,13 @@ type Request<T extends CodeAction | BlockAction> = {
 type RequestFunction<T extends CodeAction | BlockAction> = (
   request: Request<T>,
 ) => Promise<FlowExecutorContext>;
+
+type HttpErrorLike = {
+  response: {
+    status: number;
+  };
+  retryAfterMs?: number;
+};
 
 type ErrorHandlingResponse = {
   message: string;

--- a/packages/engine/src/lib/helper/error-handling.ts
+++ b/packages/engine/src/lib/helper/error-handling.ts
@@ -20,6 +20,7 @@ const executionMode = system.get<ExecutionMode>(
   SharedSystemProp.EXECUTION_MODE,
 );
 const DEFAULT_AZURE_429_RETRY_DELAY_MS = 60000;
+const MAX_AZURE_429_RETRY_DELAY_MS = 10 * 60 * 1000;
 const AZURE_BLOCK_NAME = '@openops/block-azure';
 const CUSTOM_AZURE_API_ACTION_NAME = 'custom_azure_api_call';
 const AZURE_429_RETRY_TYPE = 'AZURE_429';
@@ -161,8 +162,7 @@ export function getBlockRetryMetadata(
 
   return {
     type: AZURE_429_RETRY_TYPE,
-    retryAfterMs:
-      typeof error.retryAfterMs === 'number' ? error.retryAfterMs : undefined,
+    retryAfterMs: sanitizeRetryAfterMs(error.retryAfterMs),
   };
 }
 
@@ -174,7 +174,10 @@ function getRetryDelayMs<T extends CodeAction | BlockAction>(
 ): number {
   const retryMetadata = getRetryMetadata(executionState, action);
   if (retryMetadata?.type === AZURE_429_RETRY_TYPE) {
-    return retryMetadata.retryAfterMs ?? DEFAULT_AZURE_429_RETRY_DELAY_MS;
+    return (
+      sanitizeRetryAfterMs(retryMetadata.retryAfterMs) ??
+      DEFAULT_AZURE_429_RETRY_DELAY_MS
+    );
   }
 
   return (
@@ -212,6 +215,18 @@ function isHttpErrorLike(error: unknown): error is HttpErrorLike {
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function sanitizeRetryAfterMs(retryAfterMs: unknown): number | undefined {
+  if (typeof retryAfterMs !== 'number' || !Number.isFinite(retryAfterMs)) {
+    return undefined;
+  }
+
+  if (retryAfterMs <= 0) {
+    return undefined;
+  }
+
+  return Math.min(retryAfterMs, MAX_AZURE_429_RETRY_DELAY_MS);
 }
 
 type Request<T extends CodeAction | BlockAction> = {

--- a/packages/engine/src/lib/helper/error-handling.ts
+++ b/packages/engine/src/lib/helper/error-handling.ts
@@ -1,6 +1,6 @@
 import { SharedSystemProp, system } from '@openops/server-shared';
 import type { StepRetryMetadata } from '@openops/shared';
-import { ActionType, BlockAction, CodeAction } from '@openops/shared';
+import { ActionType, BlockAction, CodeAction, isObject } from '@openops/shared';
 import { ExecutionMode } from '../core/code/execution-mode';
 import { wasExecutionLimitReached } from '../execution-limit-reached';
 import { EngineConstants } from '../handler/context/engine-constants';
@@ -211,10 +211,6 @@ function isHttpErrorLike(error: unknown): error is HttpErrorLike {
 
   const response = error.response;
   return isObject(response) && typeof response.status === 'number';
-}
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 function sanitizeRetryAfterMs(retryAfterMs: unknown): number | undefined {

--- a/packages/engine/test/helper/error-handling.test.ts
+++ b/packages/engine/test/helper/error-handling.test.ts
@@ -1,10 +1,18 @@
+import {
+    ActionType,
+    GenericStepOutput,
+    StepOutputStatus,
+    StepRetryMetadata,
+} from '@openops/shared'
 import { ExecutionVerdict, FlowExecutorContext } from '../../src/lib/handler/context/flow-execution-context'
-import { runWithExponentialBackoff } from '../../src/lib/helper/error-handling'
-import { buildCodeAction, generateMockEngineConstants } from '../handler/test-helper'
+import { getBlockRetryMetadata, runWithExponentialBackoff } from '../../src/lib/helper/error-handling'
+import { buildBlockAction, buildCodeAction, generateMockEngineConstants } from '../handler/test-helper'
+
+const AZURE_429_RETRY_TYPE = 'AZURE_429' as const
 
 describe('runWithExponentialBackoff', () => {
     const executionState = FlowExecutorContext.empty()
-    const action = buildCodeAction({
+    const codeAction = buildCodeAction({
         name: 'runtime',
         input: {},
         errorHandlingOptions: {
@@ -16,51 +24,148 @@ describe('runWithExponentialBackoff', () => {
             },
         },
     })
+    const azureAction = buildBlockAction({
+        name: 'azure_step',
+        input: {},
+        blockName: '@openops/block-azure',
+        actionName: 'custom_azure_api_call',
+        errorHandlingOptions: {
+            continueOnFailure: {
+                value: false,
+            },
+            retryOnFailure: {
+                value: true,
+            },
+        },
+    })
     const constants = generateMockEngineConstants()
     const requestFunction = jest.fn()
+    let setTimeoutSpy: jest.SpyInstance
 
     beforeEach(() => {
         jest.clearAllMocks()
+        jest.useFakeTimers()
+        setTimeoutSpy = jest.spyOn(global, 'setTimeout')
     })
 
-    afterAll(() => {
-        jest.clearAllMocks()
+    afterEach(() => {
+        setTimeoutSpy.mockRestore()
+        jest.useRealTimers()
     })
 
     it('should return resultExecutionState when verdict is not FAILED', async () => {
         const resultExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED, undefined)
         requestFunction.mockResolvedValue(resultExecutionState)
 
-        const output = await runWithExponentialBackoff(executionState, action, constants, requestFunction)
+        const output = await runWithExponentialBackoff(executionState, codeAction, constants, requestFunction)
 
         expect(output).toEqual(resultExecutionState)
-        expect(requestFunction).toHaveBeenCalledWith({ action, executionState, constants })
+        expect(requestFunction).toHaveBeenCalledWith({ action: codeAction, executionState, constants })
+        expect(setTimeoutSpy).not.toHaveBeenCalled()
     })
 
+    it('should retry with the default engine backoff for non-Azure failures', async () => {
+        const failedExecutionState = createFailedExecutionState({
+            stepName: codeAction.name,
+            actionType: ActionType.CODE,
+        })
+        const successfulExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED, undefined)
 
-    it('should retry and return resultExecutionState when verdict is FAILED and retry is enabled', async () => {
-        const resultExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.FAILED, undefined)
+        requestFunction
+            .mockResolvedValueOnce(failedExecutionState)
+            .mockResolvedValueOnce(successfulExecutionState)
 
-        requestFunction.mockResolvedValue(resultExecutionState)
+        const outputPromise = runWithExponentialBackoff(
+            executionState,
+            codeAction,
+            constants,
+            requestFunction,
+        )
 
-        const output = await runWithExponentialBackoff(executionState, action, constants, requestFunction)
+        await jest.runOnlyPendingTimersAsync()
+        const output = await outputPromise
 
-        expect(output).toEqual(resultExecutionState)
-        // Mock applies for the first attempt and second attempt is a real call which return success
+        expect(output).toEqual(successfulExecutionState)
         expect(requestFunction).toHaveBeenCalledTimes(2)
-        expect(requestFunction).toHaveBeenCalledWith({ action, executionState, constants })
-        expect(requestFunction).toHaveBeenCalledWith({ action, executionState, constants })
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1)
     })
 
-    it('should not retry and return resultExecutionState when verdict is FAILED but retry is disabled', async () => {
-        const resultExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.FAILED, undefined)
+    it('should retry with the Azure retry header delay when metadata is present', async () => {
+        const failedExecutionState = createFailedExecutionState({
+            stepName: azureAction.name,
+            actionType: ActionType.BLOCK,
+            retryMetadata: {
+                type: AZURE_429_RETRY_TYPE,
+                retryAfterMs: 3000,
+            },
+        })
+        const successfulExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED, undefined)
+
+        requestFunction
+            .mockResolvedValueOnce(failedExecutionState)
+            .mockResolvedValueOnce(successfulExecutionState)
+
+        const outputPromise = runWithExponentialBackoff(
+            executionState,
+            azureAction,
+            constants,
+            requestFunction,
+        )
+
+        await jest.runOnlyPendingTimersAsync()
+        const output = await outputPromise
+
+        expect(output).toEqual(successfulExecutionState)
+        expect(requestFunction).toHaveBeenCalledTimes(2)
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 3000)
+    })
+
+    it('should retry with a 60-second fallback for Azure 429 failures without a matching header', async () => {
+        const failedExecutionState = createFailedExecutionState({
+            stepName: azureAction.name,
+            actionType: ActionType.BLOCK,
+            retryMetadata: {
+                type: AZURE_429_RETRY_TYPE,
+            },
+        })
+        const successfulExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED, undefined)
+
+        requestFunction
+            .mockResolvedValueOnce(failedExecutionState)
+            .mockResolvedValueOnce(successfulExecutionState)
+
+        const outputPromise = runWithExponentialBackoff(
+            executionState,
+            azureAction,
+            constants,
+            requestFunction,
+        )
+
+        await jest.runOnlyPendingTimersAsync()
+        const output = await outputPromise
+
+        expect(output).toEqual(successfulExecutionState)
+        expect(requestFunction).toHaveBeenCalledTimes(2)
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60000)
+    })
+
+    it('should not retry when retry is disabled even if retry metadata exists', async () => {
+        const resultExecutionState = createFailedExecutionState({
+            stepName: azureAction.name,
+            actionType: ActionType.BLOCK,
+            retryMetadata: {
+                type: AZURE_429_RETRY_TYPE,
+                retryAfterMs: 3000,
+            },
+        })
 
         requestFunction.mockResolvedValue(resultExecutionState)
 
-
-        const actionWithDisabledRetry = buildCodeAction({
-            name: 'runtime',
+        const actionWithDisabledRetry = buildBlockAction({
+            name: 'azure_step',
             input: {},
+            blockName: '@openops/block-azure',
+            actionName: 'custom_azure_api_call',
             errorHandlingOptions: {
                 continueOnFailure: {
                     value: false,
@@ -71,12 +176,108 @@ describe('runWithExponentialBackoff', () => {
             },
         })
 
-        const output = await runWithExponentialBackoff(executionState, actionWithDisabledRetry, constants, requestFunction)
+        const output = await runWithExponentialBackoff(
+            executionState,
+            actionWithDisabledRetry,
+            constants,
+            requestFunction,
+        )
 
         expect(output).toEqual(resultExecutionState)
         expect(requestFunction).toHaveBeenCalledTimes(1)
-        expect(requestFunction).toHaveBeenCalledWith({ action: actionWithDisabledRetry, executionState, constants })
+        expect(setTimeoutSpy).not.toHaveBeenCalled()
+    })
+})
 
+describe('getBlockRetryMetadata', () => {
+    const azureAction = buildBlockAction({
+        name: 'azure_step',
+        input: {},
+        blockName: '@openops/block-azure',
+        actionName: 'custom_azure_api_call',
+        errorHandlingOptions: {
+            retryOnFailure: {
+                value: true,
+            },
+        },
     })
 
+    it('should return Azure retry metadata for Azure custom API 429 errors', () => {
+        expect(
+            getBlockRetryMetadata(azureAction, {
+                response: {
+                    status: 429,
+                },
+                retryAfterMs: 5000,
+            }),
+        ).toEqual({
+            type: AZURE_429_RETRY_TYPE,
+            retryAfterMs: 5000,
+        })
+    })
+
+    it('should return fallback Azure retry metadata when no header delay exists', () => {
+        expect(
+            getBlockRetryMetadata(azureAction, {
+                response: {
+                    status: 429,
+                },
+            }),
+        ).toEqual({
+            type: AZURE_429_RETRY_TYPE,
+            retryAfterMs: undefined,
+        })
+    })
+
+    it('should ignore non-Azure actions', () => {
+        const nonAzureAction = buildBlockAction({
+            name: 'http_step',
+            input: {},
+            blockName: 'http',
+            actionName: 'send_http_request',
+            errorHandlingOptions: {
+                retryOnFailure: {
+                    value: true,
+                },
+            },
+        })
+
+        expect(
+            getBlockRetryMetadata(nonAzureAction, {
+                response: {
+                    status: 429,
+                },
+                retryAfterMs: 5000,
+            }),
+        ).toBeUndefined()
+    })
 })
+
+function createFailedExecutionState({
+    stepName,
+    actionType,
+    retryMetadata,
+}: {
+    stepName: string
+    actionType: ActionType.CODE | ActionType.BLOCK
+    retryMetadata?: StepRetryMetadata
+}): FlowExecutorContext {
+    const failedStepOutput = (
+        actionType === ActionType.CODE
+            ? GenericStepOutput.create({
+                input: {},
+                type: ActionType.CODE,
+                status: StepOutputStatus.FAILED,
+            })
+            : GenericStepOutput.create({
+                input: {},
+                type: ActionType.BLOCK,
+                status: StepOutputStatus.FAILED,
+            })
+    )
+    failedStepOutput.retryMetadata = retryMetadata
+
+    return FlowExecutorContext.empty()
+        .upsertStep(stepName, failedStepOutput)
+        .setVerdict(ExecutionVerdict.FAILED, undefined)
+}

--- a/packages/engine/test/helper/error-handling.test.ts
+++ b/packages/engine/test/helper/error-handling.test.ts
@@ -69,7 +69,7 @@ describe('runWithExponentialBackoff', () => {
             stepName: codeAction.name,
             actionType: ActionType.CODE,
         })
-        const successfulExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED, undefined)
+        const successfulExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED)
 
         requestFunction
             .mockResolvedValueOnce(failedExecutionState)
@@ -99,7 +99,7 @@ describe('runWithExponentialBackoff', () => {
                 retryAfterMs: 3000,
             },
         })
-        const successfulExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED, undefined)
+        const successfulExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED)
 
         requestFunction
             .mockResolvedValueOnce(failedExecutionState)
@@ -128,7 +128,37 @@ describe('runWithExponentialBackoff', () => {
                 type: AZURE_429_RETRY_TYPE,
             },
         })
-        const successfulExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED, undefined)
+        const successfulExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED)
+
+        requestFunction
+            .mockResolvedValueOnce(failedExecutionState)
+            .mockResolvedValueOnce(successfulExecutionState)
+
+        const outputPromise = runWithExponentialBackoff(
+            executionState,
+            azureAction,
+            constants,
+            requestFunction,
+        )
+
+        await jest.runOnlyPendingTimersAsync()
+        const output = await outputPromise
+
+        expect(output).toEqual(successfulExecutionState)
+        expect(requestFunction).toHaveBeenCalledTimes(2)
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60000)
+    })
+
+    it('should fall back to 60 seconds for invalid Azure retry metadata values', async () => {
+        const failedExecutionState = createFailedExecutionState({
+            stepName: azureAction.name,
+            actionType: ActionType.BLOCK,
+            retryMetadata: {
+                type: AZURE_429_RETRY_TYPE,
+                retryAfterMs: Number.POSITIVE_INFINITY,
+            },
+        })
+        const successfulExecutionState = FlowExecutorContext.empty().setVerdict(ExecutionVerdict.SUCCEEDED)
 
         requestFunction
             .mockResolvedValueOnce(failedExecutionState)
@@ -274,8 +304,7 @@ function createFailedExecutionState({
                 type: ActionType.BLOCK,
                 status: StepOutputStatus.FAILED,
             })
-    )
-    failedStepOutput.retryMetadata = retryMetadata
+    ).setRetryMetadata(retryMetadata)
 
     return FlowExecutorContext.empty()
         .upsertStep(stepName, failedStepOutput)

--- a/packages/shared/src/lib/flow-run/execution/step-output.ts
+++ b/packages/shared/src/lib/flow-run/execution/step-output.ts
@@ -11,6 +11,13 @@ export enum StepOutputStatus {
   EXECUTION_LIMIT_REACHED = 'EXECUTION_LIMIT_REACHED',
 }
 
+export type StepRetryMetadataType = 'AZURE_429';
+
+export type StepRetryMetadata = {
+  type: StepRetryMetadataType;
+  retryAfterMs?: number;
+};
+
 type BaseStepOutputParams<T extends ActionType | TriggerType, OUTPUT> = {
   type: T;
   status: StepOutputStatus;
@@ -18,6 +25,7 @@ type BaseStepOutputParams<T extends ActionType | TriggerType, OUTPUT> = {
   output?: OUTPUT;
   duration?: number;
   errorMessage?: string;
+  retryMetadata?: StepRetryMetadata;
 };
 
 export class GenericStepOutput<T extends ActionType | TriggerType, OUTPUT> {
@@ -27,6 +35,7 @@ export class GenericStepOutput<T extends ActionType | TriggerType, OUTPUT> {
   output?: OUTPUT;
   duration?: number;
   errorMessage?: string;
+  retryMetadata?: StepRetryMetadata;
 
   constructor(step: BaseStepOutputParams<T, OUTPUT>) {
     this.type = step.type;
@@ -35,6 +44,7 @@ export class GenericStepOutput<T extends ActionType | TriggerType, OUTPUT> {
     this.output = step.output;
     this.duration = step.duration;
     this.errorMessage = step.errorMessage;
+    this.retryMetadata = step.retryMetadata;
   }
 
   setOutput(output: OUTPUT): GenericStepOutput<T, OUTPUT> {
@@ -55,6 +65,15 @@ export class GenericStepOutput<T extends ActionType | TriggerType, OUTPUT> {
     return new GenericStepOutput<T, OUTPUT>({
       ...this,
       errorMessage,
+    });
+  }
+
+  setRetryMetadata(
+    retryMetadata: StepRetryMetadata | undefined,
+  ): GenericStepOutput<T, OUTPUT> {
+    return new GenericStepOutput<T, OUTPUT>({
+      ...this,
+      retryMetadata,
     });
   }
 


### PR DESCRIPTION


Fixes OPS-4255.

## Additional Notes

- Some Azure endpoints are throttling for the calls we make from Azure Benchmark flows.
- We do need to catch some retry headers from Azure API calls and then wait for the duration mentioned in the headers and then retry.
- So we do not throw on 429 errors and then honour the wait time.

