### PR TITLE
Bump shell-quote to fix critical audit

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -32838,7 +32838,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEAL
 The following npm packages may be included in this product:
 
  - commondir@1.0.1
- - shell-quote@1.8.1
+ - shell-quote@1.8.4
 
 These packages each contain the following license:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,7 +253,7 @@
         "rxjs": "7.8.1",
         "semver": "7.6.0",
         "shade-generator": "1.2.7",
-        "shell-quote": "1.8.1",
+        "shell-quote": "1.8.4",
         "showdown": "2.1.0",
         "snowflake-sdk": "2.4.0",
         "socket.io": "4.8.3",
@@ -45457,19 +45457,6 @@
         "shell-quote": "^1.8.3"
       }
     },
-    "node_modules/launch-editor/node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/layout-base": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
@@ -57074,10 +57061,13 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
     "rxjs": "7.8.1",
     "semver": "7.6.0",
     "shade-generator": "1.2.7",
-    "shell-quote": "1.8.1",
+    "shell-quote": "1.8.4",
     "showdown": "2.1.0",
     "snowflake-sdk": "2.4.0",
     "socket.io": "4.8.3",


### PR DESCRIPTION
## What

Bump the direct `shell-quote` dependency from `1.8.1` to `1.8.4`.

## Why

`shell-quote` 1.1.0–1.8.3 is affected by [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) (`quote()` does not escape newlines in object `.op` values), which npm classifies as **critical**. The Security Audit CI job runs `npm audit --audit-level=critical`, so this advisory fails the audit gate on every branch cut from current `main` — including #2332 and #2333, which are otherwise green.

## How

- Bump the direct dependency to `1.8.4` (the fixed release — a backward-compatible patch bump).
- `launch-editor` pulls in a transitive copy via `^1.8.3`, which `1.8.4` satisfies, so the lockfile now dedups to a single `shell-quote@1.8.4`.
- After the change, `npm audit --audit-level=critical` exits `0` (0 critical advisories). The remaining low/moderate/high advisories are not gated by CI and are out of scope here.

## Notes

- Branch uses the `dependabot/` prefix so the license file is regenerated automatically.
- Unblocks the Security Audit job on #2332 and #2333.

Fixes OPS-4490