### PR TITLE
Add padding to y-axis in combo-chart component

### DIFF
--- a/packages/ui-components/src/ui/chart/combo-chart.tsx
+++ b/packages/ui-components/src/ui/chart/combo-chart.tsx
@@ -107,6 +107,7 @@ export function ComboChart({
           tick={{
             fill: 'hsl(var(--foreground))',
           }}
+          padding={{ top: 4, bottom: 10 }}
         />
         <YAxis
           yAxisId="right"
@@ -121,6 +122,7 @@ export function ComboChart({
           tick={{
             fill: 'hsl(var(--foreground))',
           }}
+          padding={{ top: 4, bottom: 10 }}
         />
         {showTooltip && (
           <ChartTooltip cursor={false} content={<ChartTooltipContent />} />


### PR DESCRIPTION


Fixes OPS-4186

The ticket says there was no room at the top. But I think it is okay on the top of y-axis; instead I saw the issue on the bottom. 

## Additional Notes

Before:

<img width="705" height="463" alt="Screenshot 2026-05-26 at 1 27 14 PM" src="https://github.com/user-attachments/assets/f53f6022-70b4-42e1-8326-06250a245dfb" />

After:

<img width="705" height="463" alt="Screenshot 2026-05-26 at 1 25 30 PM" src="https://github.com/user-attachments/assets/6eb0905b-825a-4e14-aae8-dd9b11ed1e9d" />

