### PR TITLE
Add chart animation timing and donut hover callback

### DIFF
--- a/packages/ui-components/src/ui/chart/bar-chart.tsx
+++ b/packages/ui-components/src/ui/chart/bar-chart.tsx
@@ -8,6 +8,8 @@ import {
   YAxis,
 } from 'recharts';
 import {
+  CHART_ANIMATION_DURATION_MS,
+  CHART_ANIMATION_EASING,
   ChartConfig,
   ChartContainer,
   ChartLegend,
@@ -97,6 +99,10 @@ export function BarChart({
             tick={{
               fill: 'hsl(var(--foreground))',
             }}
+            // recharts reserves 30px for the axis by default, which is not
+            // enough for the 20px tickMargin plus the label text — the
+            // bottom few pixels of every label get clipped by the svg edge.
+            height={40}
           />
         )}
         <YAxis
@@ -133,6 +139,8 @@ export function BarChart({
             radius={bar.radius ?? 4}
             stackId={bar.stackId}
             hide={hiddenKeys.has(bar.dataKey)}
+            animationDuration={CHART_ANIMATION_DURATION_MS}
+            animationEasing={CHART_ANIMATION_EASING}
           />
         ))}
       </RechartsBarChart>

--- a/packages/ui-components/src/ui/chart/chart.tsx
+++ b/packages/ui-components/src/ui/chart/chart.tsx
@@ -8,6 +8,13 @@ import { cn } from '../../lib/cn';
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: '', dark: '.dark' } as const;
 
+// Recharts defaults differ per element (Bar 400ms, Pie 800ms, Line 1500ms),
+// so charts rendered side by side finish their transitions at different
+// times. Chart wrappers share this duration so filter changes animate at
+// the same pace across a page (currently applied to BarChart and DonutChart).
+export const CHART_ANIMATION_DURATION_MS = 800;
+export const CHART_ANIMATION_EASING = 'ease' as const;
+
 export type ChartConfig = {
   [k in string]: {
     label?: React.ReactNode;

--- a/packages/ui-components/src/ui/chart/donut-chart.tsx
+++ b/packages/ui-components/src/ui/chart/donut-chart.tsx
@@ -91,7 +91,12 @@ export function DonutChart({
 
   return (
     <ChartContainer config={config} className={className}>
-      <RechartsPieChart accessibilityLayer>
+      <RechartsPieChart
+        accessibilityLayer
+        onMouseLeave={
+          onSliceHover && !isEmpty ? () => onSliceHover(null) : undefined
+        }
+      >
         {showTooltip && !isEmpty && (
           <ChartTooltip
             cursor={false}
@@ -111,9 +116,6 @@ export function DonutChart({
               ? (entry: { name: string; value: number }) =>
                   onSliceHover({ name: entry.name, value: entry.value })
               : undefined
-          }
-          onMouseLeave={
-            onSliceHover && !isEmpty ? () => onSliceHover(null) : undefined
           }
           label={
             showLegend && !isEmpty

--- a/packages/ui-components/src/ui/chart/donut-chart.tsx
+++ b/packages/ui-components/src/ui/chart/donut-chart.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Pie, PieChart as RechartsPieChart } from 'recharts';
 import {
+  CHART_ANIMATION_DURATION_MS,
+  CHART_ANIMATION_EASING,
   ChartConfig,
   ChartContainer,
   ChartTooltip,
@@ -65,6 +67,7 @@ export type DonutChartProps = {
   outerRadius?: number;
   showTooltip?: boolean;
   showLegend?: boolean;
+  onSliceHover?: (slice: { name: string; value: number } | null) => void;
   className?: string;
 };
 
@@ -75,6 +78,7 @@ export function DonutChart({
   outerRadius = 90,
   showTooltip = true,
   showLegend = true,
+  onSliceHover,
   className,
 }: DonutChartProps): React.JSX.Element {
   const isEmpty = data.every((entry) => !entry.value);
@@ -100,6 +104,17 @@ export function DonutChart({
           nameKey="name"
           innerRadius={innerRadius}
           outerRadius={outerRadius}
+          animationDuration={CHART_ANIMATION_DURATION_MS}
+          animationEasing={CHART_ANIMATION_EASING}
+          onMouseEnter={
+            onSliceHover && !isEmpty
+              ? (entry: { name: string; value: number }) =>
+                  onSliceHover({ name: entry.name, value: entry.value })
+              : undefined
+          }
+          onMouseLeave={
+            onSliceHover && !isEmpty ? () => onSliceHover(null) : undefined
+          }
           label={
             showLegend && !isEmpty
               ? (props) => (


### PR DESCRIPTION
Fixes OPS-4728.

## Summary
- Shares a single animation duration/easing (`CHART_ANIMATION_DURATION_MS`, `CHART_ANIMATION_EASING`) across `BarChart` and `DonutChart` so side-by-side charts finish transitions at the same pace — recharts defaults differ per element (Bar 400ms, Pie 800ms, Line 1500ms)
- Fixes `BarChart` XAxis label clipping by reserving `height={40}` for the axis (default 30px isn't enough for the 20px tickMargin plus label text)
- Adds an optional `onSliceHover` callback to `DonutChart` for hover-driven UI (e.g. swapping a center label on hover)

