### PR TITLE
Improve test execution performance with quick wins

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -14,4 +14,5 @@ module.exports = {
   snapshotFormat: { escapeString: true, printBasicPrototype: true },
   transformIgnorePatterns: ['^.+\\.js$', 'node_modules/(?!(lodash-es)/)'],
   setupFilesAfterEnv: [__dirname + '/jest.setup.js'],
+  maxWorkers: '50%',
 };

--- a/packages/blocks/ai/tsconfig.spec.json
+++ b/packages/blocks/ai/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/anodot/tsconfig.spec.json
+++ b/packages/blocks/anodot/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/archera/tsconfig.spec.json
+++ b/packages/blocks/archera/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/aws-athena/tsconfig.spec.json
+++ b/packages/blocks/aws-athena/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/aws-compute-optimizer/tsconfig.spec.json
+++ b/packages/blocks/aws-compute-optimizer/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/aws/tsconfig.spec.json
+++ b/packages/blocks/aws/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/azure/tsconfig.spec.json
+++ b/packages/blocks/azure/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/cloudability/tsconfig.spec.json
+++ b/packages/blocks/cloudability/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/cloudfix/tsconfig.spec.json
+++ b/packages/blocks/cloudfix/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/cloudformation/tsconfig.spec.json
+++ b/packages/blocks/cloudformation/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/cloudhealth/tsconfig.spec.json
+++ b/packages/blocks/cloudhealth/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/cloudzero/tsconfig.spec.json
+++ b/packages/blocks/cloudzero/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/databricks/tsconfig.spec.json
+++ b/packages/blocks/databricks/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/date-helper/tsconfig.spec.json
+++ b/packages/blocks/date-helper/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/end-flow/tsconfig.spec.json
+++ b/packages/blocks/end-flow/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/finout/tsconfig.spec.json
+++ b/packages/blocks/finout/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/flexera-one/tsconfig.spec.json
+++ b/packages/blocks/flexera-one/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/flexera/tsconfig.spec.json
+++ b/packages/blocks/flexera/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/framework/tsconfig.spec.json
+++ b/packages/blocks/framework/tsconfig.spec.json
@@ -4,7 +4,8 @@
     "outDir": "../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"],
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/github/tsconfig.spec.json
+++ b/packages/blocks/github/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/google-cloud/tsconfig.spec.json
+++ b/packages/blocks/google-cloud/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/http/tsconfig.spec.json
+++ b/packages/blocks/http/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/hyperglance/tsconfig.spec.json
+++ b/packages/blocks/hyperglance/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/imap/tsconfig.spec.json
+++ b/packages/blocks/imap/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/jira-cloud/tsconfig.spec.json
+++ b/packages/blocks/jira-cloud/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/kion/tsconfig.spec.json
+++ b/packages/blocks/kion/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/list-operations/tsconfig.spec.json
+++ b/packages/blocks/list-operations/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/math-helper/tsconfig.spec.json
+++ b/packages/blocks/math-helper/tsconfig.spec.json
@@ -4,7 +4,8 @@
     "outDir": "../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"],
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/microsoft-outlook/tsconfig.spec.json
+++ b/packages/blocks/microsoft-outlook/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/microsoft-teams/tsconfig.spec.json
+++ b/packages/blocks/microsoft-teams/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/nops/tsconfig.spec.json
+++ b/packages/blocks/nops/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/openops-tables/tsconfig.spec.json
+++ b/packages/blocks/openops-tables/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/servicenow/tsconfig.spec.json
+++ b/packages/blocks/servicenow/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/slack/tsconfig.spec.json
+++ b/packages/blocks/slack/tsconfig.spec.json
@@ -4,7 +4,8 @@
     "outDir": "../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"],
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/smtp/tsconfig.spec.json
+++ b/packages/blocks/smtp/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/snowflake/tsconfig.spec.json
+++ b/packages/blocks/snowflake/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/store/tsconfig.spec.json
+++ b/packages/blocks/store/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/ternary/tsconfig.spec.json
+++ b/packages/blocks/ternary/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/terraform/tsconfig.spec.json
+++ b/packages/blocks/terraform/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/vantage/tsconfig.spec.json
+++ b/packages/blocks/vantage/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/blocks/vegacloud/tsconfig.spec.json
+++ b/packages/blocks/vegacloud/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/cli/tsconfig.spec.json
+++ b/packages/cli/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/engine/tsconfig.spec.json
+++ b/packages/engine/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/packages/openops/tsconfig.spec.json
+++ b/packages/openops/tsconfig.spec.json
@@ -1,12 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": [
-      "jest",
-      "node"
-    ]
+    "types": ["jest", "node"]
   },
   "include": [
     "jest.config.ts",
@@ -16,6 +14,6 @@
     "test/**/*.test.ts",
     "test/**/*.spec.ts",
     "test/**/*.d.ts",
-    "test/**/*.mock.ts",
+    "test/**/*.mock.ts"
   ]
 }

--- a/packages/react-ui/tsconfig.spec.json
+++ b/packages/react-ui/tsconfig.spec.json
@@ -16,7 +16,8 @@
       "node",
       "@nx/react/typings/cssmodule.d.ts",
       "@nx/react/typings/image.d.ts"
-    ]
+    ],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/server/api/tsconfig.spec.json
+++ b/packages/server/api/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node", "@fastify/cookie"]
+    "types": ["jest", "node", "@fastify/cookie"],
+    "isolatedModules": true
   },
   "include": [
     "types/**/*.d.ts",

--- a/packages/server/shared/tsconfig.spec.json
+++ b/packages/server/shared/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "types/**/*.d.ts",

--- a/packages/server/worker/tsconfig.spec.json
+++ b/packages/server/worker/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/shared/tsconfig.spec.json
+++ b/packages/shared/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/ui-components/tsconfig.spec.json
+++ b/packages/ui-components/tsconfig.spec.json
@@ -10,7 +10,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "@openops/shared": ["../../packages/shared/src"]
-    }
+    },
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",

--- a/packages/ui-kit/tsconfig.spec.json
+++ b/packages/ui-kit/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "isolatedModules": true
   },
   "include": [
     "jest.config.ts",


### PR DESCRIPTION
## Summary

Applies two low-risk, high-impact optimizations to reduce test execution time across the monorepo.

### Changes

- **Add `isolatedModules: true` to all 51 `tsconfig.spec.json` files** — switches ts-jest to transpile-only mode, skipping full type-checking during tests (~30-50% faster transpilation)
- **Add `maxWorkers: '50%'` to `jest.preset.js`** — prevents resource contention by limiting Jest worker count to half of available CPU cores

### Validation

- ✅ engine tests pass
- ✅ blocks-aws tests pass  
- ✅ react-ui tests pass (436 tests)
- ✅ server-api unit tests pass

Part of OPS-testing-improvements.