### PR TITLE
Fix invalid Dependabot cooldown keys

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -139,11 +139,10 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: ''
+    # Docker and Actions support default-days only; semver-*-days is rejected
+    # for these ecosystems and invalidates the entire file.
     cooldown:
       default-days: 5
-      semver-major-days: 14
-      semver-minor-days: 5
-      semver-patch-days: 3
     groups:
       docker-security:
         applies-to: security-updates
@@ -166,11 +165,10 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: ''
+    # Docker and Actions support default-days only; semver-*-days is rejected
+    # for these ecosystems and invalidates the entire file.
     cooldown:
       default-days: 5
-      semver-major-days: 14
-      semver-minor-days: 5
-      semver-patch-days: 3
     groups:
       actions-security:
         applies-to: security-updates


### PR DESCRIPTION
Part of OPS-4799.

## Additional Notes

Dependabot is currently rejecting the entire config, so **all version updates are stopped** until this merges:

```
The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/1/cooldown/semver-minor-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/1/cooldown/semver-patch-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/2/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/2/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/2/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```