### PR TITLE
Fix Azure CLI extensions missing from worker image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,7 +48,7 @@ RUN <<-```
   az extension add --name resource-graph --only-show-errors || true
   az extension add --name costmanagement --only-show-errors || true
   az extension add --name billing-benefits --only-show-errors || true
-  az extension add --name quotas --only-show-errors || true
+  az extension add --name quota --only-show-errors || true
   az extension add --name ssh --only-show-errors || true
 
   # Install Google Cloud CLI

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -25,7 +25,7 @@ RUN <<-```
     az extension add --name resource-graph --only-show-errors || true
     az extension add --name costmanagement --only-show-errors || true
     az extension add --name billing-benefits --only-show-errors || true
-    az extension add --name quotas --only-show-errors || true
+    az extension add --name quota --only-show-errors || true
     az extension add --name ssh --only-show-errors || true
 ```
 

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -13,6 +13,9 @@ RUN <<-```
 ```
 
 # Install Azure CLI (needs compiler for native deps)
+# AZURE_EXTENSION_DIR must be set *before* `az extension add`, otherwise the
+# extensions land in /root/.azure/cliextensions and are not copied to the final stage.
+ENV AZURE_EXTENSION_DIR="/opt/azure/config/cliextensions"
 RUN <<-```
     set -ex
     pip3 install --no-cache-dir --break-system-packages azure-cli==2.74.0


### PR DESCRIPTION
Fixes OPS-4766.

Azure CLI actions that need an az extension (e.g. `az graph query …`) fail in the worker container with:

```
WARNING: The command requires the extension resource-graph. It will be installed first.
ERROR: An error occurred. Pip failed with status code 1. Use --debug for more information.
```

- `az extension add` in the builder stage ran before `AZURE_EXTENSION_DIR` was set, so the extensions were installed to `/root/.azure/cliextensions` and never copied to the final stage; the shipped image points `az` at an empty `/opt/azure/config/cliextensions`.
- At runtime `az` tries to dynamic-install the missing extension via `python3 -m pip`, but the runtime image has no pip (and `/opt/azure` is read-only for `node`).
- Fix: set `AZURE_EXTENSION_DIR` in the builder stage before installing extensions.
- Also fix the `quotas` → `quota` extension name (install failed silently on every build behind `|| true`), in `worker.Dockerfile` and `.devcontainer/Dockerfile`.


Testing done:
- Reproduced on a docker-compose env running `openops-worker:5c75283d`: `/opt/azure/config/cliextensions` empty, `python3 -m pip` → `No module named pip`.
- Minimal two-stage repro image of the Azure lines: before → identical "Pip failed with status code 1"; after → `resource-graph` present, `az graph query` proceeds to `Please run 'az login'`.
- Built the full `worker.Dockerfile` locally with the `AZURE_EXTENSION_DIR` change: `az extension list` as user `node` shows `billing-benefits`, `costmanagement`, `reservation`, `resource-graph`, `ssh`.
- `az extension add --name quota` verified to install (1.0.0); `quotas` → `No extension found`.
