### PR TITLE
Forward container credential variables to the AWS CLI

### DIFF
--- a/packages/blocks/aws/src/lib/actions/cli/aws-cli.ts
+++ b/packages/blocks/aws/src/lib/actions/cli/aws-cli.ts
@@ -1,6 +1,41 @@
 import { runCliCommand } from '@openops/common';
 import { SharedSystemProp, system } from '@openops/server-shared';
 
+/**
+ * Variables the AWS CLI uses to find credentials it has not been handed
+ * explicitly. The CLI runs with a replaced environment (see executeFile), so
+ * under implicit role these have to be forwarded deliberately.
+ *
+ * On EC2 nothing needs forwarding: the CLI reaches the instance role over IMDS
+ * at a fixed link-local address. Every other role-based deployment is
+ * discoverable only through the environment -- ECS and Fargate task roles
+ * through the container credentials variables, EKS IRSA through the web
+ * identity ones -- so without this, implicit role fails there with
+ * "Unable to locate credentials".
+ */
+const AMBIENT_CREDENTIAL_ENV_VARS = [
+  'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+  'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+  'AWS_CONTAINER_AUTHORIZATION_TOKEN',
+  'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE',
+  'AWS_ROLE_ARN',
+  'AWS_ROLE_SESSION_NAME',
+  'AWS_WEB_IDENTITY_TOKEN_FILE',
+];
+
+function getAmbientCredentialEnvVars(): Record<string, string> {
+  const envVars: Record<string, string> = {};
+
+  for (const name of AMBIENT_CREDENTIAL_ENV_VARS) {
+    const value = process.env[name];
+    if (value) {
+      envVars[name] = value;
+    }
+  }
+
+  return envVars;
+}
+
 export async function runCommand(
   command: string,
   region: string,
@@ -26,6 +61,8 @@ export async function runCommand(
     throw new Error(
       'AWS credentials are required, please provide accessKeyId and secretAccessKey',
     );
+  } else {
+    Object.assign(envVars, getAmbientCredentialEnvVars());
   }
 
   return await runCliCommand(command, 'aws', envVars);

--- a/packages/blocks/aws/test/cli/aws-cli.test.ts
+++ b/packages/blocks/aws/test/cli/aws-cli.test.ts
@@ -20,9 +20,38 @@ const credential = {
   sessionToken: 'some token',
 };
 
+const AMBIENT_CREDENTIAL_ENV_VARS = [
+  'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+  'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+  'AWS_CONTAINER_AUTHORIZATION_TOKEN',
+  'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE',
+  'AWS_ROLE_ARN',
+  'AWS_ROLE_SESSION_NAME',
+  'AWS_WEB_IDENTITY_TOKEN_FILE',
+];
+
 describe('awsCli', () => {
+  // The machine running the tests may itself have some of these set, which
+  // would leak into the assertions below.
+  const originalEnv: Record<string, string | undefined> = {};
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    for (const name of AMBIENT_CREDENTIAL_ENV_VARS) {
+      originalEnv[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of AMBIENT_CREDENTIAL_ENV_VARS) {
+      if (originalEnv[name] === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = originalEnv[name];
+      }
+    }
   });
 
   test('should call runCliCommand with the given arguments', async () => {
@@ -71,5 +100,48 @@ describe('awsCli', () => {
     } finally {
       mockSystem.getBoolean.mockReturnValue(false);
     }
+  });
+
+  test('should forward ambient credential variables when implicit role is enabled', async () => {
+    mockSystem.getBoolean.mockReturnValue(true);
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] =
+      '/v2/credentials/abc';
+    process.env['AWS_WEB_IDENTITY_TOKEN_FILE'] = '/var/run/secrets/token';
+
+    try {
+      await runCommand('some command', 'region', {});
+
+      expect(openOpsMock.runCliCommand).toHaveBeenCalledWith(
+        'some command',
+        'aws',
+        {
+          AWS_DEFAULT_REGION: 'region',
+          PATH: process.env['PATH'],
+          AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: '/v2/credentials/abc',
+          AWS_WEB_IDENTITY_TOKEN_FILE: '/var/run/secrets/token',
+        },
+      );
+    } finally {
+      mockSystem.getBoolean.mockReturnValue(false);
+    }
+  });
+
+  test('should not forward ambient credential variables when explicit credentials are given', async () => {
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] =
+      '/v2/credentials/abc';
+
+    await runCommand('some command', 'region', credential);
+
+    expect(openOpsMock.runCliCommand).toHaveBeenCalledWith(
+      'some command',
+      'aws',
+      {
+        AWS_ACCESS_KEY_ID: credential.accessKeyId,
+        AWS_SECRET_ACCESS_KEY: credential.secretAccessKey,
+        AWS_SESSION_TOKEN: credential.sessionToken,
+        AWS_DEFAULT_REGION: 'region',
+        PATH: process.env['PATH'],
+      },
+    );
   });
 });


### PR DESCRIPTION
Fixes #2455.

Under implicit role, the AWS CLI block runs `aws` with an environment that contains only `AWS_DEFAULT_REGION`, `PATH` and `HOME` — `aws-cli.ts` builds `envVars` from scratch and `executeFile()` sets `env` rather than merging it. The CLI therefore has no way to discover the role on any platform that exposes it through the environment, and fails with `NoCredentials` (exit 253).

This forwards the variables the CLI needs for that discovery when, and only when, we fall back to the implicit role:

- `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, `AWS_CONTAINER_CREDENTIALS_FULL_URI`, `AWS_CONTAINER_AUTHORIZATION_TOKEN`, `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` — ECS and Fargate task roles
- `AWS_ROLE_ARN`, `AWS_ROLE_SESSION_NAME`, `AWS_WEB_IDENTITY_TOKEN_FILE` — EKS IRSA / Pod Identity

## Additional Notes

**Why it has not surfaced before.** On EC2 the CLI reaches the instance role over IMDS at a fixed link-local address and needs nothing from the environment, which is the deployment shape the feature is documented against. Fargate has no IMDS credential provider, so the scrub is fatal there. The asymmetry is confusing in practice: SDK-based AWS blocks work on the same task role, because they run in-process where the variables are intact — only the CLI blocks fail.

**Scope.** Deliberately narrow. Only the implicit-role branch is touched, only variables that are already in `process.env` are forwarded, and nothing is forwarded when explicit credentials are supplied (they take precedence in the chain anyway, but keeping the environment minimal seemed better than relying on that). A variable absent from `process.env` is not added, so non-container deployments are byte-for-byte unchanged.

**Possibly worth a follow-up, not done here:** `azure-cli.ts` and the Google Cloud CLI wrapper go through the same `executeFile()` and so have the same blind spot for managed identity / workload identity. I have not tested either, so I have left them alone.

## Testing Checklist

- [x] I tested the feature thoroughly, including edge cases
- [x] I verified all affected areas still work as expected
- [x] Automated tests were added/updated if necessary
- [x] Changes are backwards compatible with any existing data, otherwise a migration script is provided

Tested on a real ECS Fargate deployment of 0.6.25 (engine as its own service, task role attached, `OPS_AWS_ENABLE_IMPLICIT_ROLE=true`). Inside the engine container, reproducing the environment the block builds:

```console
$ env -i PATH=$PATH HOME=$HOME AWS_DEFAULT_REGION=us-east-1 \
    aws compute-optimizer get-ec2-instance-recommendations
aws: [ERROR]: An error occurred (NoCredentials): Unable to locate credentials.

$ env -i PATH=/tmp/bin:$PATH HOME=$HOME AWS_DEFAULT_REGION=us-east-1 \
    aws compute-optimizer get-ec2-instance-recommendations
{ "instanceRecommendations": [ { "currentInstanceType": "t3.large", "finding": "OPTIMIZED", ... } ] }
```

where `/tmp/bin/aws` is a wrapper that re-exports `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` and execs the real binary — the same variable this PR forwards.

Unit tests: two added (forwarding under implicit role; no forwarding with explicit credentials), and the existing cases pin the unchanged behaviour. The suite clears these variables around each test so a developer machine that has them set cannot leak into the assertions. `packages/blocks/aws`: 176 tests, all passing.
