### PR TITLE
Add frontend build timing audit skill

### DIFF
--- a/.claude/skills/frontend-build-timing-audit/SKILL.md
+++ b/.claude/skills/frontend-build-timing-audit/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: frontend-build-timing-audit
+description: >
+  Detects and diagnoses chunk-evaluation timing bugs in the Vite/rolldown
+  production build of react-ui (works-in-dev / broken-in-build i18n
+  regressions, missing UI labels, module-scope `t()` anti-patterns). Use when
+  editing react-ui, ui-components, shared, vite.config.ts, package.json
+  `sideEffects`, or i18n setup; or when a user reports blank labels in
+  build/docker/staging/prod.
+---
+
+# Frontend Build Timing Audit
+
+The OpenOps frontend has hit production-only i18n regressions caused by a subtle
+interaction between Vite 8 + rolldown's chunk splitting and i18next's lazy
+initialization. This skill bundles the tooling we used to diagnose and prevent
+those bugs.
+
+## When to use
+
+Trigger this skill proactively when modifying any of:
+
+- `packages/react-ui/**` (especially `main.tsx`, `i18n.ts`, routing/lazy loading)
+- `packages/ui-components/**` (barrel exports in `src/index.ts`,
+  `src/components/index.ts`)
+- `packages/shared/**` (the `@openops/shared` barrel)
+- `packages/react-ui/vite.config.ts`
+- Any `package.json` with a `sideEffects` field
+- Adding or removing top-level `import { t } from 'i18next'` calls
+
+Or reactively when a user reports:
+
+- "Works in dev, broken in production / docker compose / staging"
+- "i18n labels are missing / blank / undefined"
+- "Toggle / button / nav item has no text"
+- Empty strings appearing in the UI after deployment
+
+## The bug pattern (mental model)
+
+```text
+main.tsx imports:
+  1) ./i18n.ts    ← calls i18next.init() which sets this.translator
+  2) ./app/app    ← the rest of the App
+```
+
+In dev, `./i18n.ts` always evaluates before any App module, so a top-level
+`t('Foo')` inside an App-tree module gets a working `translator`.
+
+In production builds, rolldown can split the App tree into static-dependency
+chunks of the entry chunk (`import {...} from "./cloud-user-api-*.js"`). Per
+the ESM spec, those dependency chunks' module bodies evaluate **before** the
+entry chunk body — which means before `./i18n.ts`'s `init()` call. Any
+module-scope `t('...')` in those chunks now runs while `i18next.translator` is
+undefined, and `t()` returns `undefined`. The "label" gets frozen as
+`undefined` in a top-level array/object and the UI renders nothing.
+
+**The fix has two layers:**
+
+1. **Source layer:** never call `t()` at module top level. Use
+   `useTranslation()` (a hook) or a factory function instead. This is what PR
+   [#2292](https://github.com/openops-cloud/openops/pull/2292) did for
+   `test-step-data-viewer.tsx`.
+2. **Bundler layer:** declare
+   `"sideEffects": ["*.css", "*.scss"]` on `packages/ui-components/package.json`
+   so rolldown stops emitting `ui-components` modules as static-dependency
+   chunks and inlines them into the entry chunk body where `./i18n` always
+   wins. This is PR
+   [#2293](https://github.com/openops-cloud/openops/pull/2293).
+
+For the full investigation with measurements, see [reference.md](reference.md).
+
+## Workflows
+
+### Workflow 1: Quick anti-pattern scan (always run when touching FE code)
+
+The script `scripts/find-toplevel-init-calls.mjs` uses TypeScript's AST to
+find every call to a configured init-dependent binding whose ancestor chain
+contains no function/arrow/method — i.e. every module-scope invocation that
+runs at module load.
+
+The set of bindings to watch is declared in
+`scripts/anti-patterns.config.mjs` (data-driven). The initial entry covers
+the i18next `t` case that caused OPS-4318; adding a new pattern (Sentry,
+dayjs locale, etc.) is a one-liner.
+
+```bash
+node .claude/skills/frontend-build-timing-audit/scripts/find-toplevel-init-calls.mjs
+```
+
+Output groups results by rule, one line per offender: `<path>: lines 12, 19,
+25`. The scan runs in ~1 second across the whole repo. Pass `--json` to get
+a machine-readable shape (used by `snapshot.mjs`).
+
+**Triage rule:** every result is a latent OPS-4318-style regression. The risk
+of it manifesting today depends on which chunk the file lands in, which
+depends on rolldown's heuristics. Treat any hit as something to fix or
+explicitly justify.
+
+When you find offenders, fix them by:
+
+- For React components: `const { t } = useTranslation()` inside the component,
+  move the constant inside the function body or wrap it in `useMemo`.
+- For non-component files (zod schemas, filter configs, route metadata): convert
+  the exported constant into a factory function `getFooFilter(t)` or a hook
+  `useFooFilter()`.
+
+### Workflow 2: Bundle-diff diagnostic (when actively triaging a regression)
+
+The script `scripts/bundle-diff.mjs` runs two production builds (varying
+working-tree state), then compares:
+
+- Chunk count and entry chunk size
+- Which chunks contain a given marker string (e.g. a missing label literal)
+- Static-import dependency list at the top of the entry chunk
+- Critical-path size (raw / gzipped / brotli) — what the user actually
+  downloads before the app can boot
+
+This takes ~30s per build configuration. Use it when:
+
+- The AST scan is clean but a build-only bug is still suspected (maybe from a
+  vendor module, dependency upgrade, or vite config change).
+- Evaluating whether a proposed `sideEffects` change actually helps.
+- Comparing bundle behavior before/after a vite or rolldown upgrade.
+
+Usage:
+
+```bash
+node .claude/skills/frontend-build-timing-audit/scripts/bundle-diff.mjs \
+  --label-a 'baseline (main)' --ref-a main \
+  --label-b 'feature branch'  --ref-b HEAD \
+  --marker 'View input data'
+```
+
+`--marker` is the literal you expect to be missing or moved (e.g. a label
+that disappeared). It will be located in each build's chunk graph so you can
+see whether it's in the entry chunk (safe — runs after `i18n.init()`) or a
+statically-imported sibling chunk (dangerous — runs before).
+
+For multi-variable experiments (e.g. toggle two patches independently to
+isolate which one fixes the bug), see the `--patch-a` / `--patch-b` flags
+documented in the script's `--help`.
+
+### Workflow 3: Regression check vs committed baseline
+
+`scripts/baseline.json` captures the current build's chunk count, entry-chunk
+size, critical-path size (raw / gzipped / brotli), total JS size, and per-rule
+anti-pattern counts. Two scripts work against it:
+
+```bash
+# After editing FE code, verify nothing regressed past thresholds.
+node .claude/skills/frontend-build-timing-audit/scripts/check-regression.mjs
+# Exit codes: 0 ok, 1 warn, 2 fail (suitable as a CI gate).
+
+# Re-anchor the baseline after an intentional change (dependency upgrade,
+# refactor that legitimately moves chunks).
+node .claude/skills/frontend-build-timing-audit/scripts/update-baseline.mjs
+# Prints the diff vs the previous baseline before writing.
+```
+
+Thresholds live inside `baseline.json` as percent deltas so routine growth
+doesn't constantly require updates. Anti-pattern counts default to `warnPct:
+0` so any new offender (a new module-scope `t(...)`, a new
+module-scope `Sentry.init(...)`, etc.) warns immediately.
+
+Use this workflow:
+
+- After landing FE changes locally to catch surprise bundle bloat.
+- After a Vite, rolldown, or core dependency upgrade.
+- Before approving a PR that touches barrels, lazy-loading boundaries, or
+  `sideEffects` declarations.
+
+If the verdict is `warn` or `fail`, drop into Workflow 2 (`bundle-diff.mjs`
+against `main`) to see which chunks moved.
+
+### Workflow 4: Pre-commit verification for `sideEffects` changes
+
+If editing a `sideEffects` field in any `packages/*/package.json`:
+
+1. Identify the package's real side effects (CSS/SCSS imports, global
+   registrations, polyfills). Grep for `import '*.css'`, `customElements.define`,
+   module-scope `window.*`/`global.*` assignments.
+2. If only CSS/SCSS, use `"sideEffects": ["*.css", "*.scss"]` (array form).
+3. Run `node .../scripts/bundle-diff.mjs` against the previous commit to
+   confirm:
+   - CSS files still in the build (xyflow, tailwind, app styles).
+   - Critical-path size hasn't grown.
+   - No expected runtime code was tree-shaken out.
+
+## Key facts to remember
+
+- **`t` imported from `i18next` is NOT reactive.** It does not re-render
+  components when language changes or resources load. Use `useTranslation()`
+  from `react-i18next` in components.
+- **Before `i18next.init()` runs, `t()` returns `undefined`, not the key.**
+  React renders `undefined` as nothing — that's why labels go blank rather than
+  showing English fallback.
+- **The repo's `translation.json` is key=key**, so once init has run, missing
+  keys fall back to the English text by accident. This masks broken usage in
+  most cases — but only after init. Module-scope `t()` may run before init.
+- **`main.tsx` order matters.** `./i18n` MUST be imported before `App`.
+  Verify with `head -10 packages/react-ui/src/main.tsx` when investigating.
+- **Vite dev mode hides this bug entirely.** Always verify fixes against
+  `npx nx build react-ui` output, not the dev server.
+
+## Additional resources
+
+- [reference.md](reference.md): full root-cause analysis with the measured
+  4-way build comparison, byte-level chunk analysis, and the ESM evaluation
+  semantics that make this bug possible.
+- Related PRs: [#2292](https://github.com/openops-cloud/openops/pull/2292)
+  (hook fix), [#2293](https://github.com/openops-cloud/openops/pull/2293)
+  (`sideEffects` declaration).
+- Related Linear: OPS-4318, OPS-4320.

--- a/.claude/skills/frontend-build-timing-audit/baseline.json
+++ b/.claude/skills/frontend-build-timing-audit/baseline.json
@@ -1,0 +1,68 @@
+{
+  "version": 1,
+  "capturedAt": "2026-05-15T08:19:44.786Z",
+  "capturedFromSha": "e8d858ed89",
+  "thresholds": {
+    "chunkCount": {
+      "warnPct": 5,
+      "failPct": 15
+    },
+    "entryChunkSize": {
+      "warnPct": 5,
+      "failPct": 15
+    },
+    "criticalPathRaw": {
+      "warnPct": 3,
+      "failPct": 7
+    },
+    "criticalPathGzipped": {
+      "warnPct": 3,
+      "failPct": 7
+    },
+    "criticalPathBrotli": {
+      "warnPct": 3,
+      "failPct": 7
+    },
+    "totalJsRaw": {
+      "warnPct": 3,
+      "failPct": 7
+    },
+    "totalJsGzipped": {
+      "warnPct": 3,
+      "failPct": 7
+    },
+    "staticImportCount": {
+      "warnPct": 0,
+      "failPct": 50
+    },
+    "antiPatternCounts.i18next-t-call": {
+      "warnPct": 0,
+      "failPct": 50
+    }
+  },
+  "metrics": {
+    "chunkCount": 120,
+    "entryChunkSize": 1779713,
+    "criticalPathRaw": 4308407,
+    "criticalPathGzipped": 1253412,
+    "criticalPathBrotli": 1004569,
+    "totalJsRaw": 7373246,
+    "totalJsGzipped": 2124659,
+    "staticImportCount": 13,
+    "antiPatternCounts": {
+      "i18next-t-call": 85
+    },
+    "markers": [
+      {
+        "name": "View input data",
+        "chunk": "cloud-user-api-imKp9g4N.js",
+        "risk": "danger"
+      },
+      {
+        "name": "View output data",
+        "chunk": "cloud-user-api-imKp9g4N.js",
+        "risk": "danger"
+      }
+    ]
+  }
+}

--- a/.claude/skills/frontend-build-timing-audit/reference.md
+++ b/.claude/skills/frontend-build-timing-audit/reference.md
@@ -1,0 +1,239 @@
+# Reference: chunk-evaluation timing bugs in react-ui builds
+
+Long-form companion to `SKILL.md`. Read on demand when triaging a build-mode
+regression that resembles OPS-4318.
+
+## The OPS-4318 timeline (worked example)
+
+**Symptom:** the `<TestStepDataViewer>` toggle showed two blank buttons
+instead of "Input" / "Output" labels. Visible in docker compose, prod, and
+staging. Not reproducible in `nx serve react-ui` (dev mode).
+
+**Root cause:** the module had `import { t } from 'i18next'` and:
+
+```tsx
+const VIEW_INPUT_OPTIONS = [
+  { value: 'Input', label: t('Input'), tooltipText: t('View input data') },
+  { value: 'Output', label: t('Output'), tooltipText: t('View output data') },
+];
+```
+
+at module top level. In the production build, rolldown placed this file in a
+static-dependency chunk that ran before `./i18n.ts`'s `init()` call.
+
+## Why `t()` returns `undefined` before init
+
+From `node_modules/i18next/dist/cjs/i18next.js` line 2215:
+
+```js
+t() {
+  return this.translator && this.translator.translate(...arguments);
+}
+```
+
+The `translator` property is assigned inside `init()` at line 1987. Until
+`init()` runs, `this.translator` is `undefined`, so `t()` short-circuits and
+returns `undefined`. React renders `undefined` as nothing — hence blank
+labels.
+
+This is different from "returns the key as fallback" (which is what i18next
+does AFTER init when no translation matches). Pre-init, the function returns
+literally nothing.
+
+## Why dev mode hides the bug
+
+`packages/react-ui/src/main.tsx`:
+
+```tsx
+import '@openops/components/ui/tailwind.css';
+import './i18n';
+import App from './app/app';
+```
+
+In dev, Vite serves each ES module via separate HTTP requests. The browser
+walks the dependency graph dynamically, and `./i18n` is always discovered and
+evaluated before any module that App imports.
+
+In production, all source modules are bundled into a small number of chunks
+that are loaded as `<script type="module">` (entry) plus static `import { ... }
+from "./chunk.js"` (dependencies). ESM semantics require all dependency module
+bodies to evaluate before the importing module body — so a dependency chunk
+runs before the entry chunk body, even though the entry chunk's source has
+`import './i18n'` as its first statement.
+
+## The 4-way controlled experiment (OPS-4318 / OPS-4320)
+
+To isolate which fix actually solves the bug, we ran four production builds:
+
+| Build | `sideEffects` on ui-components | Hook fix on test-step-data-viewer | Behavior   |
+| ----- | ------------------------------ | --------------------------------- | ---------- |
+| A     | array form                     | yes                               | works      |
+| B     | none                           | yes                               | works      |
+| C     | array form                     | no                                | works      |
+| D     | none                           | no                                | **broken** |
+
+Bundle stats:
+
+| Build | # chunks | Entry size | `test-step-data-viewer` lives in                         |
+| ----- | -------- | ---------- | -------------------------------------------------------- |
+| A     | 117      | 2,941 KB   | entry chunk                                              |
+| B     | 120      | 1,736 KB   | separate `cloud-user-api-*.js` (1,330 KB), static import |
+| C     | 117      | 2,938 KB   | entry chunk                                              |
+| D     | 120      | 1,736 KB   | separate `cloud-user-api-*.js` (1,326 KB), static import |
+
+Critical-path bytes (entry chunk + every chunk it statically imports):
+
+| Build | Raw      | gzipped  | brotli |
+| ----- | -------- | -------- | ------ |
+| A     | 4,124 KB | 1,199 KB | 953 KB |
+| B     | 4,203 KB | 1,223 KB | 980 KB |
+| D     | 4,201 KB | 1,222 KB | 980 KB |
+
+Total JS shipped:
+
+| Build | Raw      | gzipped  |
+| ----- | -------- | -------- |
+| A     | 7,073 KB | 2,035 KB |
+| B     | 7,196 KB | 2,074 KB |
+| D     | 7,194 KB | 2,073 KB |
+
+**Surprising conclusion:** Declaring `sideEffects` causes rolldown to inline
+modules into the entry chunk (the entry grows from 1.7 MB to 2.9 MB), but the
+total critical path shrinks because rolldown can tree-shake unused barrel
+re-exports once it knows they're pure. The combined bytes go down ~80 KB raw
+and ~24 KB gzipped.
+
+The fix is also a slight perf win, not a regression.
+
+## Why `sideEffects` changes the chunk graph
+
+When a package's `package.json` lacks `sideEffects`, rolldown assumes every
+module in that package may have observable side effects (CSS injection,
+global registration, polyfill assignment, etc.). To preserve those side
+effects, rolldown is conservative about merging modules: it tends to split
+them into dependency chunks that are statically imported by their consumers.
+Static imports preserve evaluation order, so the side effects fire.
+
+When `sideEffects: false` (or an allowlist array) is declared, rolldown knows
+the JS modules are pure (except for the listed patterns). It can then:
+
+1. Tree-shake unused exports from barrels.
+2. Drop modules entirely from chunks that don't use any of their exports.
+3. **Inline modules into the entry chunk body** rather than emit them as
+   separate static-dep chunks.
+
+It's (3) that fixes OPS-4318. Once inlined, the module body executes within
+the entry chunk's own evaluation order — which follows `main.tsx`'s source
+declaration order, so `./i18n` is guaranteed to run before any App-tree code.
+
+## The "sideEffects" array form vs `false`
+
+For `packages/ui-components`, the right declaration is:
+
+```json
+{
+  "sideEffects": ["*.css", "*.scss"]
+}
+```
+
+We verified the package contains exactly three side-effectful imports, all
+CSS:
+
+- `packages/ui-components/src/tailwind.css` (re-exported via barrel)
+- `packages/ui-components/src/styles/global.css`
+- `import '@xyflow/react/dist/style.css'` inside
+  `packages/ui-components/src/components/flow-canvas/flow-canvas.tsx`
+
+Plain `"sideEffects": false` would silently drop the xyflow CSS import,
+breaking the flow canvas styling. The array form lets rolldown tree-shake JS
+modules while preserving CSS side effects.
+
+## Related upstream changes that exposed the bug
+
+The OPS-4318 regression was triggered by two dependency updates landing
+around the same time:
+
+- `i18next-http-backend` 2.5.2 → 3.0.5 (PR #2246). v3.0.0 switched to pure
+  ESM (`"type": "module"`, separate `esm/`/`cjs/` outputs, exports map). The
+  release notes explicitly mention top-level-await concerns: _"for esm build
+  environments not supporting top-level await, you should import the
+  `i18next-http-backend/cjs` export or stay at v2.6.2/v2.7.1"_.
+- Vite 8.0.8 (workspace upgrade for Storybook 10 compatibility, PR #2271).
+  Vite 8 uses rolldown as the bundler; rolldown's chunk-splitting heuristics
+  differ from classic Rollup, particularly for packages without explicit
+  `sideEffects` declarations.
+
+Neither change is "wrong" in isolation; together they shifted module
+evaluation timing enough to expose a latent module-scope `t()` call that had
+been ridden the lucky chunk-ordering side of the race since June 2025.
+
+## Investigation method (replicable)
+
+To reproduce or run a similar investigation on a new regression:
+
+1. Identify a literal that you expect to be missing/broken in the production
+   UI (e.g. `'View input data'`). This is your "marker".
+2. From a clean working tree, run:
+   ```bash
+   node .claude/skills/frontend-build-timing-audit/scripts/find-toplevel-init-calls.mjs
+   ```
+   This flags candidates with module-scope `t()` calls.
+3. If a candidate matches the broken module, you have a probable cause.
+4. Verify with a 4-way (or 2-way) bundle diff:
+   ```bash
+   node .claude/skills/frontend-build-timing-audit/scripts/bundle-diff.mjs \
+     --label-a 'before fix' --ref-a HEAD~1 \
+     --label-b 'after fix'  --ref-b HEAD \
+     --marker 'View input data'
+   ```
+5. Read the "Marker" section in the output. If `before fix` shows the marker
+   in a chunk listed under "DANGER (statically imported by entry…)", the
+   timing race is confirmed.
+6. Pick a remediation:
+   - **Source-level (preferred):** replace module-scope `t()` with
+     `useTranslation()` inside the component / consumer. Local, surgical, no
+     bundler dependency.
+   - **Bundler-level (defense in depth):** declare `sideEffects` on the
+     package containing the offender. Eliminates the race for every module in
+     the package — but depends on rolldown heuristics that may shift in
+     future upgrades.
+
+The two layers compose; using both is recommended.
+
+## Common offenders to watch for
+
+Patterns that very often cause this problem (caught by the AST scanner):
+
+- `const FOO_FILTER = { title: t('Status'), ... }` at module top level
+- `const RUN_TYPES = { [Enum.X]: { text: t('...') } }` lookup tables
+- `const VALIDATION_MESSAGES = { required: t('Required'), ... }` schemas
+- Zod schemas with `.message(t('...'))`
+- `react-router` route metadata `{ path: '/x', title: t('X') }`
+
+The fix shape is the same for all of them — convert to a hook or factory
+function. See `SKILL.md` for examples.
+
+## Tracking over time
+
+The skill ships a committed `baseline.json` that captures the build's
+critical-path / chunk-count / anti-pattern footprint at a known-good commit.
+Two scripts work against it:
+
+- `scripts/check-regression.mjs` — builds `react-ui`, snapshots the current
+  state, compares against `baseline.json`, and exits `0` / `1` / `2`
+  (ok / warn / fail) based on the percent thresholds embedded in the
+  baseline.
+- `scripts/update-baseline.mjs` — re-anchors `baseline.json` after a
+  deliberate change (e.g. a Vite upgrade, an intentional `sideEffects` flip,
+  a barrel re-org). Prints the diff against the previous baseline before
+  writing so the delta is visible in code review.
+
+Anti-pattern counts (from the AST scanner) ride alongside size metrics in
+the baseline. The default `warnPct: 0 / failPct: 50` on
+`antiPatternCounts.i18next-t-call` means any _new_ module-scope `t(...)`
+warns immediately even if the bundle metrics happen to fall within tolerance.
+
+The plan is intentionally narrow: one committed baseline, manual updates,
+no CI wiring. If the baseline drifts because of routine churn, edit the
+thresholds inline in `baseline.json` or run `update-baseline.mjs`. See the
+skill workflows section for the full agent loop.

--- a/.claude/skills/frontend-build-timing-audit/scripts/anti-patterns.config.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/anti-patterns.config.mjs
@@ -1,0 +1,45 @@
+// Anti-pattern definitions for the module-scope init-call scanner.
+//
+// The scanner walks every .ts/.tsx file that imports the given `module` with
+// `binding` (named or default per `importKind`). For each rule it then
+// searches for module-scope calls and reports their line numbers.
+//
+// Rule shape:
+//   name             string  unique id used in reports/baselines
+//   module           string  npm package name (or path) to match in `from`
+//   binding          string  identifier to look for in the import clause
+//   importKind       'named' | 'default'
+//   matchCall        boolean detect `binding(...)` calls at module scope
+//   matchMethodCall  string[]? detect `binding.method(...)` calls at module
+//                              scope (only methods in the array count)
+//
+// At least one of `matchCall` or `matchMethodCall` must be set.
+//
+// Adding patterns: append a new entry. The scanner is data-driven, so you
+// only need to touch this file.
+
+export default [
+  {
+    name: 'i18next-t-call',
+    module: 'i18next',
+    binding: 't',
+    importKind: 'named',
+    matchCall: true,
+  },
+  // Examples for future use (uncomment and adjust as needed):
+  //
+  // {
+  //   name: 'sentry-init',
+  //   module: '@sentry/react',
+  //   binding: 'init',
+  //   importKind: 'named',
+  //   matchCall: true,
+  // },
+  // {
+  //   name: 'dayjs-locale',
+  //   module: 'dayjs',
+  //   binding: 'dayjs',
+  //   importKind: 'default',
+  //   matchMethodCall: ['locale', 'tz'],
+  // },
+];

--- a/.claude/skills/frontend-build-timing-audit/scripts/bundle-diff.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/bundle-diff.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Compare two production builds of `react-ui` to diagnose chunk-evaluation
+// timing bugs. Two modes:
+//
+//   --ref-a / --ref-b              compare two git refs (HEAD, main, sha, etc.)
+//   --patch-a / --patch-b          apply optional patch files on top of the
+//                                  refs (combine with --ref-* to set up
+//                                  controlled multi-variable experiments)
+//
+// For each variant the script:
+//   1) Cleans dist/ and Vite's cache.
+//   2) Builds with `nx build react-ui --skip-nx-cache`.
+//   3) Copies the output to /tmp/bundle-diff-<label>/.
+//
+// Then compares:
+//   - Total chunk count
+//   - Entry chunk size & hash
+//   - Static-import dependency list of the entry chunk
+//   - Which chunk contains each marker string (--marker, repeatable)
+//   - Critical-path size (raw / gzipped / brotli) — entry chunk plus all
+//     statically-imported sibling chunks (the bytes the browser must finish
+//     loading+executing before the app body runs)
+//
+// Usage:
+//   node bundle-diff.mjs \
+//     --label-a 'main'   --ref-a main \
+//     --label-b 'HEAD'   --ref-b HEAD \
+//     --marker 'View input data' \
+//     --marker 'Some other UI label that went missing'
+//
+// IMPORTANT: this script checks out files via `git restore --source=<ref>`,
+// runs builds against the local workspace, then restores HEAD at the end.
+// It refuses to run if you have uncommitted changes (use `git stash` first).
+
+import { execSync } from 'node:child_process';
+import { rmSync, cpSync } from 'node:fs';
+import { analyzeBuild } from './lib/analyze.mjs';
+
+function parseArgs(argv) {
+  const out = { markers: [], variants: { a: {}, b: {} } };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    if (a === '--label-a') out.variants.a.label = next();
+    else if (a === '--label-b') out.variants.b.label = next();
+    else if (a === '--ref-a') out.variants.a.ref = next();
+    else if (a === '--ref-b') out.variants.b.ref = next();
+    else if (a === '--patch-a') out.variants.a.patch = next();
+    else if (a === '--patch-b') out.variants.b.patch = next();
+    else if (a === '--marker') out.markers.push(next());
+    else if (a === '--help' || a === '-h') { printHelp(); process.exit(0); }
+    else { console.error(`Unknown arg: ${a}`); printHelp(); process.exit(2); }
+  }
+  if (!out.variants.a.ref && !out.variants.a.patch) {
+    out.variants.a.ref = 'HEAD~1';
+    out.variants.a.label = out.variants.a.label || 'HEAD~1';
+  }
+  if (!out.variants.b.ref && !out.variants.b.patch) {
+    out.variants.b.ref = 'HEAD';
+    out.variants.b.label = out.variants.b.label || 'HEAD';
+  }
+  out.variants.a.label = out.variants.a.label || 'A';
+  out.variants.b.label = out.variants.b.label || 'B';
+  return out;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node bundle-diff.mjs \\
+    --label-a 'main'   --ref-a main \\
+    --label-b 'HEAD'   --ref-b HEAD \\
+    --marker 'View input data'
+
+  --ref-X    git ref to check out for variant X (default: HEAD~1 and HEAD)
+  --patch-X  optional patch file to apply on top of ref-X
+  --label-X  display label (default: ref/patch name)
+  --marker   string to locate within chunks; repeatable
+
+Outputs the comparison report to stdout. Build artifacts saved to
+/tmp/bundle-diff-<label>/ for inspection.`);
+}
+
+const args = parseArgs(process.argv);
+
+const cwd = execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+process.chdir(cwd);
+
+// Refuse to run with a dirty working tree.
+const dirty = execSync('git status --porcelain', { encoding: 'utf8' }).trim();
+if (dirty) {
+  console.error('Working tree is dirty. Commit, stash, or revert before running.');
+  console.error('Files:\n' + dirty);
+  process.exit(2);
+}
+
+const originalRef = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+const originalSha = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+
+function sh(cmd, opts = {}) {
+  return execSync(cmd, { stdio: opts.silent ? 'pipe' : 'inherit', encoding: 'utf8', ...opts });
+}
+
+function build(variant) {
+  const { label, ref, patch } = variant;
+  console.error(`\n=== Building variant '${label}' (ref=${ref || 'HEAD'}, patch=${patch || '-'}) ===`);
+
+  if (ref) {
+    // Restore the entire tree to the target ref but keep .git/HEAD pointing
+    // where it was (avoids detached-HEAD churn).
+    sh(`git restore --source=${ref} -- packages`, { silent: true });
+  }
+  if (patch) {
+    sh(`git apply --whitespace=nowarn ${patch}`);
+  }
+  rmSync(`${cwd}/dist/packages/react-ui`, { recursive: true, force: true });
+  rmSync(`${cwd}/node_modules/.vite/packages/react-ui`, { recursive: true, force: true });
+  sh(`npx nx build react-ui --skip-nx-cache 2>&1 | tail -3`, { shell: '/bin/bash' });
+
+  const outDir = `/tmp/bundle-diff-${label.replace(/[^A-Za-z0-9_-]+/g, '_')}`;
+  rmSync(outDir, { recursive: true, force: true });
+  cpSync(`${cwd}/dist/packages/react-ui`, outDir, { recursive: true });
+  console.error(`  saved to ${outDir}`);
+  return outDir;
+}
+
+function restore() {
+  // Wipe variant changes and restore the original HEAD state.
+  sh('git checkout -- packages', { silent: true });
+}
+
+let dirA, dirB;
+try {
+  dirA = build(args.variants.a);
+  restore();
+  dirB = build(args.variants.b);
+  restore();
+} catch (e) {
+  console.error('Build failed; attempting to restore tree.');
+  try { restore(); } catch {}
+  throw e;
+}
+
+const reportA = { label: args.variants.a.label, ...analyzeBuild(dirA, args.markers) };
+const reportB = { label: args.variants.b.label, ...analyzeBuild(dirB, args.markers) };
+
+// ---------- Output ----------
+function kb(n) { return (n / 1024).toFixed(1) + ' KB'; }
+function delta(a, b) {
+  const d = b - a;
+  const sign = d > 0 ? '+' : '';
+  return `${sign}${kb(d)} (${sign}${(100 * d / (a || 1)).toFixed(1)}%)`;
+}
+
+console.log('\n========== BUNDLE DIFF ==========');
+console.log(`\n${'Metric'.padEnd(28)}  ${reportA.label.padStart(20)}  ${reportB.label.padStart(20)}  Δ`);
+console.log('-'.repeat(110));
+const row = (m, a, b, fmt = kb) =>
+  console.log(`${m.padEnd(28)}  ${String(fmt(a)).padStart(20)}  ${String(fmt(b)).padStart(20)}  ${delta(a, b)}`);
+row('Total JS chunks', reportA.chunkCount, reportB.chunkCount, (n) => String(n));
+row('Entry chunk size', reportA.entrySize, reportB.entrySize);
+row('Static import count', reportA.staticImportCount, reportB.staticImportCount, (n) => String(n));
+row('Critical path raw', reportA.critRaw, reportB.critRaw);
+row('Critical path gzipped', reportA.critGz, reportB.critGz);
+row('Critical path brotli', reportA.critBr, reportB.critBr);
+row('Total JS raw', reportA.totalRaw, reportB.totalRaw);
+row('Total JS gzipped', reportA.totalGz, reportB.totalGz);
+
+console.log('\n--- Entry chunk static imports ---');
+const inB = new Set(reportB.staticImports);
+const inA = new Set(reportA.staticImports);
+const onlyA = reportA.staticImports.filter(x => !inB.has(x));
+const onlyB = reportB.staticImports.filter(x => !inA.has(x));
+console.log(`Only in ${reportA.label}: ${onlyA.length}`);
+for (const x of onlyA) console.log(`  - ${x}`);
+console.log(`Only in ${reportB.label}: ${onlyB.length}`);
+for (const x of onlyB) console.log(`  + ${x}`);
+
+const riskLabel = {
+  safe: 'safe (in entry chunk body — runs after main.tsx imports complete)',
+  danger: 'DANGER (statically imported by entry — runs before entry body, before ./i18n.init())',
+  lazy: 'lazy (loaded on demand — generally safe)',
+  missing: '(marker not found in any chunk)',
+};
+
+for (const m of args.markers) {
+  console.log(`\n--- Marker '${m}' ---`);
+  const dump = (report) => {
+    const matches = report.markers.filter(x => x.name === m && x.chunk);
+    if (!matches.length) return '(not found)';
+    return matches
+      .map(l => `${l.chunk} (offset ${l.position} of ${l.chunkSize}) — ${riskLabel[l.risk]}`)
+      .join('\n      ');
+  };
+  console.log(`  ${reportA.label}:\n      ${dump(reportA)}`);
+  console.log(`  ${reportB.label}:\n      ${dump(reportB)}`);
+}
+
+console.log('\n========== END ==========\n');
+console.log(`Artifacts kept at:\n  ${dirA}\n  ${dirB}`);
+console.log(`Restored working tree to: ${originalRef} (${originalSha.slice(0, 8)})`);

--- a/.claude/skills/frontend-build-timing-audit/scripts/bundle-diff.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/bundle-diff.mjs
@@ -105,9 +105,12 @@ function build(variant) {
   console.error(`\n=== Building variant '${label}' (ref=${ref || 'HEAD'}, patch=${patch || '-'}) ===`);
 
   if (ref) {
-    // Restore the entire tree to the target ref but keep .git/HEAD pointing
-    // where it was (avoids detached-HEAD churn).
-    sh(`git restore --source=${ref} -- packages`, { silent: true });
+    // Restore the entire tracked tree to the target ref but keep .git/HEAD
+    // pointing where it was (avoids detached-HEAD churn). Restoring the full
+    // tree (not just `packages/`) so root configs (vite.config.ts edge
+    // cases, lockfile, tsconfig, etc.) and any patch files outside
+    // `packages/` are picked up too.
+    sh(`git restore --source=${ref} -- .`, { silent: true });
   }
   if (patch) {
     sh(`git apply --whitespace=nowarn ${patch}`);
@@ -124,8 +127,10 @@ function build(variant) {
 }
 
 function restore() {
-  // Wipe variant changes and restore the original HEAD state.
-  sh('git checkout -- packages', { silent: true });
+  // Wipe variant changes across the full tracked tree (paired with the
+  // wider `git restore -- .` in build()). Required so a patch that touches
+  // files outside `packages/` cannot leak past the script.
+  sh('git checkout -- .', { silent: true });
 }
 
 let dirA, dirB;

--- a/.claude/skills/frontend-build-timing-audit/scripts/check-regression.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/check-regression.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// Compare a fresh snapshot of the current build against the committed
+// `baseline.json`. Prints a diff table identical in shape to `bundle-diff.mjs`
+// and exits with a coded status.
+//
+// Exit codes:
+//   0  every gated metric is within `warnPct`
+//   1  at least one metric exceeded its `warnPct` but stayed below `failPct`
+//   2  at least one metric exceeded its `failPct` (CI gate)
+//
+// Usage:
+//   node check-regression.mjs                          # build + compare
+//   node check-regression.mjs --no-build               # reuse dist/
+//   node check-regression.mjs --baseline path.json
+//   node check-regression.mjs --json                   # machine-readable
+//
+// Thresholds are read from baseline.json:
+//   thresholds: {
+//     <metricName>: { warnPct, failPct }
+//   }
+// where `metricName` is either a top-level metric (criticalPathGzipped,
+// totalJsGzipped, etc.) or `antiPatternCounts.<ruleName>`.
+
+import { execSync, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, '..');
+
+function parseArgs(argv) {
+  const out = { build: true, baseline: `${SKILL_DIR}/baseline.json`, json: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--no-build') out.build = false;
+    else if (a === '--baseline') out.baseline = argv[++i];
+    else if (a === '--json') out.json = true;
+    else if (a === '--help' || a === '-h') {
+      console.log('See header of check-regression.mjs for usage.');
+      process.exit(0);
+    } else {
+      console.error(`Unknown arg: ${a}`);
+      process.exit(2);
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv);
+
+let baseline;
+try {
+  baseline = JSON.parse(readFileSync(args.baseline, 'utf8'));
+} catch (e) {
+  console.error(`Could not read baseline from ${args.baseline}: ${e.message}`);
+  console.error('Run update-baseline.mjs first.');
+  process.exit(2);
+}
+
+// Re-use marker names from baseline so the comparison is apples-to-apples.
+const markerArgs = (baseline.metrics.markers || [])
+  .map((m) => ['--marker', m.name])
+  .flat();
+
+const snapshotArgs = ['--build-dir', `${execSync(
+  'git rev-parse --show-toplevel',
+  { encoding: 'utf8' },
+).trim()}/dist/packages/react-ui`];
+if (!args.build) snapshotArgs.push('--no-build');
+
+const res = spawnSync(
+  'node',
+  [`${__dirname}/snapshot.mjs`, ...snapshotArgs, ...markerArgs],
+  { encoding: 'utf8' },
+);
+if (res.status !== 0) {
+  console.error('snapshot failed:');
+  console.error(res.stdout);
+  console.error(res.stderr);
+  process.exit(2);
+}
+const current = JSON.parse(res.stdout);
+
+// ---------- Compare ----------
+const thresholds = baseline.thresholds || {};
+
+function pctDelta(baseVal, curVal) {
+  if (!baseVal) return curVal === 0 ? 0 : Infinity;
+  return (100 * (curVal - baseVal)) / baseVal;
+}
+
+function classify(name, baseVal, curVal) {
+  const t = thresholds[name];
+  const delta = pctDelta(baseVal, curVal);
+  if (!t) return { status: 'ok', delta };
+  // Improvements (delta <= 0) are always 'ok'; only regressions trigger
+  // warn/fail. `warnPct: 0` means "any positive change warns".
+  if (delta <= 0) return { status: 'ok', delta, threshold: t };
+  if (delta >= t.failPct) return { status: 'fail', delta, threshold: t };
+  if (delta > t.warnPct || (t.warnPct === 0 && delta > 0))
+    return { status: 'warn', delta, threshold: t };
+  return { status: 'ok', delta, threshold: t };
+}
+
+const gated = [
+  ['chunkCount', baseline.metrics.chunkCount, current.metrics.chunkCount],
+  ['entryChunkSize', baseline.metrics.entryChunkSize, current.metrics.entryChunkSize],
+  ['criticalPathRaw', baseline.metrics.criticalPathRaw, current.metrics.criticalPathRaw],
+  ['criticalPathGzipped', baseline.metrics.criticalPathGzipped, current.metrics.criticalPathGzipped],
+  ['criticalPathBrotli', baseline.metrics.criticalPathBrotli, current.metrics.criticalPathBrotli],
+  ['totalJsRaw', baseline.metrics.totalJsRaw, current.metrics.totalJsRaw],
+  ['totalJsGzipped', baseline.metrics.totalJsGzipped, current.metrics.totalJsGzipped],
+  ['staticImportCount', baseline.metrics.staticImportCount, current.metrics.staticImportCount],
+];
+
+const ruleNames = new Set([
+  ...Object.keys(baseline.metrics.antiPatternCounts || {}),
+  ...Object.keys(current.metrics.antiPatternCounts || {}),
+]);
+const antiPatternRows = [...ruleNames].map((rule) => [
+  `antiPatternCounts.${rule}`,
+  (baseline.metrics.antiPatternCounts || {})[rule] ?? 0,
+  (current.metrics.antiPatternCounts || {})[rule] ?? 0,
+]);
+
+const allRows = [...gated, ...antiPatternRows].map(([name, b, c]) => ({
+  name,
+  baseline: b,
+  current: c,
+  ...classify(name, b, c),
+}));
+
+let worst = 'ok';
+for (const r of allRows) {
+  if (r.status === 'fail') worst = 'fail';
+  else if (r.status === 'warn' && worst !== 'fail') worst = 'warn';
+}
+
+if (args.json) {
+  process.stdout.write(
+    JSON.stringify(
+      {
+        baseline: { sha: baseline.capturedFromSha, capturedAt: baseline.capturedAt },
+        current: { sha: current.capturedFromSha, capturedAt: current.capturedAt },
+        rows: allRows,
+        verdict: worst,
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+} else {
+  // Pretty-print.
+  const fmt = (name, n) =>
+    name === 'chunkCount' ||
+    name === 'staticImportCount' ||
+    name.startsWith('antiPatternCounts.')
+      ? String(n)
+      : (n / 1024).toFixed(1) + ' KB';
+
+  console.log('\n========== REGRESSION CHECK ==========');
+  console.log(
+    `baseline: ${baseline.capturedFromSha}  (captured ${baseline.capturedAt})`,
+  );
+  console.log(
+    `current : ${current.capturedFromSha}  (captured ${current.capturedAt})\n`,
+  );
+
+  const head = `${'Metric'.padEnd(36)}  ${'baseline'.padStart(14)}  ${'current'.padStart(14)}  ${'Δ%'.padStart(8)}  status`;
+  console.log(head);
+  console.log('-'.repeat(head.length));
+  for (const r of allRows) {
+    const tag =
+      r.status === 'fail' ? 'FAIL' : r.status === 'warn' ? 'warn' : 'ok';
+    const deltaStr = isFinite(r.delta)
+      ? `${r.delta >= 0 ? '+' : ''}${r.delta.toFixed(1)}%`
+      : 'new';
+    console.log(
+      `${r.name.padEnd(36)}  ${fmt(r.name, r.baseline).padStart(14)}  ${fmt(r.name, r.current).padStart(14)}  ${deltaStr.padStart(8)}  ${tag}`,
+    );
+  }
+  console.log('');
+  console.log(`Verdict: ${worst.toUpperCase()}`);
+  if (worst !== 'ok') {
+    console.log(
+      'Tip: run bundle-diff.mjs against main to investigate which chunks moved.',
+    );
+  }
+}
+
+process.exit(worst === 'fail' ? 2 : worst === 'warn' ? 1 : 0);

--- a/.claude/skills/frontend-build-timing-audit/scripts/find-toplevel-init-calls.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/find-toplevel-init-calls.mjs
@@ -18,7 +18,7 @@
 //   0 — always (this is a report, not a gate). Use --json + jq to gate.
 
 import { readFileSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
@@ -109,20 +109,26 @@ function fileMatchesRule(src, rule) {
   return false;
 }
 
-// Collect candidates: any file that imports any rule's module.
+// Collect candidates: any file that imports any rule's module. Use multiple
+// `-e` fixed-string patterns to stay quote-agnostic (both `from '...'` and
+// `from "..."` forms are accepted) without touching shell quoting.
 let candidates;
-try {
+{
   const modules = [...new Set(config.map((r) => r.module))];
-  const orPat = modules.map((m) => `from '${m}'`).join('\\|');
-  candidates = execSync(`git grep -l "${orPat}" -- '*.ts' '*.tsx'`, {
-    encoding: 'utf8',
-    cwd,
-  })
-    .split('\n')
-    .filter(Boolean);
-} catch {
-  console.error('git grep failed — make sure you are inside a git repo.');
-  process.exit(1);
+  const grepArgs = ['grep', '-lF'];
+  for (const m of modules) {
+    grepArgs.push('-e', `from '${m}'`);
+    grepArgs.push('-e', `from "${m}"`);
+  }
+  grepArgs.push('--', '*.ts', '*.tsx');
+  const res = spawnSync('git', grepArgs, { cwd, encoding: 'utf8' });
+  // git grep exits 1 when nothing matches; that's fine — only treat other
+  // non-zero exit codes as an error.
+  if (res.status !== 0 && res.status !== 1) {
+    console.error(`git grep failed (exit ${res.status}): ${res.stderr}`);
+    process.exit(1);
+  }
+  candidates = (res.stdout || '').split('\n').filter(Boolean);
 }
 
 const offenders = []; // { rule, file, hits: [line] }

--- a/.claude/skills/frontend-build-timing-audit/scripts/find-toplevel-init-calls.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/find-toplevel-init-calls.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// Scan every .ts/.tsx file in the repo for module-scope calls matching the
+// rules in `anti-patterns.config.mjs`. A "module-scope call" is a CallExpression
+// whose ancestor chain contains no function/arrow/method — i.e. one that
+// executes at module load.
+//
+// Such calls are dangerous in modules that may be evaluated before the entry
+// chunk's initializers (e.g. before `i18next.init()`) — see SKILL.md for the
+// full mental model.
+//
+// Usage:
+//   node find-toplevel-init-calls.mjs                 # scan workspace root
+//   node find-toplevel-init-calls.mjs <dir>           # scan a subtree
+//   node find-toplevel-init-calls.mjs --json          # machine-readable
+//                                                       output for snapshot.mjs
+//
+// Exit code:
+//   0 — always (this is a report, not a gate). Use --json + jq to gate.
+
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function findWorkspaceRoot(start) {
+  let dir = start;
+  for (let i = 0; i < 20; i++) {
+    try {
+      const pkg = readFileSync(`${dir}/package.json`, 'utf8');
+      if (/"name":\s*"openops"/.test(pkg) || /"workspaces"/.test(pkg)) return dir;
+    } catch {}
+    const parent = resolve(dir, '..');
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return start;
+}
+
+const args = process.argv.slice(2);
+const jsonMode = args.includes('--json');
+const dirArg = args.find((a) => !a.startsWith('--'));
+const cwd = dirArg ? resolve(dirArg) : findWorkspaceRoot(process.cwd());
+
+const require = createRequire(`${cwd}/package.json`);
+let ts;
+try {
+  ts = require('typescript');
+} catch {
+  console.error(`Could not load typescript from ${cwd}/node_modules.`);
+  console.error('Install dependencies first, or run from inside the repo.');
+  process.exit(1);
+}
+
+const config = (await import(`${__dirname}/anti-patterns.config.mjs`)).default;
+if (!Array.isArray(config) || config.length === 0) {
+  console.error('anti-patterns.config.mjs must default-export a non-empty array.');
+  process.exit(1);
+}
+
+// Validate rules.
+for (const r of config) {
+  if (!r.name || !r.module || !r.binding || !r.importKind) {
+    console.error(`Invalid rule: ${JSON.stringify(r)}`);
+    process.exit(1);
+  }
+  if (!r.matchCall && !(Array.isArray(r.matchMethodCall) && r.matchMethodCall.length)) {
+    console.error(`Rule '${r.name}' must set matchCall or matchMethodCall.`);
+    process.exit(1);
+  }
+}
+
+const isFunctionLike = (n) =>
+  ts.isFunctionDeclaration(n) ||
+  ts.isFunctionExpression(n) ||
+  ts.isArrowFunction(n) ||
+  ts.isMethodDeclaration(n) ||
+  ts.isConstructorDeclaration(n) ||
+  ts.isGetAccessorDeclaration(n) ||
+  ts.isSetAccessorDeclaration(n);
+
+const isModuleScope = (callNode) => {
+  let p = callNode.parent;
+  while (p) {
+    if (isFunctionLike(p)) return false;
+    p = p.parent;
+  }
+  return true;
+};
+
+// Build per-rule regexes that detect whether a file's imports match.
+function fileMatchesRule(src, rule) {
+  const mod = rule.module.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (rule.importKind === 'named') {
+    const re = new RegExp(
+      `import\\s*\\{[^}]*\\b${rule.binding}\\b[^}]*\\}\\s*from\\s*['"]${mod}['"]`,
+    );
+    return re.test(src);
+  }
+  if (rule.importKind === 'default') {
+    const re = new RegExp(
+      `import\\s+${rule.binding}\\s*(?:,\\s*\\{[^}]*\\})?\\s*from\\s*['"]${mod}['"]`,
+    );
+    return re.test(src);
+  }
+  return false;
+}
+
+// Collect candidates: any file that imports any rule's module.
+let candidates;
+try {
+  const modules = [...new Set(config.map((r) => r.module))];
+  const orPat = modules.map((m) => `from '${m}'`).join('\\|');
+  candidates = execSync(`git grep -l "${orPat}" -- '*.ts' '*.tsx'`, {
+    encoding: 'utf8',
+    cwd,
+  })
+    .split('\n')
+    .filter(Boolean);
+} catch {
+  console.error('git grep failed — make sure you are inside a git repo.');
+  process.exit(1);
+}
+
+const offenders = []; // { rule, file, hits: [line] }
+const countsByRule = Object.fromEntries(config.map((r) => [r.name, 0]));
+
+for (const relFile of candidates) {
+  const file = `${cwd}/${relFile}`;
+  const src = readFileSync(file, 'utf8');
+
+  const matchingRules = config.filter((r) => fileMatchesRule(src, r));
+  if (matchingRules.length === 0) continue;
+
+  const sf = ts.createSourceFile(
+    file,
+    src,
+    ts.ScriptTarget.Latest,
+    true,
+    relFile.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+
+  const hitsByRule = new Map();
+
+  const walk = (node) => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      for (const rule of matchingRules) {
+        let matched = false;
+        if (rule.matchCall && ts.isIdentifier(callee) && callee.text === rule.binding) {
+          matched = true;
+        } else if (
+          rule.matchMethodCall &&
+          ts.isPropertyAccessExpression(callee) &&
+          ts.isIdentifier(callee.expression) &&
+          callee.expression.text === rule.binding &&
+          rule.matchMethodCall.includes(callee.name.text)
+        ) {
+          matched = true;
+        }
+        if (matched && isModuleScope(node)) {
+          const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+          if (!hitsByRule.has(rule.name)) hitsByRule.set(rule.name, new Set());
+          hitsByRule.get(rule.name).add(line + 1);
+        }
+      }
+    }
+    ts.forEachChild(node, walk);
+  };
+  walk(sf);
+
+  for (const [ruleName, lineSet] of hitsByRule) {
+    const hits = [...lineSet].sort((a, b) => a - b);
+    offenders.push({ rule: ruleName, file: relFile, hits });
+    countsByRule[ruleName] += hits.length;
+  }
+}
+
+if (jsonMode) {
+  process.stdout.write(
+    JSON.stringify({ countsByRule, offenders }, null, 2) + '\n',
+  );
+  process.exit(0);
+}
+
+if (offenders.length === 0) {
+  console.error('No module-scope init-call offenders found.');
+  process.exit(0);
+}
+
+// Group by rule for readability.
+const byRule = new Map();
+for (const o of offenders) {
+  if (!byRule.has(o.rule)) byRule.set(o.rule, []);
+  byRule.get(o.rule).push(o);
+}
+
+for (const [rule, items] of byRule) {
+  console.log(`\n=== rule: ${rule} (${items.length} file(s), ${countsByRule[rule]} call(s)) ===`);
+  for (const { file, hits } of items) {
+    console.log(`${file}: lines ${hits.join(', ')}`);
+  }
+}
+
+console.error(
+  `\nFound ${offenders.length} file(s) with module-scope init-call hits. ` +
+    `Each is a latent build-timing regression. Fix by moving the call inside a ` +
+    `component (useTranslation() etc.) or a factory function.`,
+);

--- a/.claude/skills/frontend-build-timing-audit/scripts/lib/analyze.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/lib/analyze.mjs
@@ -34,9 +34,13 @@ export function findEntry(buildDir) {
 
 export function getStaticImports(buf) {
   const text = typeof buf === 'string' ? buf : buf.toString('utf8');
+  // Accept both `import ... from "./x.js"` (named / default / namespace) and
+  // bare side-effect `import "./x.js"`, single or double quoted. Rolldown
+  // emits double-quoted today, but tolerate variation so this also works
+  // against vendor-rolled chunks or future bundler changes.
   const m = [
     ...text.matchAll(
-      /import\s*(?:\*\s+as\s+\w+|\{[^}]*\}|\w+)?\s*from\s*"(\.\/[^"]+\.js)"/g,
+      /import\s*(?:(?:\*\s+as\s+\w+|\{[^}]*\}|\w+)\s*from\s*)?["'](\.\/[^"']+\.js)["']/g,
     ),
   ];
   return [...new Set(m.map((x) => x[1].replace(/^\.\//, '')))].sort();

--- a/.claude/skills/frontend-build-timing-audit/scripts/lib/analyze.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/lib/analyze.mjs
@@ -1,0 +1,131 @@
+// Shared analysis helpers for react-ui production builds.
+//
+// Public API:
+//   findEntry(buildDir)           -> entry chunk filename (e.g. 'index-abc.js')
+//   getStaticImports(buf)         -> [string] list of './chunk.js' siblings
+//                                    statically imported at the top of buf
+//   gz(buf)                       -> number (gzipped byte length, level 9)
+//   br(buf)                       -> number (brotli byte length, quality 11)
+//   analyzeBuild(dir, markers?)   -> AnalyzeResult (see shape below)
+//
+// AnalyzeResult shape:
+//   {
+//     entry: string,                  // entry chunk filename
+//     entrySize: number,              // raw bytes
+//     entryGzipped: number,
+//     chunkCount: number,             // total .js chunks
+//     staticImportCount: number,
+//     staticImports: string[],        // sorted, deduped
+//     critRaw, critGz, critBr: number, // entry + all static-dep chunks
+//     totalRaw, totalGz: number,       // every .js chunk in the build
+//     markers: [{ name, chunk, position, chunkSize, risk }]
+//        // risk = 'safe' | 'danger' | 'lazy' | 'missing'
+//   }
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { gzipSync, brotliCompressSync, constants } from 'node:zlib';
+
+export function findEntry(buildDir) {
+  const assets = `${buildDir}/assets`;
+  const f = readdirSync(assets).find((n) => /^index-[A-Za-z0-9_-]+\.js$/.test(n));
+  if (!f) throw new Error(`No entry chunk (index-*.js) in ${assets}`);
+  return f;
+}
+
+export function getStaticImports(buf) {
+  const text = typeof buf === 'string' ? buf : buf.toString('utf8');
+  const m = [
+    ...text.matchAll(
+      /import\s*(?:\*\s+as\s+\w+|\{[^}]*\}|\w+)?\s*from\s*"(\.\/[^"]+\.js)"/g,
+    ),
+  ];
+  return [...new Set(m.map((x) => x[1].replace(/^\.\//, '')))].sort();
+}
+
+export function gz(buf) {
+  return gzipSync(buf, { level: 9 }).length;
+}
+
+export function br(buf) {
+  return brotliCompressSync(buf, {
+    params: { [constants.BROTLI_PARAM_QUALITY]: 11 },
+  }).length;
+}
+
+function classifyMarker(chunk, entry, staticImports) {
+  if (chunk === entry) return 'safe';
+  if (staticImports.includes(chunk)) return 'danger';
+  return 'lazy';
+}
+
+export function analyzeBuild(buildDir, markers = []) {
+  const assets = `${buildDir}/assets`;
+  const files = readdirSync(assets).filter((f) => f.endsWith('.js'));
+  const entry = findEntry(buildDir);
+  const entryBuf = readFileSync(`${assets}/${entry}`);
+  const staticImports = getStaticImports(entryBuf);
+
+  let critRaw = 0,
+    critGz = 0,
+    critBr = 0;
+  const critFiles = [entry, ...staticImports];
+  for (const f of critFiles) {
+    const p = `${assets}/${f}`;
+    if (!existsSync(p)) continue;
+    const b = readFileSync(p);
+    critRaw += b.length;
+    critGz += gz(b);
+    critBr += br(b);
+  }
+
+  let totalRaw = 0,
+    totalGz = 0;
+  for (const f of files) {
+    const b = readFileSync(`${assets}/${f}`);
+    totalRaw += b.length;
+    totalGz += gz(b);
+  }
+
+  const markerResults = [];
+  for (const name of markers) {
+    let found = false;
+    for (const f of files) {
+      const text = readFileSync(`${assets}/${f}`, 'utf8');
+      const idx = text.indexOf(name);
+      if (idx !== -1) {
+        markerResults.push({
+          name,
+          chunk: f,
+          position: idx,
+          chunkSize: text.length,
+          risk: classifyMarker(f, entry, staticImports),
+        });
+        found = true;
+      }
+    }
+    if (!found) {
+      markerResults.push({
+        name,
+        chunk: null,
+        position: -1,
+        chunkSize: 0,
+        risk: 'missing',
+      });
+    }
+  }
+
+  return {
+    entry,
+    entrySize: entryBuf.length,
+    entryGzipped: gz(entryBuf),
+    chunkCount: files.length,
+    staticImportCount: staticImports.length,
+    staticImports,
+    critRaw,
+    critGz,
+    critBr,
+    totalRaw,
+    totalGz,
+    markers: markerResults,
+  };
+}

--- a/.claude/skills/frontend-build-timing-audit/scripts/snapshot.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/snapshot.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Snapshot the current production build's bundle metrics + AST anti-pattern
+// counts into a JSON document. Used by:
+//   - `update-baseline.mjs` to write `baseline.json`
+//   - `check-regression.mjs` to compare against the committed baseline
+//
+// Usage:
+//   node snapshot.mjs                                # builds, prints JSON
+//   node snapshot.mjs --no-build                     # reuse existing dist/
+//   node snapshot.mjs --out /tmp/snap.json           # write to file
+//   node snapshot.mjs --marker 'View input data' ... # repeatable
+//   node snapshot.mjs --build-dir dist/packages/react-ui
+//
+// Output shape:
+//   {
+//     version: 1,
+//     capturedAt: ISO timestamp,
+//     capturedFromSha: short SHA or 'dirty',
+//     metrics: { chunkCount, entryChunkSize, criticalPathRaw,
+//                criticalPathGzipped, criticalPathBrotli,
+//                totalJsRaw, totalJsGzipped, staticImportCount,
+//                antiPatternCounts: { <ruleName>: <count> },
+//                markers: [{ name, chunk, risk }] }
+//   }
+
+import { execSync, spawnSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { analyzeBuild } from './lib/analyze.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function parseArgs(argv) {
+  const out = { markers: [], build: true, out: null, buildDir: null };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    if (a === '--no-build') out.build = false;
+    else if (a === '--marker') out.markers.push(next());
+    else if (a === '--out') out.out = next();
+    else if (a === '--build-dir') out.buildDir = next();
+    else if (a === '--help' || a === '-h') {
+      console.log('See header of snapshot.mjs for usage.');
+      process.exit(0);
+    } else {
+      console.error(`Unknown arg: ${a}`);
+      process.exit(2);
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv);
+
+const cwd = execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+process.chdir(cwd);
+
+const buildDir = args.buildDir || `${cwd}/dist/packages/react-ui`;
+
+if (args.build) {
+  console.error('Building react-ui (this may take ~30s)...');
+  // Route build output to stderr so it cannot pollute our JSON stdout.
+  execSync(`npx nx build react-ui --skip-nx-cache 2>&1 | tail -3 1>&2`, {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    shell: '/bin/bash',
+  });
+}
+
+const build = analyzeBuild(buildDir, args.markers);
+
+// Run the AST scanner in JSON mode to get per-rule counts.
+const scanner = `${__dirname}/find-toplevel-init-calls.mjs`;
+const scan = spawnSync('node', [scanner, '--json'], {
+  cwd,
+  encoding: 'utf8',
+});
+if (scan.status !== 0) {
+  console.error('Scanner failed:');
+  console.error(scan.stdout);
+  console.error(scan.stderr);
+  process.exit(scan.status || 1);
+}
+
+let antiPatternCounts;
+try {
+  antiPatternCounts = JSON.parse(scan.stdout).countsByRule;
+} catch (e) {
+  console.error('Could not parse scanner output as JSON:');
+  console.error(scan.stdout);
+  throw e;
+}
+
+let sha;
+try {
+  // Ignore untracked files when judging "dirty" — those don't affect the
+  // build output, only tracked modifications do.
+  const dirty = execSync('git status --porcelain --untracked-files=no', {
+    encoding: 'utf8',
+  }).trim();
+  const rev = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  sha = dirty ? `${rev}-dirty` : rev;
+} catch {
+  sha = 'unknown';
+}
+
+const snapshot = {
+  version: 1,
+  capturedAt: new Date().toISOString(),
+  capturedFromSha: sha,
+  metrics: {
+    chunkCount: build.chunkCount,
+    entryChunkSize: build.entrySize,
+    criticalPathRaw: build.critRaw,
+    criticalPathGzipped: build.critGz,
+    criticalPathBrotli: build.critBr,
+    totalJsRaw: build.totalRaw,
+    totalJsGzipped: build.totalGz,
+    staticImportCount: build.staticImportCount,
+    antiPatternCounts,
+    markers: build.markers.map((m) => ({
+      name: m.name,
+      chunk: m.chunk,
+      risk: m.risk,
+    })),
+  },
+};
+
+const json = JSON.stringify(snapshot, null, 2);
+if (args.out) {
+  const target = resolve(args.out);
+  writeFileSync(target, json + '\n');
+  console.error(`Wrote ${target}`);
+} else {
+  process.stdout.write(json + '\n');
+}

--- a/.claude/skills/frontend-build-timing-audit/scripts/update-baseline.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/update-baseline.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Capture a fresh snapshot of the current build and write it to
+// `baseline.json`. Prints the diff against the previous baseline before
+// writing so changes are visible.
+//
+// Usage:
+//   node update-baseline.mjs                      # build + write
+//   node update-baseline.mjs --no-build           # reuse dist/
+//   node update-baseline.mjs --marker 'View ...'  # repeatable; preserved
+//                                                   in baseline.markers
+//
+// Thresholds are preserved across updates. If `baseline.json` does not yet
+// exist, sensible defaults are used (3% warn / 7% fail for size metrics,
+// 0% warn / 50% fail for anti-pattern counts).
+
+import { spawnSync, execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SKILL_DIR = resolve(__dirname, '..');
+const BASELINE_PATH = `${SKILL_DIR}/baseline.json`;
+
+function parseArgs(argv) {
+  const out = { build: true, markers: [] };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--no-build') out.build = false;
+    else if (a === '--marker') out.markers.push(argv[++i]);
+    else if (a === '--help' || a === '-h') {
+      console.log('See header of update-baseline.mjs for usage.');
+      process.exit(0);
+    } else {
+      console.error(`Unknown arg: ${a}`);
+      process.exit(2);
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv);
+
+let previous = null;
+if (existsSync(BASELINE_PATH)) {
+  try {
+    previous = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+  } catch (e) {
+    console.error(`Could not parse existing ${BASELINE_PATH}: ${e.message}`);
+    process.exit(2);
+  }
+}
+
+// Determine marker list: command-line args win; otherwise reuse previous.
+const markers =
+  args.markers.length > 0
+    ? args.markers
+    : (previous?.metrics.markers || []).map((m) => m.name);
+
+const cwd = execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+const buildDir = `${cwd}/dist/packages/react-ui`;
+
+const snapshotArgs = ['--build-dir', buildDir];
+if (!args.build) snapshotArgs.push('--no-build');
+for (const m of markers) snapshotArgs.push('--marker', m);
+
+console.error('Capturing snapshot...');
+const res = spawnSync('node', [`${__dirname}/snapshot.mjs`, ...snapshotArgs], {
+  encoding: 'utf8',
+});
+if (res.status !== 0) {
+  console.error('snapshot failed:');
+  console.error(res.stdout);
+  console.error(res.stderr);
+  process.exit(2);
+}
+const fresh = JSON.parse(res.stdout);
+
+// Preserve or initialise thresholds.
+const defaultThresholds = {
+  chunkCount: { warnPct: 5, failPct: 15 },
+  entryChunkSize: { warnPct: 5, failPct: 15 },
+  criticalPathRaw: { warnPct: 3, failPct: 7 },
+  criticalPathGzipped: { warnPct: 3, failPct: 7 },
+  criticalPathBrotli: { warnPct: 3, failPct: 7 },
+  totalJsRaw: { warnPct: 3, failPct: 7 },
+  totalJsGzipped: { warnPct: 3, failPct: 7 },
+  staticImportCount: { warnPct: 0, failPct: 50 },
+};
+const antiPatternDefaults = Object.fromEntries(
+  Object.keys(fresh.metrics.antiPatternCounts || {}).map((rule) => [
+    `antiPatternCounts.${rule}`,
+    { warnPct: 0, failPct: 50 },
+  ]),
+);
+
+const thresholds = {
+  ...defaultThresholds,
+  ...antiPatternDefaults,
+  ...(previous?.thresholds || {}),
+};
+
+const baseline = {
+  version: 1,
+  capturedAt: fresh.capturedAt,
+  capturedFromSha: fresh.capturedFromSha,
+  thresholds,
+  metrics: fresh.metrics,
+};
+
+// Print diff against previous if present.
+if (previous) {
+  console.error('\nDiff vs previous baseline:');
+  const keys = [
+    'chunkCount',
+    'entryChunkSize',
+    'criticalPathRaw',
+    'criticalPathGzipped',
+    'criticalPathBrotli',
+    'totalJsRaw',
+    'totalJsGzipped',
+    'staticImportCount',
+  ];
+  for (const k of keys) {
+    const before = previous.metrics[k];
+    const after = fresh.metrics[k];
+    if (before === undefined) continue;
+    const delta = before ? (100 * (after - before)) / before : 0;
+    const sign = delta >= 0 ? '+' : '';
+    console.error(`  ${k.padEnd(24)} ${String(before).padStart(12)} → ${String(after).padStart(12)}  (${sign}${delta.toFixed(2)}%)`);
+  }
+  const ruleNames = new Set([
+    ...Object.keys(previous.metrics.antiPatternCounts || {}),
+    ...Object.keys(fresh.metrics.antiPatternCounts || {}),
+  ]);
+  for (const rule of ruleNames) {
+    const before = (previous.metrics.antiPatternCounts || {})[rule] ?? 0;
+    const after = (fresh.metrics.antiPatternCounts || {})[rule] ?? 0;
+    if (before === after) continue;
+    console.error(`  antiPatternCounts.${rule}: ${before} → ${after}`);
+  }
+}
+
+writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + '\n');
+console.error(`\nWrote ${BASELINE_PATH}`);
+console.error(`capturedFromSha: ${baseline.capturedFromSha}`);

--- a/.claude/skills/frontend-build-timing-audit/scripts/update-baseline.mjs
+++ b/.claude/skills/frontend-build-timing-audit/scripts/update-baseline.mjs
@@ -126,9 +126,16 @@ if (previous) {
     const before = previous.metrics[k];
     const after = fresh.metrics[k];
     if (before === undefined) continue;
-    const delta = before ? (100 * (after - before)) / before : 0;
-    const sign = delta >= 0 ? '+' : '';
-    console.error(`  ${k.padEnd(24)} ${String(before).padStart(12)} → ${String(after).padStart(12)}  (${sign}${delta.toFixed(2)}%)`);
+    let deltaStr;
+    if (!before) {
+      deltaStr = after === 0 ? '+0.00%' : 'new';
+    } else {
+      const delta = (100 * (after - before)) / before;
+      deltaStr = `${delta >= 0 ? '+' : ''}${delta.toFixed(2)}%`;
+    }
+    console.error(
+      `  ${k.padEnd(24)} ${String(before).padStart(12)} → ${String(after).padStart(12)}  (${deltaStr})`,
+    );
   }
   const ruleNames = new Set([
     ...Object.keys(previous.metrics.antiPatternCounts || {}),


### PR DESCRIPTION
## Summary

Encodes the OPS-4318 investigation as a reusable Cursor / Claude diagnostic skill so future chunk-evaluation timing regressions in the `react-ui` production build can be caught at edit time rather than after deploy.

The skill bundles five scripts and a committed baseline:

- **`scripts/find-toplevel-init-calls.mjs`** — TypeScript-AST scanner that flags module-scope calls to init-dependent bindings. Data-driven via **`anti-patterns.config.mjs`**; initial rule covers `import { t } from 'i18next'` followed by a top-level `t(...)`. Adding a new rule (e.g. `Sentry.init`, `dayjs.locale`) is a one-line config change.
- **`scripts/bundle-diff.mjs`** — runs two production builds against arbitrary refs/patches and compares chunk count, entry-chunk size, critical-path bytes (raw / gzipped / brotli), and the chunk location of marker strings.
- **`scripts/snapshot.mjs` + `check-regression.mjs` + `update-baseline.mjs`** — capture the current build's bundle metrics plus per-rule anti-pattern counts into a JSON document, compare against a committed `baseline.json`, exit `0` / `1` / `2` (ok / warn / fail) based on percent-delta thresholds embedded in the baseline. Anti-pattern counts default to `warnPct: 0` so any new module-scope offender warns immediately.

Documentation in `SKILL.md` describes when to invoke each workflow; `reference.md` keeps the long-form root-cause write-up (ESM evaluation order, the 4-way controlled experiment, the `sideEffects` chunk-graph mechanics).

The committed `baseline.json` was captured against the current `main` HEAD (`e8d858ed89`), so future PRs will diff against the same chunk graph that ships today.

## Notes for reviewers

- Pure tooling addition under `.claude/skills/`. No app code, no dependencies, no CI wiring (deliberately deferred).
- The baseline reflects current `main`, **not** the still-open #2293 (sideEffects) — once that lands, run `node .claude/skills/frontend-build-timing-audit/scripts/update-baseline.mjs` to re-anchor.

## Test plan

- [x] `node .../find-toplevel-init-calls.mjs` reports the 18 known files / 85 hits across the repo (default rule).
- [x] `node .../find-toplevel-init-calls.mjs --json` emits parseable `{ countsByRule, offenders }`.
- [x] `node .../update-baseline.mjs --marker 'View input data' --marker 'View output data'` does a fresh `nx build react-ui --skip-nx-cache` and writes a clean baseline (capturedFromSha: `e8d858ed89`).
- [x] `node .../check-regression.mjs --no-build` against that baseline returns verdict `OK` (exit 0) on a no-op rerun; `--json` mode matches.
- [x] `bundle-diff.mjs --help` works after the `lib/analyze.mjs` extraction.
- [x] No lint errors under `.claude/skills/frontend-build-timing-audit/`.
- [ ] (Optional) Run a real `bundle-diff.mjs --ref-a main --ref-b fix/side-effects` after this PR lands to confirm the lib-refactored path still produces the experimental numbers documented in `reference.md`.

Part of OPS-4320.

Made with [Cursor](https://cursor.com)