### PR TITLE
Update the warning log emitted when ServiceNow table field metadata cannot be fetched

### DIFF
--- a/packages/blocks/servicenow/src/lib/fields-dropdown-property.ts
+++ b/packages/blocks/servicenow/src/lib/fields-dropdown-property.ts
@@ -45,8 +45,8 @@ export function servicenowFieldsDropdownProperty() {
         });
       } catch (error) {
         logger.warn(
-          'Fetching ServiceNow table fields is not possible, omit field selector. Error:',
-          { error },
+          'Fetching ServiceNow table fields is not possible, omit field selector.',
+          error,
         );
       }
 


### PR DESCRIPTION

Fixes OPS-4323

