### PR TITLE
Add follow-up question support to Teams request action

### DIFF
--- a/packages/blocks/microsoft-teams/src/lib/actions/request-action-message.ts
+++ b/packages/blocks/microsoft-teams/src/lib/actions/request-action-message.ts
@@ -6,6 +6,7 @@ import {
 } from '@openops/blocks-framework';
 import { networkUtls, SharedSystemProp, system } from '@openops/server-shared';
 import { ExecutionType } from '@openops/shared';
+import { buildWrapperUrl } from '../common/build-wrapper-url';
 import { chatExists } from '../common/chat-exists';
 import { ChannelOption, ChatOption, ChatTypes } from '../common/chat-types';
 import { chatsAndChannels } from '../common/chats-and-channels';
@@ -67,6 +68,31 @@ export const requestActionMessageAction = createAction({
               { label: 'Transparent', value: 'default' },
             ],
           },
+        }),
+        followUpQuestion: Property.ShortText({
+          displayName: 'Follow-up question',
+          description:
+            'Optionally ask a follow-up question in a popup window when this button is clicked.',
+          required: false,
+        }),
+        answerFormat: Property.StaticDropdown({
+          displayName: 'Answer format',
+          description: 'Only used when a follow-up question is set.',
+          required: false,
+          defaultValue: 'text',
+          options: {
+            options: [
+              { label: 'Text', value: 'text' },
+              { label: 'Email', value: 'email' },
+              { label: 'Number', value: 'number' },
+            ],
+          },
+        }),
+        noAnswerOption: Property.ShortText({
+          displayName: 'No answer option',
+          description:
+            "Optional text for a secondary choice when the person can't answer.",
+          required: false,
         }),
       },
     }),
@@ -133,9 +159,19 @@ export const requestActionMessageAction = createAction({
         );
         return {
           ...action,
-          resumeUrl: `${frontendUrl}/html/resume_execution.html?isTest=${
-            context.run.isTest
-          }&redirectUrl=${encodeURIComponent(resumeUrl)}`,
+          resumeUrl: buildWrapperUrl({
+            frontendUrl,
+            isTest: context.run.isTest,
+            resumeUrl,
+            followUp: action.followUpQuestion
+              ? {
+                  question: action.followUpQuestion,
+                  answerFormat: action.answerFormat,
+                  noAnswerOption: action.noAnswerOption,
+                  title: header,
+                }
+              : undefined,
+          }),
         };
       });
 

--- a/packages/blocks/microsoft-teams/src/lib/common/build-wrapper-url.ts
+++ b/packages/blocks/microsoft-teams/src/lib/common/build-wrapper-url.ts
@@ -1,0 +1,58 @@
+const RESUME_PAGE = 'resume_execution.html';
+const COLLECT_INPUT_PAGE = 'collect_input.html';
+
+const ANSWER_FORMATS = new Set(['text', 'email', 'number']);
+const DEFAULT_ANSWER_FORMAT = 'text';
+
+export type ButtonFollowUp = {
+  question: string;
+  answerFormat?: string;
+  noAnswerOption?: string;
+  title?: string;
+};
+
+// The collect-input page sends the answer back as the `answer` resume query
+// param, surfaced in the step output as parameters.answer.
+export function buildWrapperUrl({
+  frontendUrl,
+  isTest,
+  resumeUrl,
+  followUp,
+}: {
+  frontendUrl: string;
+  isTest: boolean;
+  resumeUrl: string;
+  followUp?: ButtonFollowUp;
+}): string {
+  const question = followUp?.question?.trim();
+
+  if (!question) {
+    return `${frontendUrl}/html/${RESUME_PAGE}?isTest=${isTest}&redirectUrl=${encodeURIComponent(
+      resumeUrl,
+    )}`;
+  }
+
+  const format =
+    followUp?.answerFormat && ANSWER_FORMATS.has(followUp.answerFormat)
+      ? followUp.answerFormat
+      : DEFAULT_ANSWER_FORMAT;
+
+  const params = new URLSearchParams({
+    isTest: String(isTest),
+    question,
+    format,
+    redirectUrl: resumeUrl,
+  });
+
+  const noAnswerOption = followUp?.noAnswerOption?.trim();
+  if (noAnswerOption) {
+    params.set('noAnswerOption', noAnswerOption);
+  }
+
+  const title = followUp?.title?.trim();
+  if (title) {
+    params.set('title', title);
+  }
+
+  return `${frontendUrl}/html/${COLLECT_INPUT_PAGE}?${params.toString()}`;
+}

--- a/packages/blocks/microsoft-teams/src/lib/common/generate-message-with-buttons.ts
+++ b/packages/blocks/microsoft-teams/src/lib/common/generate-message-with-buttons.ts
@@ -1,6 +1,9 @@
 export type TeamsMessageAction = {
   buttonText: string;
   buttonStyle: string;
+  followUpQuestion?: string;
+  answerFormat?: string;
+  noAnswerOption?: string;
 };
 
 export type TeamsMessageButton = TeamsMessageAction & { resumeUrl?: string };

--- a/packages/blocks/microsoft-teams/src/lib/common/on-action-received.ts
+++ b/packages/blocks/microsoft-teams/src/lib/common/on-action-received.ts
@@ -5,6 +5,18 @@ import {
   TeamsMessageButton,
 } from './generate-message-with-buttons';
 
+// Query params the resume mechanism uses for routing; everything else is
+// user-provided data (e.g. from a form wrapper page) surfaced as `parameters`.
+const EXCLUDED_RESUME_PARAMS = new Set([
+  'button',
+  'path',
+  'executionCorrelationId',
+  'isTest',
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
 export const onActionReceived = async ({
   messageObj,
   actions,
@@ -14,8 +26,9 @@ export const onActionReceived = async ({
   actions: TeamsMessageButton[];
   context: any;
 }) => {
-  const resumePayload = context.resumePayload
-    ?.queryParams as unknown as InteractionPayload;
+  const resumePayload = context.resumePayload?.queryParams as unknown as
+    | (InteractionPayload & Record<string, string>)
+    | undefined;
   const isResumedDueToButtonClicked = !!resumePayload?.button;
 
   if (!isResumedDueToButtonClicked) {
@@ -23,6 +36,7 @@ export const onActionReceived = async ({
       action: '',
       isExpired: true,
       message: messageObj,
+      parameters: {},
     };
   }
 
@@ -52,12 +66,20 @@ export const onActionReceived = async ({
       action: '',
       isExpired: undefined,
       message: messageObj,
+      parameters: {},
     };
   }
+
+  const parameters = Object.fromEntries(
+    Object.entries(resumePayload).filter(
+      ([key]) => !EXCLUDED_RESUME_PARAMS.has(key),
+    ),
+  );
 
   return {
     action: resumePayload.button,
     message: messageObj,
     isExpired: false,
+    parameters,
   };
 };

--- a/packages/blocks/microsoft-teams/test/build-wrapper-url.test.ts
+++ b/packages/blocks/microsoft-teams/test/build-wrapper-url.test.ts
@@ -1,0 +1,101 @@
+import { buildWrapperUrl } from '../src/lib/common/build-wrapper-url';
+
+const baseParams = {
+  frontendUrl: 'https://app.openops.com',
+  isTest: false,
+  resumeUrl:
+    'https://api.openops.com/v1/flow-runs/run-1/requests/pause-1?button=Not%20mine&path=step_1',
+};
+
+const encodedResumeUrl = encodeURIComponent(baseParams.resumeUrl);
+
+describe('buildWrapperUrl', () => {
+  test('uses the default resume page when no follow-up question is given', () => {
+    const url = buildWrapperUrl(baseParams);
+
+    expect(url).toBe(
+      `https://app.openops.com/html/resume_execution.html?isTest=false&redirectUrl=${encodedResumeUrl}`,
+    );
+  });
+
+  test('uses the collect-input page when a follow-up question is given', () => {
+    const url = buildWrapperUrl({
+      ...baseParams,
+      followUp: {
+        question: "What is the correct owner's email?",
+        answerFormat: 'email',
+      },
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.origin).toBe('https://app.openops.com');
+    expect(parsed.pathname).toBe('/html/collect_input.html');
+    expect(parsed.searchParams.get('question')).toBe(
+      "What is the correct owner's email?",
+    );
+    expect(parsed.searchParams.get('format')).toBe('email');
+    expect(parsed.searchParams.get('isTest')).toBe('false');
+    expect(parsed.searchParams.get('redirectUrl')).toBe(baseParams.resumeUrl);
+  });
+
+  test('includes the message header as the form title when given', () => {
+    const url = buildWrapperUrl({
+      ...baseParams,
+      followUp: {
+        question: 'Who owns this?',
+        title: 'Cost savings opportunity: vol-123',
+      },
+    });
+
+    expect(new URL(url).searchParams.get('title')).toBe(
+      'Cost savings opportunity: vol-123',
+    );
+  });
+
+  test('includes the no-answer option when given', () => {
+    const url = buildWrapperUrl({
+      ...baseParams,
+      followUp: {
+        question: "What is the correct owner's email?",
+        noAnswerOption: "I don't know the owner",
+      },
+    });
+
+    expect(new URL(url).searchParams.get('noAnswerOption')).toBe(
+      "I don't know the owner",
+    );
+  });
+
+  test('omits the no-answer option param when not given', () => {
+    const url = buildWrapperUrl({
+      ...baseParams,
+      followUp: { question: 'Why was this dismissed?' },
+    });
+
+    expect(new URL(url).searchParams.has('noAnswerOption')).toBe(false);
+  });
+
+  test('ignores a follow-up with an empty question', () => {
+    const url = buildWrapperUrl({
+      ...baseParams,
+      followUp: { question: '   ' },
+    });
+
+    expect(url).toContain('/html/resume_execution.html?');
+  });
+
+  test('defaults the answer format to text for unknown formats', () => {
+    const url = buildWrapperUrl({
+      ...baseParams,
+      followUp: { question: 'Why?', answerFormat: 'dropdown' },
+    });
+
+    expect(new URL(url).searchParams.get('format')).toBe('text');
+  });
+
+  test('passes isTest through', () => {
+    const url = buildWrapperUrl({ ...baseParams, isTest: true });
+
+    expect(url).toContain('isTest=true');
+  });
+});

--- a/packages/blocks/microsoft-teams/test/on-action-received.test.ts
+++ b/packages/blocks/microsoft-teams/test/on-action-received.test.ts
@@ -23,7 +23,7 @@ const mockContext = {
     queryParams: {
       button: 'Approve',
       path: 'execution-path-1',
-    },
+    } as Record<string, string>,
   },
   currentExecutionPath: 'execution-path-1',
   run: { pause: jest.fn() },
@@ -50,6 +50,7 @@ describe('onActionReceived', () => {
       action: '',
       isExpired: true,
       message: mockMessageObj,
+      parameters: {},
     });
   });
 
@@ -89,6 +90,75 @@ describe('onActionReceived', () => {
       action: 'Approve',
       message: mockMessageObj,
       isExpired: false,
+      parameters: {},
     });
+  });
+
+  test('should surface extra resume query params as parameters', async () => {
+    mockContext.store.get.mockResolvedValueOnce({ pauseMetadata: 'mock-data' });
+    mockContext.resumePayload = {
+      queryParams: {
+        button: 'Approve',
+        path: 'execution-path-1',
+        executionCorrelationId: 'corr-1',
+        isTest: 'false',
+        newOwner: 'alice@example.com',
+      },
+    };
+
+    const result = await onActionReceived({
+      messageObj: mockMessageObj,
+      actions: mockActions,
+      context: mockContext,
+    });
+
+    expect(result).toEqual({
+      action: 'Approve',
+      message: mockMessageObj,
+      isExpired: false,
+      parameters: { newOwner: 'alice@example.com' },
+    });
+  });
+
+  test('should not include prototype-pollution keys in parameters', async () => {
+    mockContext.store.get.mockResolvedValueOnce({ pauseMetadata: 'mock-data' });
+    mockContext.resumePayload = {
+      queryParams: {
+        button: 'Approve',
+        path: 'execution-path-1',
+        ['__proto__']: 'polluted',
+        constructor: 'polluted',
+        prototype: 'polluted',
+        answer: 'alice@example.com',
+      } as Record<string, string>,
+    };
+
+    const result = await onActionReceived({
+      messageObj: mockMessageObj,
+      actions: mockActions,
+      context: mockContext,
+    });
+
+    expect(result.parameters).toEqual({ answer: 'alice@example.com' });
+  });
+
+  test('should not include internal routing params in parameters', async () => {
+    mockContext.store.get.mockResolvedValueOnce({ pauseMetadata: 'mock-data' });
+    mockContext.resumePayload = {
+      queryParams: {
+        button: 'Approve',
+        path: 'execution-path-1',
+        executionCorrelationId: 'corr-1',
+        isTest: 'true',
+      },
+    };
+
+    const result = await onActionReceived({
+      messageObj: mockMessageObj,
+      actions: mockActions,
+      context: mockContext,
+    });
+
+    expect(result.parameters).toEqual({});
   });
 });

--- a/packages/blocks/microsoft-teams/test/on-action-received.test.ts
+++ b/packages/blocks/microsoft-teams/test/on-action-received.test.ts
@@ -122,16 +122,14 @@ describe('onActionReceived', () => {
 
   test('should not include prototype-pollution keys in parameters', async () => {
     mockContext.store.get.mockResolvedValueOnce({ pauseMetadata: 'mock-data' });
-    mockContext.resumePayload = {
-      queryParams: {
-        button: 'Approve',
-        path: 'execution-path-1',
-        ['__proto__']: 'polluted',
-        constructor: 'polluted',
-        prototype: 'polluted',
-        answer: 'alice@example.com',
-      } as Record<string, string>,
-    };
+    const queryParams = Object.create(null) as Record<string, string>;
+    queryParams['button'] = 'Approve';
+    queryParams['path'] = 'execution-path-1';
+    queryParams['__proto__'] = 'polluted';
+    queryParams['constructor'] = 'polluted';
+    queryParams['prototype'] = 'polluted';
+    queryParams['answer'] = 'alice@example.com';
+    mockContext.resumePayload = { queryParams };
 
     const result = await onActionReceived({
       messageObj: mockMessageObj,

--- a/packages/blocks/microsoft-teams/test/on-action-received.test.ts
+++ b/packages/blocks/microsoft-teams/test/on-action-received.test.ts
@@ -125,7 +125,12 @@ describe('onActionReceived', () => {
     const queryParams = Object.create(null) as Record<string, string>;
     queryParams['button'] = 'Approve';
     queryParams['path'] = 'execution-path-1';
-    queryParams['__proto__'] = 'polluted';
+    Object.defineProperty(queryParams, '__proto__', {
+      value: 'polluted',
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
     queryParams['constructor'] = 'polluted';
     queryParams['prototype'] = 'polluted';
     queryParams['answer'] = 'alice@example.com';

--- a/packages/react-ui/public/html/collect_input.html
+++ b/packages/react-ui/public/html/collect_input.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Provide Input</title>
+    <link rel="icon" type="image/x-icon" href="/logos/favicon.ico" />
+    <link href="https://fonts.cdnfonts.com/css/satoshi" rel="stylesheet" />
+    <style>
+      body {
+        font-family: 'Satoshi', sans-serif;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100vh;
+        background-color: #f9f9f9;
+        color: #333;
+        text-align: center;
+      }
+
+      .container {
+        max-width: 500px;
+        width: 100%;
+        padding: 0 16px;
+      }
+
+      .logo {
+        margin-bottom: 30px;
+      }
+
+      .message {
+        font-size: 1.2rem;
+        margin-bottom: 20px;
+      }
+
+      .note {
+        font-size: 0.9rem;
+        color: #666;
+      }
+
+      .field-label {
+        display: block;
+        text-align: left;
+        font-size: 0.95rem;
+        font-weight: 500;
+        margin-bottom: 6px;
+      }
+
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 10px 12px;
+        font-size: 1rem;
+        font-family: inherit;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+        margin-bottom: 8px;
+      }
+
+      input:focus {
+        outline: none;
+        border-color: #6e41e2;
+      }
+
+      .error {
+        display: none;
+        text-align: left;
+        color: #c0392b;
+        font-size: 0.85rem;
+        margin-bottom: 8px;
+      }
+
+      button {
+        width: 100%;
+        padding: 10px 12px;
+        font-size: 1rem;
+        font-family: inherit;
+        font-weight: 500;
+        border-radius: 6px;
+        border: none;
+        cursor: pointer;
+        background-color: #6e41e2;
+        color: #fff;
+        margin-bottom: 10px;
+      }
+
+      .secondary {
+        background-color: transparent;
+        color: #333;
+        border: 1px solid #ccc;
+      }
+
+      .divider {
+        display: flex;
+        align-items: center;
+        color: #999;
+        font-size: 0.85rem;
+        margin: 14px 0;
+      }
+
+      .divider::before,
+      .divider::after {
+        content: '';
+        flex: 1;
+        border-top: 1px solid #ddd;
+      }
+
+      .divider::before {
+        margin-right: 10px;
+      }
+
+      .divider::after {
+        margin-left: 10px;
+      }
+
+      .hidden {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <img class="logo" src="/logos/logo.positive.svg" alt="Logo" width="300" />
+
+      <div id="form-view">
+        <form id="input-form" novalidate>
+          <label class="field-label" for="input-value" id="input-label"
+            >Your answer</label
+          >
+          <input id="input-value" type="text" maxlength="254" />
+          <p class="error" id="input-error">Please enter a valid value.</p>
+          <button type="submit">Submit</button>
+        </form>
+        <div id="skip-section" class="hidden">
+          <div class="divider">or</div>
+          <button type="button" class="secondary" id="skip-button"></button>
+        </div>
+      </div>
+
+      <div id="done-view" class="hidden">
+        <h2 id="done-title">Your response has been recorded.</h2>
+        <p class="message">
+          You can close this page or it will be automatically closed in 20
+          seconds.
+        </p>
+        <p class="note">
+          If the page does not close automatically, you may safely close it
+          manually.
+        </p>
+      </div>
+
+      <div id="invalid-view" class="hidden">
+        <h2>This link is invalid.</h2>
+        <p class="note">
+          Please use the button from the original notification message.
+        </p>
+      </div>
+    </div>
+
+    <script>
+      const searchParams = new URLSearchParams(window.location.search);
+      const redirectUrl = searchParams.get('redirectUrl');
+      const isTest = searchParams.get('isTest') === 'true';
+      const question = (searchParams.get('question') || '').trim();
+
+      const ANSWER_FORMATS = ['text', 'email', 'number'];
+      const rawFormat = searchParams.get('format') || 'text';
+      const answerFormat = ANSWER_FORMATS.includes(rawFormat)
+        ? rawFormat
+        : 'text';
+
+      // The answer travels back as a fixed resume query param, surfaced in the
+      // step output as parameters.answer.
+      const ANSWER_PARAM = 'answer';
+
+      const EMAIL_REGEX = /^[^\s@]+@([^\s@.]+\.)+[^\s@.]+$/;
+      const RESUME_PATH_REGEX = /\/v1\/flow-runs\/[^/]+\/requests\/[^/]+$/;
+
+      const formView = document.getElementById('form-view');
+      const doneView = document.getElementById('done-view');
+      const invalidView = document.getElementById('invalid-view');
+      const inputField = document.getElementById('input-value');
+      const inputError = document.getElementById('input-error');
+
+      function parseResumeUrl(value) {
+        if (!value) {
+          return null;
+        }
+        try {
+          const url = new URL(value);
+          const isSameOrigin = url.origin === window.location.origin;
+          if (!isSameOrigin || !RESUME_PATH_REGEX.test(url.pathname)) {
+            return null;
+          }
+          return url;
+        } catch {
+          return null;
+        }
+      }
+
+      const resumeUrl = parseResumeUrl(redirectUrl);
+
+      function showDone(title) {
+        formView.classList.add('hidden');
+        doneView.classList.remove('hidden');
+        if (title) {
+          document.getElementById('done-title').textContent = title;
+        }
+        setTimeout(() => {
+          window.close();
+        }, 20000);
+      }
+
+      function isValidAnswer(value) {
+        if (!value || value.length > 254) {
+          return false;
+        }
+        if (answerFormat === 'email') {
+          return EMAIL_REGEX.test(value);
+        }
+        if (answerFormat === 'number') {
+          return !Number.isNaN(Number(value));
+        }
+        return true;
+      }
+
+      if (!resumeUrl || !question) {
+        formView.classList.add('hidden');
+        invalidView.classList.remove('hidden');
+      } else if (isTest) {
+        showDone(
+          'Test succeeded! Actions are disabled in test mode and are only available when running the entire workflow.',
+        );
+      } else {
+        document.getElementById('input-label').textContent = question;
+        inputField.type = answerFormat;
+        document.title = question;
+
+        const title = (searchParams.get('title') || '').trim();
+        if (title) {
+          const titleEl = document.createElement('h2');
+          titleEl.textContent = title;
+          formView.insertBefore(titleEl, document.getElementById('input-form'));
+          document.title = title;
+        }
+
+        function fireResume(value) {
+          const target = new URL(resumeUrl);
+          target.searchParams.set(ANSWER_PARAM, value);
+          const iframe = document.createElement('iframe');
+          iframe.src = target.toString();
+          iframe.style.display = 'none';
+          document.body.appendChild(iframe);
+          showDone();
+        }
+
+        document
+          .getElementById('input-form')
+          .addEventListener('submit', (event) => {
+            event.preventDefault();
+            const value = inputField.value.trim();
+            if (!isValidAnswer(value)) {
+              inputError.style.display = 'block';
+              return;
+            }
+            inputError.style.display = 'none';
+            fireResume(value);
+          });
+
+        const noAnswerOption = (
+          searchParams.get('noAnswerOption') || ''
+        ).trim();
+        if (noAnswerOption) {
+          const skipButton = document.getElementById('skip-button');
+          skipButton.textContent = noAnswerOption;
+          document.getElementById('skip-section').classList.remove('hidden');
+          skipButton.addEventListener('click', () => {
+            fireResume('');
+          });
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/packages/react-ui/public/html/collect_input.html
+++ b/packages/react-ui/public/html/collect_input.html
@@ -221,7 +221,7 @@
           return EMAIL_REGEX.test(value);
         }
         if (answerFormat === 'number') {
-          return !Number.isNaN(Number(value));
+          return Number.isFinite(Number(value));
         }
         return true;
       }


### PR DESCRIPTION
Part of OPS-4626

Adds an opt-in "follow-up question" capability to the Microsoft Teams **Request Action** block: any action button can now ask the person a question in the browser before the workflow resumes, and the workflow receives the typed answer.

### What's new

<img width="643" height="735" alt="Screenshot 2026-07-14 at 6 19 55 PM" src="https://github.com/user-attachments/assets/c4398d1f-a67d-4c0c-b5e2-a0d975fbb747" />

<img width="643" height="503" alt="Screenshot 2026-07-14 at 6" src="https://github.com/user-attachments/assets/e910f58f-c504-4b72-9f62-89ef5fa1acfd" />


- Three optional properties per action button:
  - **Follow-up question** — if set, clicking the button opens a small OpenOps-hosted page asking this question instead of resuming immediately
  - **Answer format** — Text / Email / Number (validated on the page)
  - **No answer option** — text for a secondary choice (e.g. "I don't know"); choosing it resumes with an empty answer
- The answer is surfaced in the step output as `parameters.answer` (all non-routing resume query params are exposed under `parameters`)
- New generic page `collect_input.html` renders the question (with the card header as the page title), validates the answer, and fires the existing flow-run resume URL with the answer appended

### Why

Teams Adaptive Cards sent via the Graph API support only `Action.OpenUrl` — collecting typed input natively (`Action.Submit` / `Action.Execute` / dialogs) requires a bot or Teams app installed in the tenant. This rides the existing capability-URL button mechanism instead: no new permissions, no new endpoints.

Example use case: a notification recipient reports "I'm not the owner of this resource" and provides the correct owner's email, which the workflow then acts on.

### Safety

- Buttons without a follow-up question are untouched (same wrapper page, same output shape plus an empty `parameters`)
- The form page only fires same-origin redirect targets matching the flow-run resume path shape
- Prototype-pollution keys are excluded from `parameters`
- Client-side validation is convenience only, consuming workflows should re-validate the answer server-side, since resume URLs are capability URLs

