### PR TITLE
Chunk rows to max allowed size in table batch delete endpoint

### DIFF
--- a/packages/openops/src/lib/openops-tables/rows.ts
+++ b/packages/openops/src/lib/openops-tables/rows.ts
@@ -443,11 +443,16 @@ export async function batchDeleteRows(
   await executeWithConcurrencyLimit(
     async () => {
       const authenticationHeader = createAxiosHeaders(params.tokenOrResolver);
-      return await makeOpenOpsTablesPost(
-        url,
-        { items: params.rowIds },
-        authenticationHeader,
-      );
+
+      for (
+        let index = 0;
+        index < params.rowIds.length;
+        index += MAX_BATCH_ROWS
+      ) {
+        const items = params.rowIds.slice(index, index + MAX_BATCH_ROWS);
+
+        await makeOpenOpsTablesPost(url, { items }, authenticationHeader);
+      }
     },
     (error) => {
       logger.error('Error while batch deleting rows:', {

--- a/packages/openops/test/openops-tables/rows.test.ts
+++ b/packages/openops/test/openops-tables/rows.test.ts
@@ -485,6 +485,42 @@ describe('batchDeleteRows', () => {
     );
     expect(createAxiosHeadersMock).toHaveBeenCalledWith('token');
   });
+
+  test('Should split batch delete requests into chunks of 200', async () => {
+    const rowIds = Array.from({ length: 450 }, (_, index) => index + 1);
+
+    makeOpenOpsTablesPostMock.mockResolvedValue('mock result');
+    createAxiosHeadersMock.mockReturnValue('some header');
+
+    await batchDeleteRows({
+      tableId: 5,
+      tokenOrResolver: 'token',
+      rowIds,
+    });
+
+    expect(acquireMock).toBeCalledTimes(1);
+    expect(releaseMock).toBeCalledTimes(1);
+    expect(createAxiosHeadersMock).toHaveBeenCalledWith('token');
+    expect(makeOpenOpsTablesPostMock).toBeCalledTimes(3);
+    expect(makeOpenOpsTablesPostMock).toHaveBeenNthCalledWith(
+      1,
+      'api/database/rows/table/5/batch-delete/',
+      { items: rowIds.slice(0, 200) },
+      'some header',
+    );
+    expect(makeOpenOpsTablesPostMock).toHaveBeenNthCalledWith(
+      2,
+      'api/database/rows/table/5/batch-delete/',
+      { items: rowIds.slice(200, 400) },
+      'some header',
+    );
+    expect(makeOpenOpsTablesPostMock).toHaveBeenNthCalledWith(
+      3,
+      'api/database/rows/table/5/batch-delete/',
+      { items: rowIds.slice(400, 450) },
+      'some header',
+    );
+  });
 });
 
 describe('truncateTable', () => {


### PR DESCRIPTION


Fixes OPS-4566

## Additional Notes


Problem

Baserow enforces a batch size limit of 200 on the batch-delete endpoint (items list max_length=200). When a campaign runs with a savings threshold enabled and more than 200 opportunities fall below it, batchDeleteRows sent all row IDs in a single request, which Baserow rejected with 400 ERROR_REQUEST_BODY_VALIDATION ("no more than 200 elements").

The error propagated up uncaught and aborted handleDiscoveryCompletion before it reset needsDiscoveryRefresh, so the rows were never pruned and the campaign got stuck asking the user to refresh. Hit in the Informa env on the "AWS - Rightsize EBS Volumes" campaign (the first to exceed 200 sub-threshold rows).

Fix

Chunk the row IDs into batches of at most 200 when calling the batch-delete endpoint, mirroring the existing chunking in batchCreateRows/batchUpdateRows.

