### PR TITLE
Add Vendor Account IDs input to Cloudability Get Recommendations

### DIFF
--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -15,9 +15,8 @@
   ],
   "body": [
     {
-      "pattern": "(?:Fixes|Resolves|Closes|Part of) (?:#|OPS-|OPC-|CI-|DOC-)[1-9]\\d*|Dependabot commands and options",
+      "pattern": "(?:Fixes|Resolves|Closes|Part of) (?:#|OPS-|OPC-|CI-|DOC-|SOL-)[1-9]\\d*|Dependabot commands and options",
       "message": "Add a GitHub or Linear issue ID to your PR body, e.g. \"Fixes #1002\""
     }
   ]
 }
-

--- a/packages/blocks/cloudability/src/lib/actions/get-recommendations-action.ts
+++ b/packages/blocks/cloudability/src/lib/actions/get-recommendations-action.ts
@@ -43,6 +43,12 @@ export const getRecommendationsAction = createAction({
       description: 'The maximum number of recommendations to return.',
       required: false,
     }),
+    vendorAccountIds: Property.Array({
+      displayName: 'Vendor Account IDs',
+      description:
+        'Optional list of cloud account IDs to scope recommendations to.',
+      required: false,
+    }),
     additionalFilters: Property.Array({
       displayName: 'Additional Filters',
       description:
@@ -59,6 +65,7 @@ export const getRecommendationsAction = createAction({
       additionalFilters,
       basis,
       snoozedFilter,
+      vendorAccountIds,
     } = context.propsValue;
     const { auth } = context;
 
@@ -71,6 +78,7 @@ export const getRecommendationsAction = createAction({
       filters: additionalFilters as string[],
       basis: basis,
       snoozedFilter: snoozedFilter,
+      vendorAccountIds: vendorAccountIds as string[] | undefined,
     });
 
     return result;

--- a/packages/blocks/cloudability/src/lib/actions/get-recommendations-action.ts
+++ b/packages/blocks/cloudability/src/lib/actions/get-recommendations-action.ts
@@ -75,7 +75,7 @@ export const getRecommendationsAction = createAction({
       recommendationType: recommendationType,
       duration: duration,
       limit,
-      filters: additionalFilters as string[],
+      filters: (additionalFilters as string[] | undefined) ?? [],
       basis: basis,
       snoozedFilter: snoozedFilter,
       vendorAccountIds: vendorAccountIds as string[] | undefined,

--- a/packages/blocks/cloudability/src/lib/common/recommendations-api.ts
+++ b/packages/blocks/cloudability/src/lib/common/recommendations-api.ts
@@ -14,6 +14,7 @@ export async function getRecommendations({
   filters,
   basis,
   snoozedFilter,
+  vendorAccountIds,
 }: {
   auth: CloudabilityAuth;
   vendor: Vendor;
@@ -23,6 +24,7 @@ export async function getRecommendations({
   filters: string[];
   basis: CostBasis;
   snoozedFilter: SnoozedFilter;
+  vendorAccountIds?: string[];
 }): Promise<any[]> {
   const isAwsRedshift =
     vendor === Vendor.AWS && recommendationType === 'redshift';
@@ -42,6 +44,9 @@ export async function getRecommendations({
       ...(!limit || isEmpty(limit) || isNaN(Number(limit))
         ? {}
         : { limit: limit, offset: '0' }),
+      ...(vendorAccountIds && vendorAccountIds.length > 0
+        ? { vendorAccountIds: vendorAccountIds.join(',') }
+        : {}),
     },
   });
 

--- a/packages/blocks/cloudability/test/recommendations-api.test.ts
+++ b/packages/blocks/cloudability/test/recommendations-api.test.ts
@@ -137,6 +137,102 @@ describe('recommendations-api', () => {
         }),
       );
     });
+
+    test('includes vendorAccountIds as comma-joined query param when provided', async () => {
+      (makeRequest as jest.Mock).mockResolvedValue([]);
+      await getRecommendations({
+        auth: mockAuth,
+        vendor: Vendor.AWS,
+        recommendationType: 'ec2',
+        duration: Duration.ThirtyDay,
+        limit: '1',
+        filters: [],
+        basis: CostBasis.OnDemand,
+        snoozedFilter: SnoozedFilter.NO_SNOOZED,
+        vendorAccountIds: ['058264385171', '160153085320'],
+      });
+
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryParams: expect.objectContaining({
+            vendorAccountIds: '058264385171,160153085320',
+          }),
+        }),
+      );
+    });
+
+    test('preserves leading zeros in vendorAccountIds (no numeric coercion)', async () => {
+      (makeRequest as jest.Mock).mockResolvedValue([]);
+      await getRecommendations({
+        auth: mockAuth,
+        vendor: Vendor.AWS,
+        recommendationType: 'ec2',
+        duration: Duration.ThirtyDay,
+        limit: '1',
+        filters: [],
+        basis: CostBasis.OnDemand,
+        snoozedFilter: SnoozedFilter.NO_SNOOZED,
+        vendorAccountIds: ['058264385171'],
+      });
+
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryParams: expect.objectContaining({
+            vendorAccountIds: '058264385171',
+          }),
+        }),
+      );
+    });
+
+    test.each([undefined, []])(
+      'omits vendorAccountIds query param when value is %p',
+      async (value) => {
+        (makeRequest as jest.Mock).mockResolvedValue([]);
+        await getRecommendations({
+          auth: mockAuth,
+          vendor: Vendor.AWS,
+          recommendationType: 'ec2',
+          duration: Duration.ThirtyDay,
+          limit: '1',
+          filters: [],
+          basis: CostBasis.OnDemand,
+          snoozedFilter: SnoozedFilter.NO_SNOOZED,
+          vendorAccountIds: value as string[] | undefined,
+        });
+
+        expect(makeRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            queryParams: expect.not.objectContaining({
+              vendorAccountIds: expect.anything(),
+            }),
+          }),
+        );
+      },
+    );
+
+    test('includes vendorAccountIds for AWS redshift underutilized endpoint', async () => {
+      (makeRequest as jest.Mock).mockResolvedValue([]);
+      await getRecommendations({
+        auth: mockAuth,
+        vendor: Vendor.AWS,
+        recommendationType: 'redshift',
+        duration: Duration.ThirtyDay,
+        limit: '1',
+        filters: [],
+        basis: CostBasis.OnDemand,
+        snoozedFilter: SnoozedFilter.NO_SNOOZED,
+        vendorAccountIds: ['058264385171'],
+      });
+
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: '/rightsizing/AWS/underutilized/redshift',
+          queryParams: expect.objectContaining({
+            vendorAccountIds: '058264385171',
+          }),
+        }),
+      );
+    });
   });
 
   describe('snoozeRecommendations', () => {


### PR DESCRIPTION
Adds an optional Vendor Account IDs input to the Cloudability Get Recommendations action. When provided, the account IDs are sent as the top-level vendorAccountIds query parameter on the rightsizing API call, letting users scope results to specific cloud accounts.

Previously, filtering by account was only possible via the Additional Filters field, but vendorAccountId(s) is a top-level query parameter on the Cloudability API and is rejected when placed inside filters=, returning HTTP 400.

Part of SOL-110

<img width="1653" height="907" alt="image" src="https://github.com/user-attachments/assets/64f83f48-b997-4e1a-9e1b-f48ba353dfa1" />
